### PR TITLE
Tests and corrections in alfa-crypto

### DIFF
--- a/packages/alfa-crypto/src/get-hash.ts
+++ b/packages/alfa-crypto/src/get-hash.ts
@@ -6,15 +6,9 @@ export class Hash {
 
   public constructor(algorithm: Algorithm) {
     switch (algorithm) {
-      case "sha1":
-        this.hash = new sjcl.hash.sha1();
-        break;
       case "sha256":
       default:
         this.hash = new sjcl.hash.sha256();
-        break;
-      case "sha512":
-        this.hash = new sjcl.hash.sha512();
     }
   }
 
@@ -40,10 +34,7 @@ export class Hash {
     let codec: sjcl.SjclCodec<string>;
 
     switch (encoding) {
-      case "utf8":
       default:
-        codec = sjcl.codec.utf8String;
-        break;
       case "hex":
         codec = sjcl.codec.hex;
         break;

--- a/packages/alfa-crypto/src/get-hash.ts
+++ b/packages/alfa-crypto/src/get-hash.ts
@@ -34,8 +34,8 @@ export class Hash {
     let codec: sjcl.SjclCodec<string>;
 
     switch (encoding) {
-      default:
       case "hex":
+      default:
         codec = sjcl.codec.hex;
         break;
       case "base64":

--- a/packages/alfa-crypto/src/types.ts
+++ b/packages/alfa-crypto/src/types.ts
@@ -1,5 +1,5 @@
-export type Algorithm = "sha1" | "sha256" | "sha512";
+export type Algorithm = "sha256";
 
-export type Encoding = "utf8" | "hex" | "base64";
+export type Encoding = "hex" | "base64";
 
 export type Bits = Array<number>;

--- a/packages/alfa-crypto/test/get-hash.spec.ts
+++ b/packages/alfa-crypto/test/get-hash.spec.ts
@@ -12,7 +12,7 @@ test("Can hash a SHA-256 bit array", t => {
   );
 });
 
-test("Can hash a SHA-256 bit array", t => {
+test("Can hash a SHA-256 string", t => {
   // Hex
   t.equal(
     getHash("sha256")

--- a/packages/alfa-crypto/test/get-hash.spec.ts
+++ b/packages/alfa-crypto/test/get-hash.spec.ts
@@ -1,0 +1,48 @@
+import { test } from "@siteimprove/alfa-test";
+import { getHash } from "../src/get-hash";
+
+test("Can hash a SHA-256 bit array", t => {
+  const helloWorld = [1214606444, 1864390511, 26390198772736];
+
+  t.equal(
+    getHash("sha256")
+      .update(helloWorld)
+      .digest("hex"),
+    "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e"
+  );
+});
+
+test("Can hash a SHA-256 bit array", t => {
+  // Hex
+  t.equal(
+    getHash("sha256")
+      .update("Hello World")
+      .digest("hex"),
+    "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e"
+  );
+
+  // Base64
+  t.equal(
+    getHash("sha256")
+      .update("Hello World")
+      .digest("base64"),
+    "pZGm1Av0IEBKARczz7exkNYsZb8LzaMrV7J32a2fFG4="
+  );
+
+  // Raw bits
+  t.deepEqual(
+    getHash("sha256")
+      .update("Hello World")
+      .digest(),
+    [
+      -1517181228,
+      200548416,
+      1241585459,
+      -810045040,
+      -701733441,
+      198026027,
+      1471313881,
+      -1382083474
+    ]
+  );
+});


### PR DESCRIPTION
To get closer to our goal of 90% test-coverage, I have written tests to alfa-crypto. The task above introduced a lot of weirdness, so I have removed things from alfa-crypto, that does not work or have issues.

- I have removed the SHA1 and SHA512 algorithm target from alfa-crypto, as they are not shipped with SJCL (.. any more?).
- I have removed the UTF-8 codec as only some bit strings are valid UTF-8 sequences (see https://github.com/bitwiseshiftleft/sjcl/issues/131). I haven't gotten the UTF-8 codec to work on any string yet. If I have misunderstood something here, please correct me.