### PR TITLE
Disregard decorative images in SIA-R2

### DIFF
--- a/packages/alfa-rules/src/sia-r2/rule.ts
+++ b/packages/alfa-rules/src/sia-r2/rule.ts
@@ -8,10 +8,8 @@ import { Page } from "@siteimprove/alfa-web";
 import { expectation } from "../common/expectation";
 
 import { hasAccessibleName } from "../common/predicate/has-accessible-name";
-import { hasName } from "../common/predicate/has-name";
 import { hasNamespace } from "../common/predicate/has-namespace";
 import { hasRole } from "../common/predicate/has-role";
-import { isDecorative } from "../common/predicate/is-decorative";
 import { isIgnored } from "../common/predicate/is-ignored";
 
 const { filter } = Iterable;
@@ -28,12 +26,9 @@ export default Rule.Atomic.of<Page, Element>({
             Element.isElement,
             and(
               hasNamespace(equals(Namespace.HTML)),
-              or(
-                hasName(equals("img")),
-                and(
-                  hasRole(property("name", equals("img"))),
-                  not(isIgnored(device))
-                )
+              and(
+                hasRole(property("name", equals("img"))),
+                not(isIgnored(device))
               )
             )
           )
@@ -43,13 +38,9 @@ export default Rule.Atomic.of<Page, Element>({
       expectations(target) {
         return {
           1: expectation(
-            isDecorative(target),
-            Outcomes.IsDecorative,
-            expectation(
-              hasAccessibleName(device)(target),
-              Outcomes.HasAccessibleName,
-              Outcomes.HasNoAccessibleNameNorIsDecorative
-            )
+            hasAccessibleName(device)(target),
+            Outcomes.HasAccessibleName,
+            Outcomes.HasNoAccessibleName
           )
         };
       }
@@ -60,9 +51,5 @@ export default Rule.Atomic.of<Page, Element>({
 export namespace Outcomes {
   export const HasAccessibleName = Ok.of("The image has an accessible name");
 
-  export const IsDecorative = Ok.of("The image is marked as decorative");
-
-  export const HasNoAccessibleNameNorIsDecorative = Err.of(
-    "The image neither has an accessible name nor is marked as decorative"
-  );
+  export const HasNoAccessibleName = Err.of("The image has no accessible name");
 }

--- a/packages/alfa-rules/test/sia-r2/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r2/rule.spec.tsx
@@ -25,22 +25,6 @@ test("evaluate() passes an image with an accessible name", async t => {
   ]);
 });
 
-test("evaluate() passes an image that is marked as decorative", async t => {
-  const document = Document.of(self => [
-    Element.fromElement(<img role="none"></img>, Option.of(self))
-  ]);
-
-  const img = document
-    .children()
-    .filter(Element.isElement)
-    .first()
-    .get();
-
-  t.deepEqual(await evaluate(R2, { document }), [
-    passed(R2, img, [["1", Outcomes.IsDecorative]])
-  ]);
-});
-
 test("evaluate() fails an image that has no accessible name", async t => {
   const document = Document.of(self => [
     Element.fromElement(<img></img>, Option.of(self))
@@ -53,12 +37,40 @@ test("evaluate() fails an image that has no accessible name", async t => {
     .get();
 
   t.deepEqual(await evaluate(R2, { document }), [
-    failed(R2, img, [["1", Outcomes.HasNoAccessibleNameNorIsDecorative]])
+    failed(R2, img, [["1", Outcomes.HasNoAccessibleName]])
   ]);
 });
 
 test("evaluate() is inapplicable when a document has no images", async t => {
   const document = Document.empty();
+
+  t.deepEqual(await evaluate(R2, { document }), [inapplicable(R2)]);
+});
+
+test("evaluate() is inapplicable to an image that is marked as decorative", async t => {
+  const document = Document.of(self => [
+    Element.fromElement(<img role="none"></img>, Option.of(self))
+  ]);
+
+  const img = document
+    .children()
+    .filter(Element.isElement)
+    .first()
+    .get();
+
+  t.deepEqual(await evaluate(R2, { document }), [inapplicable(R2)]);
+});
+
+test("evaluate() is inapplicable to an image that is hidden", async t => {
+  const document = Document.of(self => [
+    Element.fromElement(<img hidden alt="Hello world"></img>, Option.of(self))
+  ]);
+
+  const img = document
+    .children()
+    .filter(Element.isElement)
+    .first()
+    .get();
 
   t.deepEqual(await evaluate(R2, { document }), [inapplicable(R2)]);
 });


### PR DESCRIPTION
This pull request deals with the issue outlined in https://github.com/act-rules/act-rules.github.io/issues/446 by completely disregarding decorative images. From an implementation perspective, my suggested solution to that issue, namely changing the applicability to...

> any HTML <img> element that is either included in the accessibility tree or excluded from the accessibility tree because it is marked as decorative.

...seems to introduce too much complexity for too little gain. While we can easily determine if an image is decorative, tying its exclusion from the accessibility tree to the fact that it is decorative is not simple. The best solution to this would be to have the accessibility tree keep track of the reason why a given node was either excluded or included. If there's a strong enough case for actually implementing that, I'd however be happy to reconsider.

@May-N Just a heads up that this change will require updating the issue description in the platform.