### PR TITLE
Increasing coverage and fixing a bug

### DIFF
--- a/packages/alfa-aria/src/is-visible.ts
+++ b/packages/alfa-aria/src/is-visible.ts
@@ -1,6 +1,7 @@
 import {
   Element,
   getAttribute,
+  getClosest,
   getComputedStyle,
   getParentElement,
   isElement,
@@ -10,20 +11,18 @@ import {
 } from "@siteimprove/alfa-dom";
 
 export function isVisible(node: Element | Text, context: Node): boolean {
+  if (
+    getClosest(
+      node,
+      context,
+      node => isElement(node) && getAttribute(node, "aria-hidden") === "true",
+      { flattened: true }
+    ) !== null
+  ) {
+    return false;
+  }
+
   if (isElement(node)) {
-    if (getAttribute(node, "aria-hidden") === "true") {
-      return false;
-    }
-
-    let parent = getParentElement(node, context);
-    while (parent !== null) {
-      if (getAttribute(parent, "aria-hidden") === "true") {
-        return false;
-      }
-
-      parent = getParentElement(parent, context);
-    }
-
     const { visibility } = getComputedStyle(node, context);
 
     if (visibility === "hidden" || visibility === "collapse") {

--- a/packages/alfa-aria/src/is-visible.ts
+++ b/packages/alfa-aria/src/is-visible.ts
@@ -15,9 +15,13 @@ export function isVisible(node: Element | Text, context: Node): boolean {
       return false;
     }
 
-    const parent = getParentElement(node, context);
-    if (parent !== null && !isVisible(parent, context)) {
-      return false;
+    let parent = getParentElement(node, context);
+    while (parent !== null) {
+      if (getAttribute(parent, "aria-hidden") === "true") {
+        return false;
+      }
+
+      parent = getParentElement(parent, context);
     }
 
     const { visibility } = getComputedStyle(node, context);

--- a/packages/alfa-aria/src/is-visible.ts
+++ b/packages/alfa-aria/src/is-visible.ts
@@ -15,6 +15,11 @@ export function isVisible(node: Element | Text, context: Node): boolean {
       return false;
     }
 
+    const parent = getParentElement(node, context);
+    if (parent !== null && !isVisible(parent, context)) {
+      return false;
+    }
+
     const { visibility } = getComputedStyle(node, context);
 
     if (visibility === "hidden" || visibility === "collapse") {

--- a/packages/alfa-aria/test/is-visible.spec.tsx
+++ b/packages/alfa-aria/test/is-visible.spec.tsx
@@ -1,0 +1,36 @@
+import { jsx } from "@siteimprove/alfa-jsx";
+import { test } from "@siteimprove/alfa-test";
+import { isVisible } from "../src/is-visible";
+
+test("Returns true on a visible element", t => {
+  const div = <div />;
+  t(isVisible(div, div));
+});
+
+test("Returns false on a hidden element", t => {
+  const div = <div style="visibility:hidden;" />;
+  t(!isVisible(div, div));
+});
+
+test("Returns false on a aria hidden element", t => {
+  const div = <div aria-hidden="true" />;
+  t(!isVisible(div, div));
+});
+
+test("Returns false on a implicitly hidden element using display", t => {
+  const child = <button />;
+  const div = <div style="display:none;">{child}</div>;
+  t(!isVisible(child, div));
+});
+
+test("Returns false on a implicitly hidden element using visibility", t => {
+  const child = <button />;
+  const div = <div style="visibility:hidden;">{child}</div>;
+  t(!isVisible(child, div));
+});
+
+test("Returns false on a implicitly hidden element using aria", t => {
+  const child = <button />;
+  const div = <div aria-hidden="true">{child}</div>;
+  t(!isVisible(child, div));
+});

--- a/packages/alfa-dom/test/get-specificity.spec.ts
+++ b/packages/alfa-dom/test/get-specificity.spec.ts
@@ -37,3 +37,18 @@ test("Single ID selectors have the same specificity", t => {
 test("An ID is more specific than a class", t => {
   t(getSpecificity(selector("#foo")) > getSpecificity(selector(".bar")));
 });
+
+test("A class is as specific as a pseudo-class-selector", t => {
+  t(getSpecificity(selector(".foo")) === getSpecificity(selector(":visited")));
+});
+
+test("A class is more specific than a type-selector", t => {
+  t(getSpecificity(selector(".foo")) > getSpecificity(selector("a")));
+});
+
+test("A class is more specific than a pseudo-element-selector", t => {
+  t(
+    getSpecificity(selector(".foo")) >
+      getSpecificity(selector("::first-letter"))
+  );
+});

--- a/packages/alfa-dom/test/user-agent.spec.ts
+++ b/packages/alfa-dom/test/user-agent.spec.ts
@@ -1,6 +1,18 @@
 import { test } from "@siteimprove/alfa-test";
-import { UserAgent } from "../src/user-agent";
+import { Rule, RuleType } from "../src/types";
+import { isUserAgentRule, UserAgent } from "../src/user-agent";
 
 test("Parses UA style sheet without blowing up", t => {
   t(UserAgent.cssRules.length > 0);
+});
+
+test("An User-Agent CSS rule is being parsed as being an UA rule", t => {
+  t(isUserAgentRule(UserAgent.cssRules[0]));
+});
+
+test("A non User-Agent CSS rule is not being parsed as being an UA rule", t => {
+  const rule: Rule = {
+    type: RuleType.Style // something
+  };
+  t(!isUserAgentRule(rule));
 });


### PR DESCRIPTION
This PR increases the coverage of various parts of the code-base, as well as fixing a bug, where aria-hidden wasn't inherited down to child elements.

I've implemented a check for this inheritance using a while-loop that climbs the tree of nodes instead of recursively calling isVisible. I chose this solution because isVisible does more than just checking for aria-hidden, which would cause an unnecessary performance penalty.