### PR TITLE
Test only files with corresponding .ts(x)

### DIFF
--- a/scripts/common/tester.js
+++ b/scripts/common/tester.js
@@ -4,7 +4,8 @@ const { system } = require("./system");
 
 exports.tester = {
   test(root = "packages") {
-    for (const fileName of system.readDirectory(root, [".spec.js"])) {
+    for (const fileNameTS of system.readDirectory(root, [".spec.ts", ".spec.tsx"])) {
+      const fileName = fileNameTS.replace(/\.tsx?/, ".js");
       execa
         .node(fileName, [], {
           nodeOptions: [

--- a/scripts/common/tester.js
+++ b/scripts/common/tester.js
@@ -4,8 +4,8 @@ const { system } = require("./system");
 
 exports.tester = {
   test(root = "packages") {
-    for (const fileNameTS of system.readDirectory(root, [".spec.ts", ".spec.tsx"])) {
-      const fileName = fileNameTS.replace(/\.tsx?/, ".js");
+    for (let fileName of system.readDirectory(root, [".spec.ts", ".spec.tsx"])) {
+      fileName = fileName.replace(/\.tsx?$/, ".js");
       execa
         .node(fileName, [], {
           nodeOptions: [


### PR DESCRIPTION
I keep switching between branches and having test failing because the `.js` is still here but orphaned from its `.ts(x)` (residing in another branch).

This will only run tests for files whose source is here, thus removing the need to manually cleaning when switching branches.