### PR TITLE
Closes #18: Implement remaining HTML tokenisation steps

### DIFF
--- a/packages/alfa-html/test/alphabet.spec.ts
+++ b/packages/alfa-html/test/alphabet.spec.ts
@@ -392,6 +392,52 @@ test("Can lex CDATA outside of the HTML namespace", t => {
   ]);
 });
 
+// Tests that the namespaceStack is working as expected
+test("Can lex CDATA outside of the HTML namespace with multiple non-html tags", t => {
+  html(t, "<svg><svg></svg><![CDATA[<p>]]]]></svg>", [
+    {
+      type: TokenType.StartTag,
+      name: "svg",
+      selfClosing: false,
+      attributes: []
+    },
+    {
+      type: TokenType.StartTag,
+      name: "svg",
+      selfClosing: false,
+      attributes: []
+    },
+    {
+      type: TokenType.EndTag,
+      name: "svg"
+    },
+    {
+      type: TokenType.Character,
+      data: char("<")
+    },
+    {
+      type: TokenType.Character,
+      data: char("p")
+    },
+    {
+      type: TokenType.Character,
+      data: char(">")
+    },
+    {
+      type: TokenType.Character,
+      data: char("]")
+    },
+    {
+      type: TokenType.Character,
+      data: char("]")
+    },
+    {
+      type: TokenType.EndTag,
+      name: "svg"
+    }
+  ]);
+});
+
 test("Cannot lex CDATA inside of the HTML namespace (bogus comment)", t => {
   html(t, "<![CDATA[<p>]]]]>", [
     {

--- a/packages/alfa-html/test/alphabet.spec.ts
+++ b/packages/alfa-html/test/alphabet.spec.ts
@@ -357,6 +357,70 @@ test("Can lex a doctype with both a public ID and system ID", t => {
   ]);
 });
 
+test("Can lex CDATA outside of the HTML namespace", t => {
+  html(t, "<svg><![CDATA[<p>]]]]></svg>", [
+    {
+      type: TokenType.StartTag,
+      name: "svg",
+      selfClosing: false,
+      attributes: []
+    },
+    {
+      type: TokenType.Character,
+      data: char("<")
+    },
+    {
+      type: TokenType.Character,
+      data: char("p")
+    },
+    {
+      type: TokenType.Character,
+      data: char(">")
+    },
+    {
+      type: TokenType.Character,
+      data: char("]")
+    },
+    {
+      type: TokenType.Character,
+      data: char("]")
+    },
+    {
+      type: TokenType.EndTag,
+      name: "svg"
+    }
+  ]);
+});
+
+test("Cannot lex CDATA inside of the HTML namespace (bogus comment)", t => {
+  html(t, "<![CDATA[<p>]]]]>", [
+    {
+      type: TokenType.Comment,
+      data: "[CDATA[<p"
+    },
+    {
+      type: TokenType.Character,
+      data: char("]")
+    },
+    {
+      type: TokenType.Character,
+      data: char("]")
+    },
+    {
+      type: TokenType.Character,
+      data: char("]")
+    },
+    {
+      type: TokenType.Character,
+      data: char("]")
+    },
+    {
+      type: TokenType.Character,
+      data: char(">")
+    }
+  ]);
+});
+
 test("Can lex a textarea element with an apparent tag", t => {
   html(t, "<textarea><tag></textarea>", [
     {


### PR DESCRIPTION
This implements the remaining tokenisation steps in Alphabet.ts.