### PR TITLE
Incorrect path separator in build phase

### DIFF
--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -44,7 +44,7 @@ for (const pkg of packages) {
   );
 
   for (const file of files) {
-    if (file.indexOf("/src/") === -1) {
+    if (file.indexOf(`${path.sep}src${path.sep}`) === -1) {
       continue; // File is not in source folder
     }
 


### PR DESCRIPTION
The current `prepare.js` does not work correctly on Windows, due to the incorrect path separator.