### PR TITLE
Coverage tools stopped working on never node versions

### DIFF
--- a/scripts/helpers/coverage.js
+++ b/scripts/helpers/coverage.js
@@ -66,7 +66,9 @@ process.on("beforeExit", code => {
     const impl = path.join(dir, `${path.basename(spec, ".spec.js")}.js`);
 
     for (const scriptCoverage of result) {
-      scriptCoverage.url = scriptCoverage.url.replace("file://", "");
+      if (scriptCoverage.url.indexOf("file://") === 0) {
+        scriptCoverage.url = scriptCoverage.url.replace("file://", "");
+      }
       if (scriptCoverage.url !== impl) {
         continue;
       }

--- a/scripts/helpers/coverage.js
+++ b/scripts/helpers/coverage.js
@@ -66,6 +66,7 @@ process.on("beforeExit", code => {
     const impl = path.join(dir, `${path.basename(spec, ".spec.js")}.js`);
 
     for (const scriptCoverage of result) {
+      scriptCoverage.url = scriptCoverage.url.replace("file://", "");
       if (scriptCoverage.url !== impl) {
         continue;
       }


### PR DESCRIPTION
Our coverage tool stopped working on some newer versions of node (10.12.0 and later). This issue is possibly related to https://github.com/nodejs/node/pull/22251.
Nonetheless, I have added a replace statement that is triggered if the protocol is prepended to the URL. This fixes the issue and should be backwards-compatible as well :-)