### PR TITLE
Correcting contact information

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-act/package.json
+++ b/packages/alfa-act/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-affine/package.json
+++ b/packages/alfa-affine/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-angular/package.json
+++ b/packages/alfa-angular/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-aria/package.json
+++ b/packages/alfa-aria/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-assert/package.json
+++ b/packages/alfa-assert/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-chai/package.json
+++ b/packages/alfa-chai/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-cheerio/package.json
+++ b/packages/alfa-cheerio/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-cli/package.json
+++ b/packages/alfa-cli/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-collection/package.json
+++ b/packages/alfa-collection/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-compatibility/package.json
+++ b/packages/alfa-compatibility/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-crypto/package.json
+++ b/packages/alfa-crypto/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-css/package.json
+++ b/packages/alfa-css/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-cypress/package.json
+++ b/packages/alfa-cypress/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-device/package.json
+++ b/packages/alfa-device/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-dom/package.json
+++ b/packages/alfa-dom/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-enzyme/package.json
+++ b/packages/alfa-enzyme/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-highlight/package.json
+++ b/packages/alfa-highlight/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-html/package.json
+++ b/packages/alfa-html/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-http/package.json
+++ b/packages/alfa-http/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-iana/package.json
+++ b/packages/alfa-iana/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-jasmine/package.json
+++ b/packages/alfa-jasmine/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-jest/package.json
+++ b/packages/alfa-jest/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-jquery/package.json
+++ b/packages/alfa-jquery/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-json-ld/package.json
+++ b/packages/alfa-json-ld/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-lang/package.json
+++ b/packages/alfa-lang/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-math/package.json
+++ b/packages/alfa-math/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-pointer/package.json
+++ b/packages/alfa-pointer/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-puppeteer/package.json
+++ b/packages/alfa-puppeteer/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-react/package.json
+++ b/packages/alfa-react/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-rules/package.json
+++ b/packages/alfa-rules/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-scrape/package.json
+++ b/packages/alfa-scrape/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-test/package.json
+++ b/packages/alfa-test/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-unexpected/package.json
+++ b/packages/alfa-unexpected/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-unicode/package.json
+++ b/packages/alfa-unicode/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-util/package.json
+++ b/packages/alfa-util/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-vue/package.json
+++ b/packages/alfa-vue/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-webdriver/package.json
+++ b/packages/alfa-webdriver/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/alfa-xpath/package.json
+++ b/packages/alfa-xpath/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],

--- a/packages/eslint-plugin-alfa/package.json
+++ b/packages/eslint-plugin-alfa/package.json
@@ -17,7 +17,7 @@
     "Búgvi Benjamin Magnussen <bbm@siteimprove.com>",
     "Jean-Yves Moyen <jym@siteimprove.com>",
     "Kasper Kronborg Isager <kki@siteimprove.com>",
-    "Niclas Hedam <nhe@siteimprove.com>",
+    "Niclas Hedam <niclas@hed.am>",
     "Per Jakobsen <pja@siteimprove.com>",
     "Tobias Christian Jensen <tcj@siteimprove.com>"
   ],


### PR DESCRIPTION
As I am not employed by Siteimprove anymore, I cannot be reached on the listed email.
I think it would make sense to either remove my email or update it to an active one.

This PR updates my listing to my personal address.

Signed-off-by: Niclas Hedam <niclas@hed.am>