### PR TITLE
Closes #24: Implement `getTabSequence()`

### DIFF
--- a/packages/alfa-dom/src/get-tab-sequence.ts
+++ b/packages/alfa-dom/src/get-tab-sequence.ts
@@ -1,31 +1,40 @@
 import { getTabIndex } from "./get-tab-index";
 import { Element, Node, NodeType } from "./types";
 
+export interface TabIndexedElement extends Element {
+  index: number;
+}
+
 /**
  * @see https://www.w3.org/TR/html/editing.html#the-tabindex-attribute
  */
 export function getTabSequence(
   element: Element,
-  tabSequence: Array<Element> = []
-): Array<Element> {
+  tabSequence: Array<TabIndexedElement> = []
+): Array<TabIndexedElement> {
   (<Array<Node>>element.childNodes).forEach(element => {
     if (element.nodeType === NodeType.Element) {
-      getTabSequence(<Element>element, tabSequence);
+      getTabSequence(<TabIndexedElement>element, tabSequence);
     }
   });
 
   const index = getTabIndex(element);
+
   if (index === null || index === -1) {
     return tabSequence;
   }
 
+  const weightedElement = <TabIndexedElement>element;
+
   if (index > 0) {
-    tabSequence.splice(index - 1, 0, element);
+    weightedElement.index = index - 1;
   }
 
   if (index === 0) {
-    tabSequence.splice(999999, 0, element);
+    weightedElement.index = Number.MAX_SAFE_INTEGER;
   }
 
-  return tabSequence;
+  tabSequence.push(weightedElement);
+
+  return tabSequence.sort((a, b) => a.index - b.index);
 }

--- a/packages/alfa-dom/src/get-tab-sequence.ts
+++ b/packages/alfa-dom/src/get-tab-sequence.ts
@@ -1,5 +1,5 @@
 import { getTabIndex } from "./get-tab-index";
