### PR TITLE
Optmizing code output

### DIFF
--- a/scripts/helpers/coverage.js
+++ b/scripts/helpers/coverage.js
@@ -132,9 +132,9 @@ process.on("beforeExit", code => {
             uncovered[i].range.end.line - uncovered[i].range.start.line + 5; // Buffer added for dots and spacing
           if (
             lineSum > (process.stdout.rows ? process.stdout.rows : 24) &&
-            i > 0
+            i > 0 // At least one block has to be printed
           ) {
-            break; // If the next block is going to fill
+            break; // If the next block is going to fill more than the height
           }
 
           printBlockCoverage(script, uncovered[i], widths);

--- a/scripts/helpers/coverage.js
+++ b/scripts/helpers/coverage.js
@@ -130,19 +130,19 @@ process.on("beforeExit", code => {
           return a.range.start.line - b.range.start.line;
         });
 
+        const widths = {
+          // Make the gutter width as wide as the line number of the last line.
+          // Since line counts are 1-indexed and an additional line may be added
+          // to the output, we bump the line count twice to make sure the gutter
+          // is wide enough.
+          gutter: `${selectedBlocks[selectedBlocks.length - 1].range.end.line +
+            2}`.length
+        };
+
         for (let i = 0; blockCount > i; i++) {
           if (i !== 0) {
             process.stdout.write(chalk.blue(`${"\u00b7".repeat(3)}\n`));
           }
-
-          const widths = {
-            // Make the gutter width as wide as the line number of the last line.
-            // Since line counts are 1-indexed and an additional line may be added
-            // to the output, we bump the line count twice to make sure the gutter
-            // is wide enough.
-            gutter: `${selectedBlocks[selectedBlocks.length - 1].range.end
-              .line + 2}`.length
-          };
 
           printBlockCoverage(script, selectedBlocks[i], widths);
         }

--- a/scripts/helpers/coverage.js
+++ b/scripts/helpers/coverage.js
@@ -88,10 +88,6 @@ process.on("beforeExit", code => {
           const bp = blocks.get(b);
 
           return (bp === undefined ? 0 : bp) - (ap === undefined ? 0 : ap);
-        })
-        .slice(0, 3)
-        .sort((a, b) => {
-          return a.range.start.line - b.range.start.line;
         });
 
       if (uncovered.length > 0 && process.env.npm_lifecycle_event === "start") {
@@ -120,12 +116,30 @@ process.on("beforeExit", code => {
           gutter: `${uncovered[uncovered.length - 1].range.end.line + 2}`.length
         };
 
-        for (let i = 0, n = uncovered.length; i < n; i++) {
+        let lineSum = 5;
+        let i = 0;
+
+        while (true) {
+          if (uncovered[i] === undefined) {
+            break;
+          }
+
           if (i !== 0) {
             process.stdout.write(chalk.blue(`${"\u00b7".repeat(3)}\n`));
           }
 
+          lineSum +=
+            uncovered[i].range.end.line - uncovered[i].range.start.line + 5; // Buffer added for dots and spacing
+          if (
+            lineSum > (process.stdout.rows ? process.stdout.rows : 24) &&
+            i > 0
+          ) {
+            break; // If the next block is going to fill
+          }
+
           printBlockCoverage(script, uncovered[i], widths);
+
+          i++;
         }
       }
 


### PR DESCRIPTION
This changes the output of the coverage helper a bit:
- It will now print as many blocks as there is room for (not three), but minimum 1.
- ~It was sorting based on line number, which I removed (We don't know how many is going to be printed, so we can't slice it).~