### PR TITLE
Closes #49: Detect untested files

### DIFF
--- a/scripts/helpers/metrics/arithmetic.js
+++ b/scripts/helpers/metrics/arithmetic.js
@@ -156,9 +156,7 @@ const Arithmetic = {
     }
 
     return (uncovered / total) * 100;
-  },
-
-  visit
+  }
 };
 
 exports.Arithmetic = Arithmetic;

--- a/scripts/helpers/metrics/arithmetic.js
+++ b/scripts/helpers/metrics/arithmetic.js
@@ -156,7 +156,9 @@ const Arithmetic = {
     }
 
     return (uncovered / total) * 100;
-  }
+  },
+
+  visit
 };
 
 exports.Arithmetic = Arithmetic;

--- a/scripts/helpers/metrics/logical.js
+++ b/scripts/helpers/metrics/logical.js
@@ -58,6 +58,8 @@ function visit(node, depth = -1) {
         case TypeScript.SyntaxKind.LessThanEqualsToken:
         case TypeScript.SyntaxKind.EqualsEqualsToken:
         case TypeScript.SyntaxKind.EqualsEqualsEqualsToken:
+        case TypeScript.SyntaxKind.ExclamationEqualsToken:
+        case TypeScript.SyntaxKind.ExclamationEqualsEqualsToken:
           depth++;
           total += Math.pow(1.1, depth);
       }
@@ -132,7 +134,9 @@ const Logical = {
     }
 
     return (uncovered / total) * 100;
-  }
+  },
+
+  visit
 };
 
 exports.Logical = Logical;

--- a/scripts/helpers/metrics/logical.js
+++ b/scripts/helpers/metrics/logical.js
@@ -134,9 +134,7 @@ const Logical = {
     }
 
     return (uncovered / total) * 100;
-  },
-
-  visit
+  }
 };
 
 exports.Logical = Logical;

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -44,6 +44,10 @@ for (const pkg of packages) {
   );
 
   for (const file of files) {
+    if (file.indexOf("/src/") === -1) {
+      continue; // File is not in source folder
+    }
+
     const dir = path
       .dirname(file)
       .split(path.sep)

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -61,7 +61,7 @@ for (const pkg of packages) {
       path.join(dir, `${path.basename(file, ".ts")}.spec.tsx`)
     ];
 
-    if (potentialTestFiles.some(isFile(file))) {
+    if (potentialTestFiles.some(isFile)) {
       continue; // An associated test file was found
     }
 

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -1,4 +1,9 @@
-const { findFiles } = require("./helpers/file-system");
+const { default: chalk } = require("chalk");
+const fs = require("fs");
+const path = require("path");
+const TypeScript = require("typescript");
+
+const { findFiles, isFile } = require("./helpers/file-system");
 const { endsWith, not } = require("./helpers/predicates");
 const { packages } = require("./helpers/meta");
 const { format, now } = require("./helpers/time");
@@ -6,6 +11,11 @@ const notify = require("./helpers/notify");
 
 const { build } = require("./tasks/build");
 const { clean } = require("./tasks/clean");
+
+const { Logical } = require("./helpers/metrics/logical");
+const { Arithmetic } = require("./helpers/metrics/arithmetic");
+
+const metrics = [Arithmetic, Logical];
 
 /**
  * @param {Array<string>} files
@@ -35,11 +45,46 @@ for (const pkg of packages) {
 
   handle(findFiles(`${root}/scripts`, endsWith(".js")));
 
-  handle(
-    findFiles(root, endsWith(".ts", ".tsx")).filter(
-      not(endsWith(".spec.ts", ".spec.tsx"))
-    )
+  const files = findFiles(root, endsWith(".ts", ".tsx")).filter(
+    not(endsWith(".spec.ts", ".spec.tsx"))
   );
+
+  for (const file of files) {
+    const dir = path
+      .dirname(file)
+      .split(path.sep)
+      .map(part => (part === "src" ? "test" : part))
+      .join(path.sep);
+
+    const tsTestFile = path.join(dir, `${path.basename(file, ".ts")}.spec.ts`);
+    const tsxTestFile = path.join(
+      dir,
+      `${path.basename(file, ".tsx")}.spec.tsx`
+    );
+
+    if (isFile(tsTestFile) || isFile(tsxTestFile)) {
+      continue; // Found an associated test file
+    }
+
+    const compiled = TypeScript.createSourceFile(
+      "anon.ts",
+      fs.readFileSync(file).toString(),
+      TypeScript.ScriptTarget.ES2015
+    );
+
+    let operators = metrics.reduce(
+      (acc, metric) => acc + metric.visit(compiled),
+      0
+    );
+
+    if (operators <= 0) {
+      continue;
+    }
+
+    notify.warn(`${chalk.gray(file)} Missing spec file`); // This could be an error in the future and actually fail the build.
+  }
+
+  handle(files);
 }
 
 handle(findFiles("docs", endsWith(".ts", ".tsx")));

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -1,9 +1,8 @@
 const { default: chalk } = require("chalk");
-const fs = require("fs");
 const path = require("path");
 const TypeScript = require("typescript");
 
-const { findFiles, isFile } = require("./helpers/file-system");
+const { findFiles, isFile, readFile } = require("./helpers/file-system");
 const { endsWith, not } = require("./helpers/predicates");
 const { packages } = require("./helpers/meta");
 const { format, now } = require("./helpers/time");
@@ -62,13 +61,13 @@ for (const pkg of packages) {
       path.join(dir, `${path.basename(file, ".ts")}.spec.tsx`)
     ];
 
-    if (potentialTestFiles.some(file => isFile(file))) {
+    if (potentialTestFiles.some(isFile(file))) {
       continue; // An associated test file was found
     }
 
     const compiled = TypeScript.createSourceFile(
       "anon.ts",
-      fs.readFileSync(file).toString(),
+      readFile(file),
       TypeScript.ScriptTarget.ES2015
     );
 

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -51,14 +51,19 @@ for (const pkg of packages) {
       .map(part => (part === "src" ? "test" : part))
       .join(path.sep);
 
-    const tsTestFile = path.join(dir, `${path.basename(file, ".ts")}.spec.ts`);
-    const tsxTestFile = path.join(
-      dir,
-      `${path.basename(file, ".tsx")}.spec.tsx`
-    );
+    const potentialTestFiles = [
+      // TS source with TS test file
+      path.join(dir, `${path.basename(file, ".ts")}.spec.ts`),
+      // TSX source with TS test file
+      path.join(dir, `${path.basename(file, ".tsx")}.spec.ts`),
+      // TSX source with TSX test file
+      path.join(dir, `${path.basename(file, ".tsx")}.spec.tsx`),
+      // TS source with TSX test file
+      path.join(dir, `${path.basename(file, ".ts")}.spec.tsx`)
+    ];
 
-    if (isFile(tsTestFile) || isFile(tsxTestFile)) {
-      continue; // Found an associated test file
+    if (potentialTestFiles.some(file => isFile(file))) {
+      continue; // An associated test file was found
     }
 
     const compiled = TypeScript.createSourceFile(
@@ -92,7 +97,7 @@ function isTestable(node, testable = false) {
         )
       ) {
         // Functions that are exported is testable
-        testable = true;
+        return true;
       }
       break;
   }


### PR DESCRIPTION
As discussed in person, precise heuristics to detect untested files are required. These heuristics must not create false positives.

This initial version extends the prepare method to look for source files without an associated test file. The unassociated files will then be compiled to search for exported functions.