-import { Element, Node, NodeType } from "./types";
+import { Element, NodeType } from "./types";
 
 export interface TabIndexedElement extends Element {
   index: number;
@@ -12,11 +12,13 @@ export function getTabSequence(
   element: Element,
   tabSequence: Array<TabIndexedElement> = []
 ): Array<TabIndexedElement> {
-  (<Array<Node>>element.childNodes).forEach(element => {
-    if (element.nodeType === NodeType.Element) {
-      getTabSequence(<TabIndexedElement>element, tabSequence);
+  element.childNodes.length;
+  for (let i = 0, n = element.childNodes.length; i < n; i++) {
+    const child = element.childNodes[i];
+    if (child.nodeType === NodeType.Element) {
+      getTabSequence(<TabIndexedElement>child, tabSequence);
     }
-  });
+  }
 
   const index = getTabIndex(element);
 

--- a/packages/alfa-dom/src/get-tab-sequence.ts
+++ b/packages/alfa-dom/src/get-tab-sequence.ts
@@ -1,0 +1,31 @@
+import { getTabIndex } from "./get-tab-index";
+import { Element, Node, NodeType } from "./types";
+
+/**
+ * @see https://www.w3.org/TR/html/editing.html#the-tabindex-attribute
+ */
+export function getTabSequence(
+  element: Element,
+  tabSequence: Array<Element> = []
+): Array<Element> {
+  (<Array<Node>>element.childNodes).forEach(element => {
+    if (element.nodeType === NodeType.Element) {
+      getTabSequence(<Element>element, tabSequence);
+    }
+  });
+
+  const index = getTabIndex(element);
+  if (index === null || index === -1) {
+    return tabSequence;
+  }
+
+  if (index > 0) {
+    tabSequence.splice(index - 1, 0, element);
+  }
+
+  if (index === 0) {
+    tabSequence.splice(999999, 0, element);
+  }
+
+  return tabSequence;
+}

--- a/packages/alfa-dom/src/get-tab-sequence.ts
+++ b/packages/alfa-dom/src/get-tab-sequence.ts
@@ -30,7 +30,7 @@ function indexWithin(array: Array<Element>, element: Element) {
 export function getTabSequence(element: Element): Array<Element> {
   const result: Array<Element> = [];
 
-  traverseNode(element, {
+  traverseNode(element, element, {
     enter(node, parent) {
       if (!isElement(node)) {
         return;

--- a/packages/alfa-dom/src/get-tab-sequence.ts
+++ b/packages/alfa-dom/src/get-tab-sequence.ts
@@ -7,7 +7,7 @@ import { Element, Node } from "./types";
  * @see https://www.w3.org/TR/html/editing.html#sequential-focus-navigation
  */
 export function getTabSequence(
-  element: Element,
+  element: Node,
   context: Node
 ): Readonly<Array<Element>> {
   const result: Array<Element> = [];

--- a/packages/alfa-dom/src/get-tab-sequence.ts
+++ b/packages/alfa-dom/src/get-tab-sequence.ts
@@ -2,32 +2,24 @@ import { getTabIndex } from "./get-tab-index";
 import { traverseNode } from "./traverse-node";
 import { Element, NodeType } from "./types";
 
-function binaryInsert(
-  arr: Array<Element>,
-  element: Element,
-  index: number,
-  i: number,
-  depth = 0
-) {
-  if (arr.length === 0) {
-    arr.push(element);
+function binaryIndexSearch(array: Array<Element>, index: number) {
+  let low = 0;
+  let high = array.length;
+
+  if (index === 0) {
+    return high;
   }
 
-  const competitorIndex = getTabIndex(arr[i]);
-
-  if (competitorIndex === null) {
-    return;
+  while (low < high) {
+    const mid = (low + high) >>> 1;
+    const other = <number>getTabIndex(array[mid]);
+    if (other <= index && other !== 0) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
   }
-
-  if (competitorIndex < index) {
-    binaryInsert(arr, element, index, i + i / 2);
-  }
-
-  if (competitorIndex > index) {
-    binaryInsert(arr, element, index, i - i / 2);
-  }
-
-  arr.splice(i, 0, element);
+  return low;
 }
 
 /**
@@ -44,12 +36,8 @@ export function getTabSequence(element: Element): Array<Element> {
 
       const index = getTabIndex(<Element>node);
       if (index !== null && index >= 0) {
-        binaryInsert(
-          result,
-          <Element>node,
-          index,
-          Math.floor(result.length / 2)
-        );
+        const location = binaryIndexSearch(result, index);
+        result.splice(location, 0, <Element>node);
       }
     }
   });

--- a/packages/alfa-dom/src/get-tab-sequence.ts
+++ b/packages/alfa-dom/src/get-tab-sequence.ts
@@ -1,7 +1,7 @@
 import { getTabIndex } from "./get-tab-index";
 import { isElement } from "./guards";
 import { traverseNode } from "./traverse-node";
-import { Element } from "./types";
+import { Element, Node } from "./types";
 
 function indexWithin(array: Array<Element>, element: Element) {
   let lower = 0;
@@ -25,16 +25,16 @@ function indexWithin(array: Array<Element>, element: Element) {
 }
 
 /**
- * @see https://www.w3.org/TR/html/editing.html#the-tabindex-attribute
+ * @see https://www.w3.org/TR/html/editing.html#sequential-focus-navigation
  */
 export function getTabSequence(
   element: Element,
-  context: Element
+  context: Node
 ): Array<Element> {
   const result: Array<Element> = [];
 
   traverseNode(element, context, {
-    enter(node, parent) {
+    enter(node) {
       if (!isElement(node)) {
         return;
       }

--- a/packages/alfa-dom/src/get-tab-sequence.ts
+++ b/packages/alfa-dom/src/get-tab-sequence.ts
@@ -1,25 +1,27 @@
 import { getTabIndex } from "./get-tab-index";
+import { isElement } from "./guards";
 import { traverseNode } from "./traverse-node";
-import { Element, NodeType } from "./types";
+import { Element } from "./types";
 
-function binaryIndexSearch(array: Array<Element>, index: number) {
-  let low = 0;
-  let high = array.length;
+function indexWithin(array: Array<Element>, element: Element) {
+  let lower = 0;
+  let upper = array.length;
+  const index = <number>getTabIndex(element);
 
   if (index === 0) {
-    return high;
+    return upper;
   }
 
-  while (low < high) {
-    const mid = (low + high) >>> 1;
-    const other = <number>getTabIndex(array[mid]);
+  while (lower < upper) {
+    const middle = (lower + (upper - lower) / 2) | 0;
+    const other = <number>getTabIndex(array[middle]);
     if (other <= index && other !== 0) {
-      low = mid + 1;
+      lower = middle + 1;
     } else {
-      high = mid;
+      upper = middle;
     }
   }
-  return low;
+  return lower;
 }
 
 /**
@@ -30,14 +32,14 @@ export function getTabSequence(element: Element): Array<Element> {
 
   traverseNode(element, {
     enter(node, parent) {
-      if (node.nodeType !== NodeType.Element) {
+      if (!isElement(node)) {
         return;
       }
 
-      const index = getTabIndex(<Element>node);
+      const index = getTabIndex(node);
       if (index !== null && index >= 0) {
-        const location = binaryIndexSearch(result, index);
-        result.splice(location, 0, <Element>node);
+        const location = indexWithin(result, node);
+        result.splice(location, 0, node);
       }
     }
   });

--- a/packages/alfa-dom/src/get-tab-sequence.ts
+++ b/packages/alfa-dom/src/get-tab-sequence.ts
@@ -28,7 +28,7 @@ function indexWithin(array: Array<Element>, element: Element) {
  * @see https://www.w3.org/TR/html/editing.html#the-tabindex-attribute
  */
 export function getTabSequence(element: Element): Array<Element> {
-  const result = <Array<Element>>[];
+  const result: Array<Element> = [];
 
   traverseNode(element, {
     enter(node, parent) {

--- a/packages/alfa-dom/src/get-tab-sequence.ts
+++ b/packages/alfa-dom/src/get-tab-sequence.ts
@@ -27,10 +27,13 @@ function indexWithin(array: Array<Element>, element: Element) {
 /**
  * @see https://www.w3.org/TR/html/editing.html#the-tabindex-attribute
  */
-export function getTabSequence(element: Element): Array<Element> {
+export function getTabSequence(
+  element: Element,
+  context: Element
+): Array<Element> {
   const result: Array<Element> = [];
 
-  traverseNode(element, element, {
+  traverseNode(element, context, {
     enter(node, parent) {
       if (!isElement(node)) {
         return;

--- a/packages/alfa-dom/src/get-tab-sequence.ts
+++ b/packages/alfa-dom/src/get-tab-sequence.ts
@@ -3,6 +3,32 @@ import { isElement } from "./guards";
 import { traverseNode } from "./traverse-node";
 import { Element, Node } from "./types";
 
+/**
+ * @see https://www.w3.org/TR/html/editing.html#sequential-focus-navigation
+ */
+export function getTabSequence(
+  element: Element,
+  context: Node
+): Readonly<Array<Element>> {
+  const result: Array<Element> = [];
+
+  traverseNode(element, context, {
+    enter(node) {
+      if (!isElement(node)) {
+        return;
+      }
+
+      const index = getTabIndex(node);
+      if (index !== null && index >= 0) {
+        const location = indexWithin(result, node);
+        result.splice(location, 0, node);
+      }
+    }
+  });
+
+  return result;
+}
+
 function indexWithin(array: Array<Element>, element: Element) {
   let lower = 0;
   let upper = array.length;
@@ -22,30 +48,4 @@ function indexWithin(array: Array<Element>, element: Element) {
     }
   }
   return lower;
-}
-
-/**
- * @see https://www.w3.org/TR/html/editing.html#sequential-focus-navigation
- */
-export function getTabSequence(
-  element: Element,
-  context: Node
-): Array<Element> {
-  const result: Array<Element> = [];
-
-  traverseNode(element, context, {
-    enter(node) {
-      if (!isElement(node)) {
-        return;
-      }
-
-      const index = getTabIndex(node);
-      if (index !== null && index >= 0) {
-        const location = indexWithin(result, node);
-        result.splice(location, 0, node);
-      }
-    }
-  });
-
-  return result;
 }

--- a/packages/alfa-dom/src/get-tab-sequence.ts
+++ b/packages/alfa-dom/src/get-tab-sequence.ts
@@ -7,12 +7,12 @@ import { Element, Node } from "./types";
  * @see https://www.w3.org/TR/html/editing.html#sequential-focus-navigation
  */
 export function getTabSequence(
-  element: Node,
+  node: Node,
   context: Node
 ): Readonly<Array<Element>> {
   const result: Array<Element> = [];
 
-  traverseNode(element, context, {
+  traverseNode(node, context, {
     enter(node) {
       if (!isElement(node)) {
         return;

--- a/packages/alfa-dom/src/get-tab-sequence.ts
+++ b/packages/alfa-dom/src/get-tab-sequence.ts
@@ -6,7 +6,7 @@ import { Element } from "./types";
 function indexWithin(array: Array<Element>, element: Element) {
   let lower = 0;
   let upper = array.length;
-  const index = <number>getTabIndex(element);
+  const index = getTabIndex(element) as number;
 
   if (index === 0) {
     return upper;
@@ -14,7 +14,7 @@ function indexWithin(array: Array<Element>, element: Element) {
 
   while (lower < upper) {
     const middle = (lower + (upper - lower) / 2) | 0;
-    const other = <number>getTabIndex(array[middle]);
+    const other = getTabIndex(array[middle]) as number;
     if (other <= index && other !== 0) {
       lower = middle + 1;
     } else {

--- a/packages/alfa-dom/test/get-tab-sequence.spec.tsx
+++ b/packages/alfa-dom/test/get-tab-sequence.spec.tsx
@@ -1,0 +1,104 @@
+import { jsx } from "@siteimprove/alfa-jsx";
+import { test } from "@siteimprove/alfa-test";
+import { getTabSequence } from "../src/get-tab-sequence";
+
+test("Computes the tab sequence of three non-prioritized elements", t => {
+  const a1 = <a href="#">Foo</a>;
+  const a2 = <a href="#">Bar</a>;
+  const input = <input type="text" value="Hello" />;
+
+  t.deepEqual(
+    getTabSequence(
+      <div id="root">
+        {a1}
+        {a2}
+        {input}
+      </div>
+    ),
+    [a1, a2, input]
+  );
+});
+
+test("Computes the tab sequence of three elements with priotization", t => {
+  const a1 = <a href="#">Foo</a>;
+  const a2 = (
+    <a tabindex="1" href="#">
+      Bar
+    </a>
+  );
+  const input = <input type="text" value="Hello" />;
+
+  t.deepEqual(
+    getTabSequence(
+      <div id="root">
+        {a1}
+        {a2}
+        {input}
+      </div>
+    ),
+    [a2, a1, input]
+  );
+});
+
+test("Computes the tab sequence of three elements with ignoring priotization", t => {
+  const a1 = <a href="#">Foo</a>;
+  const a2 = <a href="#">Bar</a>;
+  const input = <input tabindex="-1" type="text" value="Hello" />;
+
+  t.deepEqual(
+    getTabSequence(
+      <div id="root">
+        {a1}
+        {a2}
+        {input}
+      </div>
+    ),
+    [a1, a2]
+  );
+});
+
+test("Computes the tab sequence of colliding elements", t => {
+  const a1 = (
+    <a tabindex="1" href="#">
+      Foo
+    </a>
+  );
+  const a2 = (
+    <a tabindex="1" href="#">
+      Bar
+    </a>
+  );
+  const input = <input type="text" value="Hello" />;
+
+  t.deepEqual(
+    getTabSequence(
+      <div id="root">
+        {a1}
+        {a2}
+        {input}
+      </div>
+    ),
+    [a1, a2, input]
+  );
+});
+
+test("Computes the tab sequence of three elements with out of bounds priotization", t => {
+  const a1 = <a href="#">Foo</a>;
+  const a2 = (
+    <a tabindex="6" href="#">
+      Bar
+    </a>
+  );
+  const input = <input tabindex="2" type="text" value="Hello" />;
+
+  t.deepEqual(
+    getTabSequence(
+      <div id="root">
+        {a1}
+        {a2}
+        {input}
+      </div>
+    ),
+    [input, a2, a1]
+  );
+});

--- a/packages/alfa-dom/test/get-tab-sequence.spec.tsx
+++ b/packages/alfa-dom/test/get-tab-sequence.spec.tsx
@@ -13,7 +13,8 @@ test("Computes the tab sequence of three non-prioritized elements", t => {
         {a1}
         {a2}
         {input}
-      </div>
+      </div>,
+      <div id="context" />
     ),
     [a1, a2, input]
   );
@@ -34,7 +35,8 @@ test("Computes the tab sequence of three elements with priotization", t => {
         {a1}
         {a2}
         {input}
-      </div>
+      </div>,
+      <div id="context" />
     ),
     [a2, a1, input]
   );
@@ -51,7 +53,8 @@ test("Computes the tab sequence of three elements with ignoring priotization", t
         {a1}
         {a2}
         {input}
-      </div>
+      </div>,
+      <div id="context" />
     ),
     [a1, a2]
   );
@@ -76,7 +79,8 @@ test("Computes the tab sequence of colliding elements", t => {
         {a1}
         {a2}
         {input}
-      </div>
+      </div>,
+      <div id="context" />
     ),
     [a1, a2, input]
   );
@@ -97,7 +101,8 @@ test("Computes the tab sequence of three elements with out of bounds priotizatio
         {a1}
         {a2}
         {input}
-      </div>
+      </div>,
+      <div id="context" />
     ),
     [a2, input, a1]
   );

--- a/packages/alfa-dom/test/get-tab-sequence.spec.tsx
+++ b/packages/alfa-dom/test/get-tab-sequence.spec.tsx
@@ -20,18 +20,20 @@ test("Gets the tab sequence of a node and its children", t => {
 
 test("Sorts element based on their tab index", t => {
   const div = <div />;
-  const a = <a href="#" />;
+  const a = <a tabindex="2" href="#" />;
+  const button = <button />;
   const input = <input tabindex="1" type="text" />;
 
   const context = (
     <div>
       {div}
       {a}
+      {button}
       {input}
     </div>
   );
 
-  t.deepEqual(getTabSequence(context, context), [input, a]);
+  t.deepEqual(getTabSequence(context, context), [input, a, button]);
 });
 
 test("Leaves out elements with negative tab indices", t => {
@@ -86,7 +88,7 @@ test("Positions elements with a tab index of zero after elements with a non-zero
   t.deepEqual(getTabSequence(context, context), [a, input, button]);
 });
 
-test("Positions elements with spread tab index in correct order", t => {
+test("Positions elements with tabindex larger than the array size in the correct order", t => {
   const div = <div />;
   const a = <a tabindex="6" href="#" />;
   const input = <input tabindex="1" type="text" />;

--- a/packages/alfa-dom/test/get-tab-sequence.spec.tsx
+++ b/packages/alfa-dom/test/get-tab-sequence.spec.tsx
@@ -3,107 +3,83 @@ import { test } from "@siteimprove/alfa-test";
 import { getTabSequence } from "../src/get-tab-sequence";
 
 test("Computes the tab sequence of three non-prioritized elements", t => {
-  const a1 = <a href="#">Foo</a>;
-  const a2 = <a href="#">Bar</a>;
-  const input = <input type="text" value="Hello" />;
+  const div = <div />;
+  const a = <a href="#" />;
+  const input = <input type="text" />;
 
-  t.deepEqual(
-    getTabSequence(
-      <div id="root">
-        {a1}
-        {a2}
-        {input}
-      </div>,
-      <div id="context" />
-    ),
-    [a1, a2, input]
+  const context = (
+    <div>
+      {div}
+      {a}
+      {input}
+    </div>
   );
+
+  t.deepEqual(getTabSequence(context, context), [a, input]);
 });
 
 test("Computes the tab sequence of three elements with priotization", t => {
-  const a1 = <a href="#">Foo</a>;
-  const a2 = (
-    <a tabindex="1" href="#">
-      Bar
-    </a>
-  );
-  const input = <input type="text" value="Hello" />;
+  const div = <div />;
+  const a = <a href="#" />;
+  const input = <input tabindex="1" type="text" />;
 
-  t.deepEqual(
-    getTabSequence(
-      <div id="root">
-        {a1}
-        {a2}
-        {input}
-      </div>,
-      <div id="context" />
-    ),
-    [a2, a1, input]
+  const context = (
+    <div>
+      {div}
+      {a}
+      {input}
+    </div>
   );
+
+  t.deepEqual(getTabSequence(context, context), [input, a]);
 });
 
 test("Computes the tab sequence of three elements with ignoring priotization", t => {
-  const a1 = <a href="#">Foo</a>;
-  const a2 = <a href="#">Bar</a>;
-  const input = <input tabindex="-1" type="text" value="Hello" />;
+  const div = <div />;
+  const a = <a href="#" />;
+  const input = <input tabindex="-1" type="text" />;
 
-  t.deepEqual(
-    getTabSequence(
-      <div id="root">
-        {a1}
-        {a2}
-        {input}
-      </div>,
-      <div id="context" />
-    ),
-    [a1, a2]
+  const context = (
+    <div>
+      {div}
+      {a}
+      {input}
+    </div>
   );
+
+  t.deepEqual(getTabSequence(context, context), [a]);
 });
 
 test("Computes the tab sequence of colliding elements", t => {
-  const a1 = (
-    <a tabindex="1" href="#">
-      Foo
-    </a>
-  );
-  const a2 = (
-    <a tabindex="1" href="#">
-      Bar
-    </a>
-  );
-  const input = <input type="text" value="Hello" />;
+  const div = <div />;
+  const button = <button />;
+  const a = <a tabindex="1" href="#" />;
+  const input = <input tabindex="1" type="text" />;
 
-  t.deepEqual(
-    getTabSequence(
-      <div id="root">
-        {a1}
-        {a2}
-        {input}
-      </div>,
-      <div id="context" />
-    ),
-    [a1, a2, input]
+  const context = (
+    <div>
+      {div}
+      {button}
+      {a}
+      {input}
+    </div>
   );
+
+  t.deepEqual(getTabSequence(context, context), [a, input, button]);
 });
 
 test("Computes the tab sequence of three elements with out of bounds priotization", t => {
-  const a1 = <a href="#">Foo</a>;
-  const a2 = (
-    <a tabindex="2" href="#">
-      Bar
-    </a>
-  );
-  const input = <input tabindex="6" type="text" value="Hello" />;
+  const div = <div />;
+  const a = <a tabindex="6" href="#" />;
+  const input = <input tabindex="2" type="text" />;
 
-  t.deepEqual(
-    getTabSequence(
-      <div id="root">
-        {a1}
-        {a2}
-        {input}
-      </div>,
-      <div id="context" />
-    ),
-    [a2, input, a1]
+  const context = (
+    <div>
+      {div}
+      {a}
+      {input}
+    </div>
   );
+
+  t.deepEqual(getTabSequence(context, context), [input, a]);
 });

--- a/packages/alfa-dom/test/get-tab-sequence.spec.tsx
+++ b/packages/alfa-dom/test/get-tab-sequence.spec.tsx
@@ -85,11 +85,11 @@ test("Computes the tab sequence of colliding elements", t => {
 test("Computes the tab sequence of three elements with out of bounds priotization", t => {
   const a1 = <a href="#">Foo</a>;
   const a2 = (
-    <a tabindex="6" href="#">
+    <a tabindex="2" href="#">
       Bar
     </a>
   );
-  const input = <input tabindex="2" type="text" value="Hello" />;
+  const input = <input tabindex="6" type="text" value="Hello" />;
 
   t.deepEqual(
     getTabSequence(
@@ -99,6 +99,6 @@ test("Computes the tab sequence of three elements with out of bounds priotizatio
         {input}
       </div>
     ),
-    [input, a2, a1]
+    [a2, input, a1]
   );
 });

--- a/packages/alfa-dom/test/get-tab-sequence.spec.tsx
+++ b/packages/alfa-dom/test/get-tab-sequence.spec.tsx
@@ -2,7 +2,7 @@ import { jsx } from "@siteimprove/alfa-jsx";
 import { test } from "@siteimprove/alfa-test";
 import { getTabSequence } from "../src/get-tab-sequence";
 
-test("Computes the tab sequence of three non-prioritized elements", t => {
+test("Gets the tab sequence of a node and its children", t => {
   const div = <div />;
   const a = <a href="#" />;
   const input = <input type="text" />;
@@ -18,7 +18,7 @@ test("Computes the tab sequence of three non-prioritized elements", t => {
   t.deepEqual(getTabSequence(context, context), [a, input]);
 });
 
-test("Computes the tab sequence of three elements with priotization", t => {
+test("Sorts element based on their tab index", t => {
   const div = <div />;
   const a = <a href="#" />;
   const input = <input tabindex="1" type="text" />;
@@ -34,7 +34,7 @@ test("Computes the tab sequence of three elements with priotization", t => {
   t.deepEqual(getTabSequence(context, context), [input, a]);
 });
 
-test("Computes the tab sequence of three elements with ignoring priotization", t => {
+test("Leaves out elements with negative tab indices", t => {
   const div = <div />;
   const a = <a href="#" />;
   const input = <input tabindex="-1" type="text" />;
@@ -50,7 +50,7 @@ test("Computes the tab sequence of three elements with ignoring priotization", t
   t.deepEqual(getTabSequence(context, context), [a]);
 });
 
-test("Computes the tab sequence of colliding elements", t => {
+test("Positions elements with the same tab indices in tree order", t => {
   const div = <div />;
   const button = <button />;
   const a = <a tabindex="1" href="#" />;
@@ -68,10 +68,28 @@ test("Computes the tab sequence of colliding elements", t => {
   t.deepEqual(getTabSequence(context, context), [a, input, button]);
 });
 
-test("Computes the tab sequence of three elements with out of bounds priotization", t => {
+test("Positions elements with a tab index of zero after elements with a non-zero tab index", t => {
+  const div = <div />;
+  const button = <button tabindex="0" />;
+  const a = <a tabindex="1" href="#" />;
+  const input = <input tabindex="1" type="text" />;
+
+  const context = (
+    <div>
+      {div}
+      {button}
+      {a}
+      {input}
+    </div>
+  );
+
+  t.deepEqual(getTabSequence(context, context), [a, input, button]);
+});
+
+test("Positions elements with spread tab index in correct order", t => {
   const div = <div />;
   const a = <a tabindex="6" href="#" />;
-  const input = <input tabindex="2" type="text" />;
+  const input = <input tabindex="1" type="text" />;
 
   const context = (
     <div>


### PR DESCRIPTION
The `getTabSequence()` casts all elements to an TabIndexedElement, which contains its index weight. This is done, due to the fact that the order of which the elements are put into the array could return a bad order.