### PR TITLE
Make outcome test helpers accept expectation object

### DIFF
--- a/packages/alfa-rules/test/common/outcome.ts
+++ b/packages/alfa-rules/test/common/outcome.ts
@@ -1,5 +1,4 @@
 import { Rule, Outcome } from "@siteimprove/alfa-act";
-import { Iterable } from "@siteimprove/alfa-iterable";
 import { Some } from "@siteimprove/alfa-option";
 import { Record } from "@siteimprove/alfa-record";
 import { Result } from "@siteimprove/alfa-result";
@@ -8,24 +7,28 @@ import { Page } from "@siteimprove/alfa-web";
 export function passed<T, Q>(
   rule: Rule<Page, T, Q>,
   target: T,
-  expectations: Iterable<[string, Result<string, string>]>
+  expectations: { [id: string]: Result<string, string> }
 ): Outcome.Passed<Page, T, Q> {
   return Outcome.Passed.of(
     rule,
     target,
-    Record.from(Iterable.map(expectations, ([id, exp]) => [id, Some.of(exp)]))
+    Record.from(
+      Object.entries(expectations).map(([id, exp]) => [id, Some.of(exp)])
+    )
   );
 }
 
 export function failed<T, Q>(
   rule: Rule<Page, T, Q>,
   target: T,
-  expectations: Iterable<[string, Result<string, string>]>
+  expectations: { [id: string]: Result<string, string> }
 ): Outcome.Failed<Page, T, Q> {
   return Outcome.Failed.of(
     rule,
     target,
-    Record.from(Iterable.map(expectations, ([id, exp]) => [id, Some.of(exp)]))
+    Record.from(
+      Object.entries(expectations).map(([id, exp]) => [id, Some.of(exp)])
+    )
   );
 }
 

--- a/packages/alfa-rules/test/sia-r1/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r1/rule.spec.tsx
@@ -22,10 +22,10 @@ test("evaluate() passes a document that that a non-empty <title> element", async
   ]);
 
   t.deepEqual(await evaluate(R1, { document }), [
-    passed(R1, document, [
-      ["1", Outcomes.HasTitle],
-      ["2", Outcomes.HasNonEmptyTitle],
-    ]),
+    passed(R1, document, {
+      1: Outcomes.HasTitle,
+      2: Outcomes.HasNonEmptyTitle,
+    }),
   ]);
 });
 
@@ -35,10 +35,7 @@ test("evaluate() fails a document that has no <title> element", async (t) => {
   ]);
 
   t.deepEqual(await evaluate(R1, { document }), [
-    failed(R1, document, [
-      ["1", Outcomes.HasNoTitle],
-      ["2", Outcomes.HasEmptyTitle],
-    ]),
+    failed(R1, document, { 1: Outcomes.HasNoTitle, 2: Outcomes.HasEmptyTitle }),
   ]);
 });
 
@@ -55,10 +52,7 @@ test("evaluate() fails a document that has an empty <title> element", async (t) 
   ]);
 
   t.deepEqual(await evaluate(R1, { document }), [
-    failed(R1, document, [
-      ["1", Outcomes.HasTitle],
-      ["2", Outcomes.HasEmptyTitle],
-    ]),
+    failed(R1, document, { 1: Outcomes.HasTitle, 2: Outcomes.HasEmptyTitle }),
   ]);
 });
 

--- a/packages/alfa-rules/test/sia-r2/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r2/rule.spec.tsx
@@ -17,7 +17,7 @@ test("evaluate() passes an image with an accessible name", async (t) => {
   const img = document.children().filter(Element.isElement).first().get();
 
   t.deepEqual(await evaluate(R2, { document }), [
-    passed(R2, img, [["1", Outcomes.HasAccessibleName]]),
+    passed(R2, img, { 1: Outcomes.HasAccessibleName }),
   ]);
 });
 
@@ -29,7 +29,7 @@ test("evaluate() fails an image that has no accessible name", async (t) => {
   const img = document.children().filter(Element.isElement).first().get();
 
   t.deepEqual(await evaluate(R2, { document }), [
-    failed(R2, img, [["1", Outcomes.HasNoAccessibleName]]),
+    failed(R2, img, { 1: Outcomes.HasNoAccessibleName }),
   ]);
 });
 

--- a/packages/alfa-rules/test/sia-r24/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r24/rule.spec.tsx
@@ -45,7 +45,7 @@ test("Passes when non-streaming video elements have all audio and visual informa
   });
 
   t.deepEqual(await evaluate(R24, { document }, oracle), [
-    passed(R24, video, [["1", Outcomes.HasTranscript]]),
+    passed(R24, video, { 1: Outcomes.HasTranscript }),
   ]);
 });
 
