### PR TITLE
Reorganise @siteimprove/alfa-highlight

### DIFF
--- a/packages/alfa-highlight/src/index.ts
+++ b/packages/alfa-highlight/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./highlight";
-export * from "./markers";
+export * from "./marker";
+export * from "./syntax";

--- a/packages/alfa-highlight/src/marker.ts
+++ b/packages/alfa-highlight/src/marker.ts
@@ -25,7 +25,7 @@ export interface Marker {
   readonly gray: this;
 }
 
-export namespace Markers {
+export namespace Marker {
   // Styles
   export const reset: Marker = chalk.reset;
   export const bold: Marker = chalk.bold;
@@ -48,4 +48,4 @@ export namespace Markers {
   export const gray: Marker = chalk.gray;
 }
 
-export const mark = Markers;
+export const mark = Marker;

--- a/packages/alfa-highlight/src/syntax.ts
+++ b/packages/alfa-highlight/src/syntax.ts
@@ -2,7 +2,7 @@
 
 import * as emphasize from "emphasize";
 
-import { mark } from "./markers";
+import { mark } from "./marker";
 
 const sheet: emphasize.Sheet = {
   comment: mark.gray,
@@ -49,6 +49,6 @@ const sheet: emphasize.Sheet = {
   formula: mark.inverse,
 };
 
-export function highlight(language: string, value: string): string {
+export function syntax(language: string, value: string): string {
   return mark.reset(emphasize.highlight(language, value, sheet).value);
 }

--- a/packages/alfa-highlight/tsconfig.json
+++ b/packages/alfa-highlight/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "../tsconfig.json",
-  "files": ["src/highlight.ts", "src/index.ts", "src/markers.ts"],
+  "files": ["src/index.ts", "src/marker.ts", "src/syntax.ts"],
   "references": []
 }


### PR DESCRIPTION
It struck me yesterday while looking into the different test integrations that the @siteimprove/alfa-highlight package is currently a little unfortunately organised. As it doesn't export any namespaces, the way it will typically be consumed within Alfa is like this:

```ts
import * as highlight from "@siteimprove/alfa-highlight";

highlight.highlight("html", "<div>Hello</div>");
highlight.mark.red("Foo");
```

Looking at the above, `highlight.highlight()` is not... great. I've therefore changed the name of the function to `syntax()` to better communicate what kind of highlighting is done, which leads to code like this:

```ts
highlight.syntax("html", "<div>Hello</div>");
```

Much better!