### PR TITLE
Include media conditions in `Sheet`

### DIFF
--- a/packages/alfa-cascade/src/selector-map.ts
+++ b/packages/alfa-cascade/src/selector-map.ts
@@ -120,6 +120,18 @@ export class SelectorMap {
     };
 
     for (const sheet of sheets) {
+      if (sheet.disabled) {
+        continue;
+      }
+
+      if (sheet.condition.isSome()) {
+        const query = Media.parse(sheet.condition.get());
+
+        if (query.isNone() || !query.get().matches(device)) {
+          continue;
+        }
+      }
+
       for (const rule of sheet.children()) {
         visit(rule);
       }

--- a/packages/alfa-cypress/src/cypress.ts
+++ b/packages/alfa-cypress/src/cypress.ts
@@ -141,6 +141,7 @@ function toSheet(sheet: globalThis.CSSStyleSheet): Sheet.JSON {
   return {
     rules: [...sheet.cssRules].map(toRule),
     disabled: sheet.disabled,
+    condition: sheet.media.mediaText === "" ? null : sheet.media.mediaText,
   };
 }
 

--- a/packages/alfa-puppeteer/src/puppeteer.ts
+++ b/packages/alfa-puppeteer/src/puppeteer.ts
@@ -151,6 +151,8 @@ export namespace Puppeteer {
         return {
           rules: [...sheet.cssRules].map(toRule),
           disabled: sheet.disabled,
+          condition:
+            sheet.media.mediaText === "" ? null : sheet.media.mediaText,
         };
       }
 

--- a/packages/alfa-webdriver/src/web-element.ts
+++ b/packages/alfa-webdriver/src/web-element.ts
@@ -151,6 +151,8 @@ export namespace WebElement {
         return {
           rules: [...sheet.cssRules].map(toRule),
           disabled: sheet.disabled,
+          condition:
+            sheet.media.mediaText === "" ? null : sheet.media.mediaText,
         };
       }
 


### PR DESCRIPTION
Closes #219.

We need to coordinate this with @lukasbob as well as the crawler services that handle page rendering will need to include media conditions in their internal page representation if they don't already do so.