@@ -74,7 +74,7 @@ test("Fails when non-streaming video elements have no audio and visual informati
   });
 
   t.deepEqual(await evaluate(R24, { document }, oracle), [
-    failed(R24, video, [["1", Outcomes.HasNoTranscript]]),
+    failed(R24, video, {1: Outcomes.HasNoTranscript}),
   ]);
 });
 

--- a/packages/alfa-rules/test/sia-r38/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r38/rule.spec.tsx
@@ -44,7 +44,7 @@ test("Passes when some atomic rules are passing", async (t) => {
   });
 
   t.deepEqual(await evaluate(R38, { document }, oracle), [
-    passed(R38, video, [["1", Outcomes.HasAlternative]]),
+    passed(R38, video, { 1: Outcomes.HasAlternative }),
   ]);
 });
 

--- a/packages/alfa-rules/test/sia-r57/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r57/rule.spec.tsx
@@ -20,7 +20,7 @@ test("evaluate() passes a text node that is included in a landmark", async (t) =
   const text = document.descendants().filter(Text.isText).first().get();
 
   t.deepEqual(await evaluate(R57, { document }), [
-    passed(R57, text, [["1", Outcomes.IsIncludedInLandmark]]),
+    passed(R57, text, { 1: Outcomes.IsIncludedInLandmark }),
   ]);
 });
 
@@ -35,7 +35,7 @@ test("evaluate() fails a text node that is not included in a landmark", async (t
   const text = document.descendants().filter(Text.isText).first().get();
 
   t.deepEqual(await evaluate(R57, { document }), [
-    failed(R57, text, [["1", Outcomes.IsNotIncludedInLandmark]]),
+    failed(R57, text, { 1: Outcomes.IsNotIncludedInLandmark }),
   ]);
 });
 

--- a/packages/alfa-rules/test/sia-r64/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r64/rule.spec.tsx
@@ -21,7 +21,7 @@ test("evaluate() passes a heading that has an accessible name", async (t) => {
     .get();
 
   t.deepEqual(await evaluate(R64, { document }), [
-    passed(R64, heading, [["1", Outcomes.HasAccessibleName]]),
+    passed(R64, heading, { 1: Outcomes.HasAccessibleName }),
   ]);
 });
 
@@ -37,7 +37,7 @@ test("evaluate() fails a heading that has no accessible name", async (t) => {
     .get();
 
   t.deepEqual(await evaluate(R64, { document }), [
-    failed(R64, heading, [["1", Outcomes.HasNoAccessibleName]]),
+    failed(R64, heading, { 1: Outcomes.HasNoAccessibleName }),
   ]);
 });
 

--- a/packages/alfa-rules/test/sia-r68/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r68/rule.spec.tsx
@@ -23,7 +23,7 @@ test("evaluate() passes a list with two list items", async (t) => {
   const list = document.descendants().filter(Element.isElement).first().get();
 
   t.deepEqual(await evaluate(R68, { document }), [
-    passed(R68, list, [["1", Outcomes.HasCorrectOwnedElements]]),
+    passed(R68, list, { 1: Outcomes.HasCorrectOwnedElements }),
   ]);
 });
 
@@ -44,7 +44,7 @@ test("evaluate() passes a list with a list item and a group of list items", asyn
   const list = document.descendants().filter(Element.isElement).first().get();
 
   t.deepEqual(await evaluate(R68, { document }), [
-    passed(R68, list, [["1", Outcomes.HasCorrectOwnedElements]]),
+    passed(R68, list, { 1: Outcomes.HasCorrectOwnedElements }),
   ]);
 });
 
@@ -61,6 +61,6 @@ test("evaluate() fails a list with a non-list item", async (t) => {
   const list = document.descendants().filter(Element.isElement).first().get();
 
   t.deepEqual(await evaluate(R68, { document }), [
-    failed(R68, list, [["1", Outcomes.HasIncorrectOwnedElements]]),
+    failed(R68, list, { 1: Outcomes.HasIncorrectOwnedElements }),
   ]);
 });


### PR DESCRIPTION
Make the outcome test helpers accept expectation as an object (`{1: Outcomes.Foo}`) rather than an array of array (`[["1", Outcomes.Foo]]`).

Helpers argument is thus closer to how the expectations are defined in the rules.