### PR TITLE
Adding some missing test-cases for the meta-refresh wcag rule

### DIFF
--- a/packages/alfa-wcag/test/meta-refresh/rule.spec.tsx
+++ b/packages/alfa-wcag/test/meta-refresh/rule.spec.tsx
@@ -56,3 +56,29 @@ test("Fails when a refresh has a timeout greater than 0 and a URL", t => {
 
   outcome(t, results, { failed: [meta] });
 });
+
+test("Fails when a refresh has a timeout and not being ended correctly", t => {
+  const meta = <meta http-equiv="refresh" content="5." />;
+  const document = (
+    <html>
+      <head>{meta}</head>
+    </html>
+  );
+
+  const results = audit({ document }, MetaRefresh);
+
+  outcome(t, results, { failed: [meta] });
+});
+
+test("Inapplicable when a refresh has no content attribute", t => {
+  const meta = <meta http-equiv="refresh" />;
+  const document = (
+    <html>
+      <head>{meta}</head>
+    </html>
+  );
+
+  const results = audit({ document }, MetaRefresh);
+
+  outcome(t, results, { inapplicable: [meta] });
+});


### PR DESCRIPTION
Two test cases that increase the coverage of edge cases in the file to above 90%.