### PR TITLE
Closes #15: Implement HTML RAWTEXT tokenisation steps

### DIFF
--- a/packages/alfa-html/test/alphabet.spec.ts
+++ b/packages/alfa-html/test/alphabet.spec.ts
@@ -225,6 +225,41 @@ test("Can lex a simple script element", t => {
   ]);
 });
 
+test("Can lex a noscript element with an apparent tag", t => {
+  html(t, "<noscript><tag></noscript>", [
+    {
+      type: TokenType.StartTag,
+      name: "noscript",
+      selfClosing: false,
+      attributes: []
+    },
+    {
+      type: TokenType.Character,
+      data: "<"
+    },
+    {
+      type: TokenType.Character,
+      data: "t"
+    },
+    {
+      type: TokenType.Character,
+      data: "a"
+    },
+    {
+      type: TokenType.Character,
+      data: "g"
+    },
+    {
+      type: TokenType.Character,
+      data: ">"
+    },
+    {
+      type: TokenType.EndTag,
+      name: "noscript"
+    }
+  ]);
+});
+
 test("Can lex a script element with an apparent tag", t => {
   html(t, "<script><tag></script>", [
     {


### PR DESCRIPTION
This implements RAWTEXT tokenisation.
Mind that this PR might conflict with #16, since the code is located at the same space in alphabet.ts.