### PR TITLE
Rework @siteimprove/alfa-scraper and @siteimprove/alfa-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ const scraper = await Scraper.of();
 
 scraper
   .scrape("https://example.com")
+  .then((result) => {
+    if (result.isErr()) {
+      throw result.getErr();
+    } else {
+      return result.get();
+    }
+  })
   .then((page) => {
     const audit = Rules.reduce(
       (audit, rule) => audit.add(rule),
@@ -95,9 +102,6 @@ scraper
     audit.evaluate().then((outcomes) => {
       // ...
     });
-  })
-  .catch((err) => {
-    console.error(err);
   })
   .finally(() => {
     scraper.close();

--- a/docs/examples/page-testing/puppeteer/package.json
+++ b/docs/examples/page-testing/puppeteer/package.json
@@ -10,9 +10,9 @@
     "@siteimprove/alfa-puppeteer": "^0.0.1",
     "@types/chai": "^4.2.3",
     "@types/mocha": "^5.2.7",
-    "@types/puppeteer": "^1.20.1",
+    "@types/puppeteer": "^2.0.1",
     "chai": "^4.2.0",
     "mocha": "^6.2.1",
-    "puppeteer": "^1.20.0"
+    "puppeteer": "^2.1.1"
   }
 }

--- a/packages/alfa-cli/bin/alfa/commands/scrape.ts
+++ b/packages/alfa-cli/bin/alfa/commands/scrape.ts
@@ -115,7 +115,7 @@ export default class Scrape extends Command {
       default: false,
       allowNo: true,
       description:
-        "Whether or not the screenshot should include a solid, white background",
+        "Whether or not the screenshot should include a default white background. Only applies to PNG screenshots",
     }),
 
     "screenshot-quality": flags.integer({

--- a/packages/alfa-cli/bin/alfa/commands/scrape.ts
+++ b/packages/alfa-cli/bin/alfa/commands/scrape.ts
@@ -1,0 +1,230 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as url from "url";
+
+import { Command, flags } from "@oclif/command";
+
+import { Device, Display, Viewport } from "@siteimprove/alfa-device";
+import {
+  Scraper,
+  Awaiter,
+  Screenshot,
+  Credentials,
+} from "@siteimprove/alfa-scraper";
+import { Timeout } from "@siteimprove/alfa-time";
+
+export default class Scrape extends Command {
+  public static description =
+    "Scrape a page and output it in a serialisable format";
+
+  public static flags = {
+    help: flags.help({
+      description: "Display this command help",
+    }),
+
+    output: flags.string({
+      char: "o",
+      helpValue: "path",
+      description:
+        "The path to write the page to. If no path is provided, the page is written to stdout",
+    }),
+
+    timeout: flags.integer({
+      default: 10000,
+      helpValue: "milliseconds",
+      description: "The maximum time to wait for the page to load",
+    }),
+
+    width: flags.integer({
+      char: "w",
+      default: Viewport.standard().width,
+      helpValue: "pixels",
+      description: "The width of the browser viewport",
+    }),
+
+    height: flags.integer({
+      char: "h",
+      default: Viewport.standard().height,
+      helpValue: "pixels",
+      description: "The height of the browser viewport",
+    }),
+
+    orientation: flags.enum({
+      options: ["landscape", "portrait"],
+      default: Viewport.standard().orientation,
+      description: "The orientation of the browser viewport",
+    }),
+
+    resolution: flags.integer({
+      default: 1,
+      description: "The pixel density of the browser",
+    }),
+
+    username: flags.string({
+      char: "u",
+      dependsOn: ["password"],
+      description: "The username to use for HTTP Basic authentication",
+    }),
+
+    password: flags.string({
+      char: "p",
+      dependsOn: ["username"],
+      description: "The password to use for HTTP Basic authentication",
+    }),
+
+    "await-state": flags.enum({
+      options: ["ready", "loaded", "idle"],
+      default: "ready",
+      exclusive: ["await-duration", "await-selector", "await-xpath"],
+      description: "The state to await before considering the page loaded",
+    }),
+
+    "await-duration": flags.integer({
+      exclusive: ["await-state", "await-selector", "await-xpath"],
+      helpValue: "milliseconds",
+      description: "The duration to wait before considering the page loaded",
+    }),
+
+    "await-selector": flags.string({
+      exclusive: ["await-state", "await-duration", "await-xpath"],
+      helpValue: "selector",
+      description:
+        "A CSS selector matching an element that must be present before considering the page loaded",
+    }),
+
+    "await-xpath": flags.string({
+      exclusive: ["await-state", "await-duration", "await-selector"],
+      helpValue: "expression",
+      description:
+        "An XPath expression evaluating to an element that must be present before considering the page loaded",
+    }),
+
+    screenshot: flags.string({
+      helpValue: "path",
+      description:
+        "The path to write a screenshot to. If not provided, no screenshot is taken",
+    }),
+
+    "screenshot-type": flags.enum({
+      options: ["png", "jpeg"],
+      default: "png",
+      description: "The file type of the screenshot",
+    }),
+
+    "screenshot-background": flags.boolean({
+      default: false,
+      allowNo: true,
+      description:
+        "Whether or not the screenshot should include a solid, white background",
+    }),
+
+    "screenshot-quality": flags.integer({
+      default: 100,
+      helpValue: "0-100",
+      description:
+        "The quality of the screenshot. Only applies to JPEG screenshots",
+    }),
+  };
+
+  public static args = [
+    {
+      name: "url",
+      required: true,
+      description: "The URL of the page to scrape",
+    },
+  ];
+
+  public async run() {
+    const { args, flags } = this.parse(Scrape);
+
+    const scraper = await Scraper.of();
+
+    let awaiter: Awaiter;
+
+    switch (flags["await-state"]) {
+      case "ready":
+      default:
+        awaiter = Awaiter.ready();
+        break;
+      case "loaded":
+        awaiter = Awaiter.loaded();
+        break;
+      case "idle":
+        awaiter = Awaiter.idle();
+    }
+
+    if (flags["await-duration"] !== undefined) {
+      awaiter = Awaiter.duration(flags["await-duration"]);
+    }
+
+    if (flags["await-selector"] !== undefined) {
+      awaiter = Awaiter.selector(flags["await-selector"]);
+    }
+
+    if (flags["await-xpath"] !== undefined) {
+      awaiter = Awaiter.xpath(flags["await-xpath"]);
+    }
+
+    const orientation =
+      flags.orientation === "portrait"
+        ? Viewport.Orientation.Portrait
+        : Viewport.Orientation.Landscape;
+
+    const device = Device.of(
+      Device.Type.Screen,
+      Viewport.of(flags.width, flags.height, orientation),
+      Display.of(flags.resolution)
+    );
+
+    const credentials =
+      flags.username === undefined || flags.password === undefined
+        ? undefined
+        : Credentials.of(flags.username, flags.password);
+
+    let screenshot: Screenshot | undefined;
+
+    if (flags.screenshot !== undefined) {
+      switch (flags["screenshot-type"]) {
+        case "png":
+          screenshot = Screenshot.of(
+            flags.screenshot,
+            Screenshot.Type.PNG.of(flags["screenshot-background"])
+          );
+          break;
+
+        case "jpeg":
+          screenshot = Screenshot.of(
+            flags.screenshot,
+            Screenshot.Type.JPEG.of(flags["screenshot-quality"])
+          );
+      }
+    }
+
+    const timeout = Timeout.of(flags.timeout);
+
+    const result = await scraper.scrape(
+      new URL(args.url, url.pathToFileURL(process.cwd() + path.sep)),
+      {
+        timeout,
+        awaiter,
+        device,
+        credentials,
+        screenshot,
+      }
+    );
+
+    await scraper.close();
+
+    if (result.isErr()) {
+      this.error(result.getErr(), { exit: 1 });
+    }
+
+    const output = JSON.stringify(result.get()) + "\n";
+
+    if (flags.output === undefined) {
+      process.stdout.write(output);
+    } else {
+      fs.writeFileSync(flags.output, output);
+    }
+  }
+}

--- a/packages/alfa-cli/package.json
+++ b/packages/alfa-cli/package.json
@@ -24,10 +24,7 @@
   ],
   "oclif": {
     "commands": "./bin/alfa/commands",
-    "bin": "alfa",
-    "plugins": [
-      "@oclif/plugin-help"
-    ]
+    "bin": "alfa"
   },
   "dependencies": {
     "@oclif/command": "^1.5.19",
@@ -38,8 +35,10 @@
     "@siteimprove/alfa-json-ld": "^0.0.1",
     "@siteimprove/alfa-rules": "^0.0.1",
     "@siteimprove/alfa-scraper": "^0.0.1",
+    "@siteimprove/alfa-time": "^0.0.1",
     "@siteimprove/alfa-web": "^0.0.1",
-    "enquirer": "^2.3.0"
+    "enquirer": "^2.3.0",
+    "tempy": "^0.5.0"
   },
   "devDependencies": {
     "@siteimprove/alfa-test": "^0.0.1"

--- a/packages/alfa-cli/src/index.ts
+++ b/packages/alfa-cli/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./formatter";
+export * from "./oracle";

--- a/packages/alfa-cli/src/oracle.ts
+++ b/packages/alfa-cli/src/oracle.ts
@@ -1,0 +1,78 @@
+import * as enquirer from "enquirer";
+
+import { Cache } from "@siteimprove/alfa-cache";
+import { Future } from "@siteimprove/alfa-future";
+import { Iterable } from "@siteimprove/alfa-iterable";
+import { Option, None } from "@siteimprove/alfa-option";
+import { Question } from "@siteimprove/alfa-rules";
+import { Page } from "@siteimprove/alfa-web";
+
+import * as act from "@siteimprove/alfa-act";
+import * as xpath from "@siteimprove/alfa-xpath";
+
+export const Oracle = (page: Page): act.Oracle<Question> => {
+  const answers = Cache.empty<unknown, Cache<string, Future<any>>>();
+
+  return (_, question) => {
+    return answers.get(question.subject, Cache.empty).get(question.uri, () => {
+      process.stdout.write(`\n${question.subject}\n\n`);
+
+      if (question.type === "boolean") {
+        return Future.from(
+          enquirer
+            .prompt<{ [key: string]: boolean }>({
+              name: question.uri,
+              type: "toggle",
+              message: question.message,
+            })
+            .then((answer) => Option.of(question.answer(answer[question.uri])))
+            .catch(() => None)
+        );
+      }
+
+      if (question.type === "node") {
+        return Future.from(
+          enquirer
+            .prompt<{ [key: string]: string }>({
+              name: question.uri,
+              type: "input",
+              message: question.message,
+              validate: (expression) => {
+                if (expression === "") {
+                  return true;
+                }
+
+                const nodes = [
+                  ...xpath.evaluate(page.document, expression, {
+                    composed: true,
+                    nested: true,
+                  }),
+                ];
+
+                if (nodes.length === 1) {
+                  return true;
+                }
+
+                return "Invalid XPath expression";
+              },
+            })
+            .then((answer) => {
+              const expression = answer[question.uri];
+
+              const node = Iterable.first(
+                xpath.evaluate(page.document, expression, {
+                  composed: true,
+                  nested: true,
+                })
+              );
+
+              return Option.of(question.answer(node));
+            })
+            .catch(() => None)
+        );
+      }
+
+      return Future.now(None);
+    });
+  };
+};

--- a/packages/alfa-cli/tsconfig.json
+++ b/packages/alfa-cli/tsconfig.json
@@ -7,10 +7,12 @@
   "files": [
     "bin/alfa.ts",
     "bin/alfa/commands/audit.ts",
+    "bin/alfa/commands/scrape.ts",
     "src/formatter.ts",
     "src/formatter/earl.ts",
     "src/formatter/json.ts",
-    "src/index.ts"
+    "src/index.ts",
+    "src/oracle.ts"
   ],
   "references": [
     {
@@ -30,6 +32,9 @@
     },
     {
       "path": "../alfa-test"
+    },
+    {
+      "path": "../alfa-time"
     },
     {
       "path": "../alfa-web"

--- a/packages/alfa-device/src/viewport.ts
+++ b/packages/alfa-device/src/viewport.ts
@@ -45,6 +45,14 @@ export class Viewport implements Serializable {
     return this._orientation;
   }
 
+  public isLandscape(): boolean {
+    return this._orientation === Viewport.Orientation.Landscape;
+  }
+
+  public isPortrait(): boolean {
+    return this._orientation === Viewport.Orientation.Portrait;
+  }
+
   public toJSON(): Viewport.JSON {
     return {
       width: this._width,

--- a/packages/alfa-puppeteer/package.json
+++ b/packages/alfa-puppeteer/package.json
@@ -28,8 +28,8 @@
     "@siteimprove/alfa-option": "^0.0.1",
     "@siteimprove/alfa-predicate": "^0.0.1",
     "@siteimprove/alfa-web": "^0.0.1",
-    "@types/puppeteer": "^1.20.1",
-    "puppeteer": "^1.20.0"
+    "@types/puppeteer": "^2.0.1",
+    "puppeteer": "^2.1.1"
   },
   "devDependencies": {
     "@siteimprove/alfa-test": "^0.0.1"

--- a/packages/alfa-scraper/package.json
+++ b/packages/alfa-scraper/package.json
@@ -24,8 +24,8 @@
     "@siteimprove/alfa-http": "^0.0.1",
     "@siteimprove/alfa-puppeteer": "^0.0.1",
     "@siteimprove/alfa-web": "^0.0.1",
-    "@types/puppeteer": "^1.20.1",
-    "puppeteer": "^1.20.0"
+    "@types/puppeteer": "^2.0.1",
+    "puppeteer": "^2.1.1"
   },
   "devDependencies": {
     "@siteimprove/alfa-test": "^0.0.1"

--- a/packages/alfa-scraper/package.json
+++ b/packages/alfa-scraper/package.json
@@ -21,8 +21,11 @@
     "@siteimprove/alfa-device": "^0.0.1",
     "@siteimprove/alfa-dom": "^0.0.1",
     "@siteimprove/alfa-encoding": "^0.0.1",
+    "@siteimprove/alfa-equatable": "^0.0.1",
     "@siteimprove/alfa-http": "^0.0.1",
+    "@siteimprove/alfa-json": "^0.0.1",
     "@siteimprove/alfa-puppeteer": "^0.0.1",
+    "@siteimprove/alfa-time": "^0.0.1",
     "@siteimprove/alfa-web": "^0.0.1",
     "@types/puppeteer": "^2.0.1",
     "puppeteer": "^2.1.1"

--- a/packages/alfa-scraper/src/awaiter.ts
+++ b/packages/alfa-scraper/src/awaiter.ts
@@ -1,0 +1,98 @@
+import { Result, Ok, Err } from "@siteimprove/alfa-result";
+
+import * as puppeteer from "puppeteer";
+
+export type Awaiter<T = unknown> = (
+  page: puppeteer.Page,
+  timeout: number
+) => Promise<Result<T, string>>;
+
+export namespace Awaiter {
+  export function ready(): Awaiter<puppeteer.Response> {
+    return async (page, timeout) => {
+      try {
+        return Ok.of(
+          await page.waitForNavigation({
+            waitUntil: "domcontentloaded",
+            timeout,
+          })
+        );
+      } catch {
+        return Err.of(
+          `Timeout of exceeded while waiting for the document to be ready`
+        );
+      }
+    };
+  }
+
+  export function loaded(): Awaiter<puppeteer.Response> {
+    return async (page, timeout) => {
+      try {
+        return Ok.of(
+          await page.waitForNavigation({ waitUntil: "load", timeout })
+        );
+      } catch {
+        return Err.of(
+          `Timeout exceeded while waiting for the document to load`
+        );
+      }
+    };
+  }
+
+  export function idle(): Awaiter<puppeteer.Response> {
+    return async (page, timeout) => {
+      try {
+        return Ok.of(
+          await page.waitForNavigation({ waitUntil: "networkidle0", timeout })
+        );
+      } catch {
+        return Err.of(
+          `Timeout exceeded while waiting for the network to be idle`
+        );
+      }
+    };
+  }
+
+  export function duration(
+    duration: number,
+    after: Awaiter<puppeteer.Response> = loaded()
+  ): Awaiter<puppeteer.Response> {
+    return async (page, timeout) => {
+      const result = await after(page, timeout);
+
+      if (result.isOk()) {
+        await page.waitFor(duration);
+      }
+
+      return result;
+    };
+  }
+
+  export function selector(
+    selector: string
+  ): Awaiter<puppeteer.ElementHandle<Element>> {
+    return async (page, timeout) => {
+      try {
+        return Ok.of(await page.waitForSelector(selector, { timeout }));
+      } catch {
+        return Err.of(
+          `Timeout exceeded while waiting for the selector "${selector}"`
+        );
+      }
+    };
+  }
+
+  export function xpath(
+    expression: string
+  ): Awaiter<puppeteer.ElementHandle<Element>> {
+    return async (page, timeout) => {
+      try {
+        return Ok.of(await page.waitForXPath(expression, { timeout }));
+      } catch {
+        return Err.of(
+          `Timeout exceeded while waiting for the expression "${selector}"`
+        );
+      }
+    };
+  }
+}

--- a/packages/alfa-scraper/src/awaiter.ts
+++ b/packages/alfa-scraper/src/awaiter.ts
@@ -19,7 +19,7 @@ export namespace Awaiter {
         );
       } catch {
         return Err.of(
-          `Timeout of exceeded while waiting for the document to be ready`
+          `Timeout exceeded while waiting for the document to be ready`
         );
       }
     };

--- a/packages/alfa-scraper/src/credentials.ts
+++ b/packages/alfa-scraper/src/credentials.ts
@@ -1,0 +1,53 @@
+import { Equatable } from "@siteimprove/alfa-equatable";
+import { Serializable } from "@siteimprove/alfa-json";
+
+import * as json from "@siteimprove/alfa-json";
+
+export class Credentials implements Equatable, Serializable {
+  public static of(username: string, password: string): Credentials {
+    return new Credentials(username, password);
+  }
+
+  private readonly _username: string;
+  private readonly _password: string;
+
+  private constructor(username: string, password: string) {
+    this._username = username;
+    this._password = password;
+  }
+
+  public get username(): string {
+    return this._username;
+  }
+
+  public get password(): string {
+    return this._password;
+  }
+
+  public equals(value: unknown): value is this {
+    return (
+      value instanceof Credentials &&
+      value._username === this._username &&
+      value._password === this._password
+    );
+  }
+
+  public toJSON(): Credentials.JSON {
+    return {
+      username: this._username,
+      password: this._password,
+    };
+  }
+
+  public toString(): string {
+    return `${this._username}:${this._password}`;
+  }
+}
+
+export namespace Credentials {
+  export interface JSON {
+    [key: string]: json.JSON;
+    username: string;
+    password: string;
+  }
+}

--- a/packages/alfa-scraper/src/index.ts
+++ b/packages/alfa-scraper/src/index.ts
@@ -1,1 +1,4 @@
+export * from "./awaiter";
+export * from "./credentials";
 export * from "./scraper";
+export * from "./screenshot";

--- a/packages/alfa-scraper/src/scraper.ts
+++ b/packages/alfa-scraper/src/scraper.ts
@@ -1,11 +1,17 @@
-import { Device, Display, Viewport } from "@siteimprove/alfa-device";
+import { Device } from "@siteimprove/alfa-device";
 import { Document } from "@siteimprove/alfa-dom";
 import { Decoder } from "@siteimprove/alfa-encoding";
 import { Headers, Request, Response } from "@siteimprove/alfa-http";
 import { Puppeteer } from "@siteimprove/alfa-puppeteer";
+import { Result, Ok } from "@siteimprove/alfa-result";
+import { Timeout } from "@siteimprove/alfa-time";
 import { Page } from "@siteimprove/alfa-web";
 
 import * as puppeteer from "puppeteer";
+
+import { Awaiter } from "./awaiter";
+import { Credentials } from "./credentials";
+import { Screenshot } from "./screenshot";
 
 const { entries } = Object;
 
@@ -24,144 +30,149 @@ export class Scraper {
     return new Scraper(await browser);
   }
 
-  private readonly browser: puppeteer.Browser;
+  private readonly _browser: puppeteer.Browser;
 
   private constructor(browser: puppeteer.Browser) {
-    this.browser = browser;
+    this._browser = browser;
   }
 
   public async scrape(
     url: string | URL,
     options: Scraper.scrape.Options = {}
-  ): Promise<Page> {
+  ): Promise<Result<Page, string>> {
     const {
-      wait = Scraper.Wait.Loaded,
-      timeout = 10000,
-      viewport = Viewport.standard(),
-      display = Display.standard(),
+      timeout = Timeout.of(10000),
+      awaiter = Awaiter.ready(),
+      device = Device.standard(),
       credentials = null,
+      screenshot = null,
     } = options;
 
-    const device = Device.of(Device.Type.Screen, viewport, display);
-
-    const page = await this.browser.newPage();
-
-    await page.setViewport({
-      width: viewport.width,
-      height: viewport.width,
-      deviceScaleFactor: display.resolution,
-      isLandscape: viewport.orientation === Viewport.Orientation.Landscape,
-    });
-
-    await page.authenticate(credentials);
-
-    let request: Request | null = null;
-    let response: Response | null | Promise<Response | null> = null;
-
-    // Origin is used to refer to the resource being scraped. While origin is
-    // initially the resource at the URL passed to this method, origin may
-    // change if the resource in question performs certain redirects.
-    let origin = typeof url === "string" ? new URL(url) : url;
-
-    page.on("response", (res) => {
-      if (res.request().resourceType() !== "document") {
-        return;
-      }
-
-      const destination = new URL(res.url());
-
-      if (origin.href === destination.href) {
-        const status = res.status();
-
-        // If the response performs a redirect using 3xx status codes, parse the
-        // location HTTP header and use that as the new origin.
-        if (status >= 300 && status <= 399) {
-          try {
-            origin = new URL(res.headers().location);
-          } catch (err) {}
-        } else {
-          request = parseRequest(res.request());
-
-          // As response handlers are not async, we have to assign the parsed
-          // response as a promise and immediately register an error handler to
-          // avoid an uncaugt exception if parsing the response fails.
-          response = parseResponse(res).catch((err) => null);
-        }
-      }
-    });
-
-    const start = Date.now();
-
+    let page: puppeteer.Page | undefined;
     try {
-      // Attempt navigating to the origin until we either have a parsed request
-      // and response, or the timeout is reached.
+      page = await this._browser.newPage();
+
+      await page.emulateMediaType(
+        device.type === Device.Type.Print ? "print" : "screen"
+      );
+
+      await page.setViewport({
+        width: device.viewport.width,
+        height: device.viewport.width,
+        deviceScaleFactor: device.display.resolution,
+        isLandscape: device.viewport.isLandscape(),
+      });
+
+      await page.authenticate(credentials);
+
+      let request: Request | null = null;
+      let response: Response | null | Promise<Response | null> = null;
+
+      // Origin is used to refer to the resource being scraped. While origin is
+      // initially the resource at the URL passed to this method, origin may
+      // change if the resource in question performs certain redirects.
+      let origin = typeof url === "string" ? new URL(url) : url;
+
+      page.on("response", (res) => {
+        if (res.request().resourceType() !== "document") {
+          return;
+        }
+
+        const destination = new URL(res.url());
+
+        if (origin.href === destination.href) {
+          const status = res.status();
+
+          // If the response performs a redirect using 3xx status codes, parse
+          // the location HTTP header and use that as the new origin.
+          if (status >= 300 && status <= 399) {
+            try {
+              origin = new URL(res.headers().location);
+            } catch {}
+          } else {
+            request = parseRequest(res.request());
+
+            // As response handlers are not async, we have to assign the parsed
+            // response as a promise and immediately register an error handler
+            // to avoid an uncaugt exception if parsing the response fails.
+            response = parseResponse(res).catch((err) => null);
+          }
+        }
+      });
+
+      // Attempt navigating to the origin until we either have a parsed
+      // request and response, or the timeout is reached.
       while (request === null || response === null) {
-        await page.goto(origin.href, {
-          timeout: timeout - (Date.now() - start),
-          waitUntil: wait,
-        });
+        page
+          .goto(origin.href, {
+            timeout: timeout.remaining(),
+            waitUntil: "domcontentloaded",
+          })
+          .catch(() => {});
+
+        const result = await awaiter(page, timeout.remaining());
+
+        if (result.isErr()) {
+          return result;
+        }
 
         // Await parsing of the response, which may fail and result in a null
         // response. If this happens, we retry per the above.
         response = await response;
       }
-    } catch (err) {
-      if (err instanceof Error && err.name === "TimeoutError") {
-        err.message = `Navigation Timeout Exceeded: ${timeout}ms exceeded`;
+
+      let document: Document | null = null;
+
+      // Now that the page has successfully loaded, take a snapshot of the page
+      // unless the page has navigated away from the origin.
+      if (page.url() === origin.href) {
+        try {
+          document = await parseDocument(page);
+        } catch {
+          // Due to a race condition between Puppeteer and Chromium, the page
+          // may be released due to navigation while script evaluation is in
+          // progress. If this happens, we simply ignore it as it's beyond our
+          // control.
+        }
       }
 
-      throw err;
-    }
+      // If requested, take a screenshot of the page as it looks at the time of
+      // snapshot. This can be a useful aid in debugging.
+      if (screenshot !== null) {
+        await takeScreenshot(page, screenshot);
+      }
 
-    let document: Document | null = null;
+      // If the snapshot failed we instead take a snapshot directly of the
+      // response body.
+      if (document === null) {
+        // Navigate to a blank page to ensure that we're not affected by the
+        // race condition between Puppeteer and Chromium.
+        await page.goto("about:blank");
 
-    // Now that the page has successfully loaded, take a snapshot of the page
-    // unless the page has navigated away from the origin.
-    if (page.url() === origin.href) {
-      try {
-        document = await parseDocument(page);
-      } catch (err) {
-        // Due to a race condition between Puppeteer and Chromium, the page may
-        // be released due to navigation while script evaluation is in progress.
-        // If this happens, we simply ignore it as it's beyond our control.
+        document = await parseDocument(page, (response as Response).body);
+      }
+
+      return Ok.of(Page.of(request, response, document, device));
+    } finally {
+      if (page !== undefined) {
+        await page.close();
       }
     }
-
-    // If the snapshot failed we instead take a snapshot directly of the
-    // response body.
-    if (document === null) {
-      // Navigate to a blank page to ensure that we're not affected by the race
-      // condition between Puppeteer and Chromium.
-      await page.goto("about:blank");
-
-      document = await parseDocument(page, (response as Response).body);
-    }
-
-    return Page.of(request, response, document, device);
   }
 
   public async close(): Promise<void> {
-    await this.browser.close();
+    await this._browser.close();
   }
 }
 
 export namespace Scraper {
-  export enum Wait {
-    Ready = "domcontentloaded",
-    Loaded = "load",
-    Idle = "networkidle0",
-  }
-
   export namespace scrape {
     export interface Options {
-      readonly timeout?: number;
-      readonly wait?: Wait;
-      readonly viewport?: Viewport;
-      readonly display?: Display;
-      readonly credentials?: {
-        readonly username: string;
-        readonly password: string;
-      };
+      readonly timeout?: Timeout;
+      readonly awaiter?: Awaiter;
+      readonly device?: Device;
+      readonly credentials?: Credentials;
+      readonly screenshot?: Screenshot;
     }
   }
 }
@@ -193,9 +204,7 @@ async function parseDocument(
         return window.document;
       }
 
-      const parser = new DOMParser();
-
-      return parser.parseFromString(html, "text/html");
+      return new DOMParser().parseFromString(html, "text/html");
     },
     html === null ? null : Decoder.decode(new Uint8Array(html))
   );
@@ -203,4 +212,27 @@ async function parseDocument(
   const { document } = await Puppeteer.asPage(handle);
 
   return document;
+}
+
+async function takeScreenshot(
+  page: puppeteer.Page,
+  screenshot: Screenshot
+): Promise<Buffer> {
+  switch (screenshot.type.type) {
+    case "png":
+      return page.screenshot({
+        path: screenshot.path,
+        type: "png",
+        omitBackground: screenshot.type.background,
+        fullPage: true,
+      });
+
+    case "jpeg":
+      return page.screenshot({
+        path: screenshot.path,
+        type: "jpeg",
+        quality: screenshot.type.quality,
+        fullPage: true,
+      });
+  }
 }

--- a/packages/alfa-scraper/src/scraper.ts
+++ b/packages/alfa-scraper/src/scraper.ts
@@ -223,7 +223,7 @@ async function takeScreenshot(
       return page.screenshot({
         path: screenshot.path,
         type: "png",
-        omitBackground: screenshot.type.background,
+        omitBackground: !screenshot.type.background,
         fullPage: true,
       });
 

--- a/packages/alfa-scraper/src/scraper.ts
+++ b/packages/alfa-scraper/src/scraper.ts
@@ -94,7 +94,7 @@ export class Scraper {
 
             // As response handlers are not async, we have to assign the parsed
             // response as a promise and immediately register an error handler
-            // to avoid an uncaugt exception if parsing the response fails.
+            // to avoid an uncaught exception if parsing the response fails.
             response = parseResponse(res).catch((err) => null);
           }
         }

--- a/packages/alfa-scraper/src/screenshot.ts
+++ b/packages/alfa-scraper/src/screenshot.ts
@@ -1,0 +1,136 @@
+import { Equatable } from "@siteimprove/alfa-equatable";
+import { Serializable } from "@siteimprove/alfa-json";
+
+import * as json from "@siteimprove/alfa-json";
+
+export class Screenshot implements Equatable, Serializable {
+  public static of(
+    path: string,
+    type: Screenshot.Type = Screenshot.Type.PNG.of(true)
+  ): Screenshot {
+    return new Screenshot(path, type);
+  }
+
+  private readonly _path: string;
+  private readonly _type: Screenshot.Type;
+
+  private constructor(path: string, type: Screenshot.Type) {
+    this._path = path;
+    this._type = type;
+  }
+
+  public get path(): string {
+    return this._path;
+  }
+
+  public get type(): Screenshot.Type {
+    return this._type;
+  }
+
+  public equals(value: unknown): value is this {
+    return (
+      value instanceof Screenshot &&
+      value._path === this._path &&
+      value._type.equals(this._type)
+    );
+  }
+
+  public toJSON(): Screenshot.JSON {
+    return {
+      path: this._path,
+      type: this._type.toJSON(),
+    };
+  }
+}
+
+export namespace Screenshot {
+  export interface JSON {
+    [key: string]: json.JSON;
+    path: string;
+    type: Type.JSON;
+  }
+
+  export type Type = Type.PNG | Type.JPEG;
+
+  export namespace Type {
+    export type JSON = PNG.JSON | JPEG.JSON;
+
+    export class PNG implements Equatable, Serializable {
+      public static of(background: boolean): PNG {
+        return new PNG(background);
+      }
+
+      private readonly _background: boolean;
+
+      private constructor(background: boolean) {
+        this._background = background;
+      }
+
+      public get type(): "png" {
+        return "png";
+      }
+
+      public get background(): boolean {
+        return this._background;
+      }
+
+      public equals(value: unknown): value is this {
+        return value instanceof PNG && value._background === this._background;
+      }
+
+      public toJSON(): PNG.JSON {
+        return {
+          type: "png",
+          background: this._background,
+        };
+      }
+    }
+
+    export namespace PNG {
+      export interface JSON {
+        [key: string]: json.JSON;
+        type: "png";
+        background: boolean;
+      }
+    }
+
+    export class JPEG implements Equatable, Serializable {
+      public static of(quality: number): JPEG {
+        return new JPEG(quality);
+      }
+
+      private readonly _quality: number;
+
+      private constructor(quality: number) {
+        this._quality = quality;
+      }
+
+      public get type(): "jpeg" {
+        return "jpeg";
+      }
+
+      public get quality(): number {
+        return this._quality;
+      }
+
+      public equals(value: unknown): value is this {
+        return value instanceof JPEG && value._quality === this._quality;
+      }
+
+      public toJSON(): JPEG.JSON {
+        return {
+          type: "jpeg",
+          quality: this._quality,
+        };
+      }
+    }
+
+    export namespace JPEG {
+      export interface JSON {
+        [key: string]: json.JSON;
+        type: "jpeg";
+        quality: number;
+      }
+    }
+  }
+}

--- a/packages/alfa-scraper/tsconfig.json
+++ b/packages/alfa-scraper/tsconfig.json
@@ -1,7 +1,15 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "../tsconfig.json",
-  "files": ["src/index.ts", "src/scraper.ts"],
+  "files": [
+    "src/awaiter.ts",
+    "src/credentials.ts",
+    "src/index.ts",
+    "src/scraper.ts",
+    "src/screenshot.ts",
+    "../alfa-time/src/time.ts",
+    "../alfa-time/src/timeout.ts"
+  ],
   "references": [
     {
       "path": "../alfa-device"
@@ -13,13 +21,22 @@
       "path": "../alfa-encoding"
     },
     {
+      "path": "../alfa-equatable"
+    },
+    {
       "path": "../alfa-http"
+    },
+    {
+      "path": "../alfa-json"
     },
     {
       "path": "../alfa-puppeteer"
     },
     {
       "path": "../alfa-test"
+    },
+    {
+      "path": "../alfa-time"
     },
     {
       "path": "../alfa-web"

--- a/packages/alfa-scraper/tsconfig.json
+++ b/packages/alfa-scraper/tsconfig.json
@@ -6,9 +6,7 @@
     "src/credentials.ts",
     "src/index.ts",
     "src/scraper.ts",
-    "src/screenshot.ts",
-    "../alfa-time/src/time.ts",
-    "../alfa-time/src/timeout.ts"
+    "src/screenshot.ts"
   ],
   "references": [
     {

--- a/packages/alfa-time/package.json
+++ b/packages/alfa-time/package.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json.schemastore.org/package",
+  "name": "@siteimprove/alfa-time",
+  "homepage": "https://siteimprove.com",
+  "version": "0.0.1",
+  "license": "MIT",
+  "description": "Functionality for working with time",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/siteimprove/alfa.git",
+    "directory": "packages/alfa-time"
+  },
+  "bugs": "https://github.com/siteimprove/alfa/issues",
+  "main": "src/index.js",
+  "types": "src/index.d.ts",
+  "files": [
+    "src/**/*.js",
+    "src/**/*.d.ts"
+  ],
+  "devDependencies": {
+    "@siteimprove/alfa-test": "^0.0.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
+  }
+}

--- a/packages/alfa-time/src/index.ts
+++ b/packages/alfa-time/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./time";
+export * from "./timeout";

--- a/packages/alfa-time/src/time.ts
+++ b/packages/alfa-time/src/time.ts
@@ -1,0 +1,23 @@
+export class Time {
+  public static of(epoch: number): Time {
+    return new Time(epoch);
+  }
+
+  public static now(): Time {
+    return this.of(Date.now());
+  }
+
+  private readonly _epoch: number;
+
+  constructor(epoch: number) {
+    this._epoch = epoch;
+  }
+
+  public get epoch(): number {
+    return this._epoch;
+  }
+
+  public elapsed(now: number = Date.now()): number {
+    return now - this._epoch;
+  }
+}

--- a/packages/alfa-time/src/timeout.ts
+++ b/packages/alfa-time/src/timeout.ts
@@ -1,0 +1,35 @@
+import { Time } from "./time";
+
+export class Timeout {
+  public static of(timeout: number, time: Time = Time.now()): Timeout {
+    return new Timeout(timeout, time);
+  }
+
+  private readonly _timeout: number;
+  private readonly _time: Time;
+
+  private constructor(timeout: number, time: Time) {
+    this._timeout = timeout;
+    this._time = time;
+  }
+
+  public get timeout(): number {
+    return this._timeout;
+  }
+
+  public get time(): Time {
+    return this._time;
+  }
+
+  public reset(time: Time = Time.now()): Timeout {
+    return new Timeout(this._timeout, time);
+  }
+
+  public elapsed(now: number = Date.now()): number {
+    return this._time.elapsed(now);
+  }
+
+  public remaining(now: number = Date.now()): number {
+    return this._timeout - this.elapsed(now);
+  }
+}

--- a/packages/alfa-time/test/time.spec.ts
+++ b/packages/alfa-time/test/time.spec.ts
@@ -1,0 +1,22 @@
+import { test } from "@siteimprove/alfa-test";
+
+import { Time } from "../src/time";
+
+test(".of() contructs a time using the given epoch", (t) => {
+  const time = Time.of(42);
+
+  t.equal(time.epoch, 42);
+});
+
+test(".now() contructs a time using the current epoch", (t) => {
+  const time = Time.now();
+
+  // Accept a divergence of +-1ms from the current now.
+  t(Math.abs(Date.now() - time.epoch) <= 1);
+});
+
+test("#elapsed() returns the time elapsed since epoch", (t) => {
+  const time = Time.of(42);
+
+  t.equal(time.elapsed(74), 32);
+});

--- a/packages/alfa-time/tsconfig.json
+++ b/packages/alfa-time/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "extends": "../tsconfig.json",
+  "files": [
+    "src/index.ts",
+    "src/time.ts",
+    "src/timeout.ts",
+    "test/time.spec.ts"
+  ],
+  "references": [
+    {
+      "path": "../alfa-test"
+    }
+  ]
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -72,6 +72,7 @@
     { "path": "alfa-table" },
     { "path": "alfa-test" },
     { "path": "alfa-thunk" },
+    { "path": "alfa-time" },
     { "path": "alfa-trampoline" },
     { "path": "alfa-trilean" },
     { "path": "alfa-unexpected" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1473,6 +1473,11 @@
   dependencies:
     decimal.js "^10.0.0"
 
+"@types/mime-types@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/mime-types/-/mime-types-2.1.0.tgz#9ca52cda363f699c69466c2a6ccdaad913ea7a73"
+  integrity sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM=
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -1498,10 +1503,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/puppeteer@^1.20.1":
-  version "1.20.4"
-  resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-1.20.4.tgz#30cb0a4ee5394c420119cbdf9f079d6595a07f67"
-  integrity sha512-T/kFgyLnYWk0H94hxI0HbOLnqHvzBRpfS0F0oo9ESGI24oiC2fEjDcMbBjuK3wH7VLsaIsp740vVXVzR1dsMNg==
+"@types/puppeteer@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-2.0.1.tgz#83a1d7f0a1c2e0edbbb488b4d8fb54b14ec9d455"
+  integrity sha512-G8vEyU83Bios+dzs+DZGpAirDmMqRhfFBJCkFrg+A5+6n5EPPHxwBLImJto3qjh0mrBXbLBCyuahhhtTrAfR5g==
   dependencies:
     "@types/node" "*"
 
@@ -1733,6 +1738,11 @@ agent-base@4, agent-base@^4.3.0:
   integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
   dependencies:
     es6-promisify "^5.0.0"
+
+agent-base@5:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
+  integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
 
 agent-base@~4.2.1:
   version "4.2.1"
@@ -3019,6 +3029,11 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+crypto-random-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
+  integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
+
 css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
@@ -3159,10 +3174,17 @@ debug@3.1.0, debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@3.2.6, debug@^3.1.0, debug@^3.2.6:
+debug@3.2.6, debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  dependencies:
+    ms "^2.1.1"
+
+debug@4, debug@^4.1.0, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -3170,13 +3192,6 @@ debug@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
   integrity sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -3219,11 +3234,6 @@ deep-eql@^3.0.1:
   integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
   dependencies:
     type-detect "^4.0.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.3"
@@ -3312,11 +3322,6 @@ detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -4611,13 +4616,21 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-https-proxy-agent@^2.2.1, https-proxy-agent@^2.2.3:
+https-proxy-agent@^2.2.3:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz#4ee7a737abd92678a293d9b34a1af4d0d08c787b"
   integrity sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==
   dependencies:
     agent-base "^4.3.0"
     debug "^3.1.0"
+
+https-proxy-agent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz#702b71fb5520a132a66de1f67541d9e62154d82b"
+  integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
+  dependencies:
+    agent-base "5"
+    debug "4"
 
 human-signals@^1.1.1:
   version "1.1.1"
@@ -4631,7 +4644,7 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -4716,7 +4729,7 @@ inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
+ini@^1.3.2, ini@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -6330,12 +6343,24 @@ mime-db@1.43.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.43.0.tgz#0a12e0502650e473d735535050e7c8f4eb4fae58"
   integrity sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==
 
+mime-db@1.44.0:
+  version "1.44.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
+  integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
+
 mime-types@^2.1.12, mime-types@~2.1.19:
   version "2.1.26"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.26.tgz#9c921fc09b7e149a65dfdc0da4d20997200b0a06"
   integrity sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==
   dependencies:
     mime-db "1.43.0"
+
+mime-types@^2.1.25:
+  version "2.1.27"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
+  integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
+  dependencies:
+    mime-db "1.44.0"
 
 mime@^2.0.3:
   version "2.4.4"
@@ -6629,15 +6654,6 @@ nearley@^2.7.10:
     randexp "0.4.6"
     semver "^5.4.1"
 
-needle@^2.2.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.1.tgz#14af48732463d7475696f937626b1b993247a56a"
-  integrity sha512-x/gi6ijr4B7fwl6WYL9FwlCvRQKGlUNvnceho8wxkwXqN8jvVmmmATTmZPRRG7b/yC1eode26C2HO9jl78Du9g==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 neo-async@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
@@ -6716,22 +6732,6 @@ node-notifier@^5.4.2:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.53:
   version "1.1.53"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.53.tgz#2d821bfa499ed7c5dffc5e2f28c88e78a08ee3f4"
@@ -6808,7 +6808,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.6, npm-packlist@^1.4.4:
+npm-packlist@^1.4.4:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
   integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
@@ -6840,7 +6840,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -7522,15 +7522,17 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@^1.20.0:
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.20.0.tgz#e3d267786f74e1d87cf2d15acc59177f471bbe38"
-  integrity sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==
+puppeteer@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-2.1.1.tgz#ccde47c2a688f131883b50f2d697bd25189da27e"
+  integrity sha512-LWzaDVQkk1EPiuYeTOj+CZRIjda4k2s5w4MK4xoH2+kgWV/SDlkYHmxatDdtYrciHUKSXTsGgPgPP8ILVdBsxg==
   dependencies:
+    "@types/mime-types" "^2.1.0"
     debug "^4.1.0"
     extract-zip "^1.6.6"
-    https-proxy-agent "^2.2.1"
+    https-proxy-agent "^4.0.0"
     mime "^2.0.3"
+    mime-types "^2.1.25"
     progress "^2.0.1"
     proxy-from-env "^1.0.0"
     rimraf "^2.6.1"
@@ -7580,16 +7582,6 @@ randexp@0.4.6:
   dependencies:
     discontinuous-range "1.0.0"
     ret "~0.1.10"
-
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
 
 react-dom@^16.8.6:
   version "16.13.1"
@@ -8088,7 +8080,7 @@ seed-random@^2.2.0:
   resolved "https://registry.yarnpkg.com/seed-random/-/seed-random-2.2.0.tgz#2a9b19e250a817099231a5b99a4daf80b7fbed54"
   integrity sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ=
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -8560,7 +8552,7 @@ strip-indent@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
   integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
-strip-json-comments@2.0.1, strip-json-comments@~2.0.1:
+strip-json-comments@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
@@ -8633,7 +8625,7 @@ tar-stream@^2.1.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^4.4.10, tar@^4.4.12, tar@^4.4.2, tar@^4.4.8:
+tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
@@ -8659,6 +8651,11 @@ temp-dir@^1.0.0:
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
   integrity sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=
 
+temp-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-2.0.0.tgz#bde92b05bdfeb1516e804c9c00ad45177f31321e"
+  integrity sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==
+
 temp-write@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/temp-write/-/temp-write-3.4.0.tgz#8cff630fb7e9da05f047c74ce4ce4d685457d492"
@@ -8670,6 +8667,16 @@ temp-write@^3.4.0:
     pify "^3.0.0"
     temp-dir "^1.0.0"
     uuid "^3.0.1"
+
+tempy@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.5.0.tgz#2785c89df39fcc4d1714fc554813225e1581d70b"
+  integrity sha512-VEY96x7gbIRfsxqsafy2l5yVxxp3PhwAGoWMyC2D2Zt5DmEv+2tGiPOrquNRpf21hhGnKLVEsuqleqiZmKG/qw==
+  dependencies:
+    is-stream "^2.0.0"
+    temp-dir "^2.0.0"
+    type-fest "^0.12.0"
+    unique-string "^2.0.0"
 
 test-exclude@^5.2.3:
   version "5.2.3"
@@ -8884,6 +8891,11 @@ type-fest@^0.11.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
 
+type-fest@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.12.0.tgz#f57a27ab81c68d136a51fd71467eff94157fa1ee"
+  integrity sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==
+
 type-fest@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
@@ -8973,6 +8985,13 @@ unique-slug@^2.0.0:
   integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
   dependencies:
     imurmurhash "^0.1.4"
+
+unique-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-2.0.0.tgz#39c6451f81afb2749de2b233e3f7c5e8843bd89d"
+  integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
+  dependencies:
+    crypto-random-string "^2.0.0"
 
 universal-user-agent@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
This pull request introduces a larger number of changes to the @siteimprove/alfa-scraper and @siteimprove/alfa-cli packages with the aim of better aligning the scraper implementation with the rest of Alfa and making available new features in the CLI for better managing page state. The pull request also introduces a new package, @siteimprove/alfa-time, for working with time and, in particular, timeouts.

## @siteimprove/alfa-scraper

### Awaiters

A key change to the `Scraper` class is the introduction of the new `Awaiter` type, which models functions responsible for awaiting a given condition, such as document state or the presence of an element, signalling that a webpage is done loading:

https://github.com/Siteimprove/alfa/blob/1c3625e3adea6309ef2e0207ad01261b36299097/packages/alfa-scraper/src/awaiter.ts#L5-L8

Previously, the only option in this regard was the `Wait` enum with one of three possible states. Now, all this is modelled using the `Awaiter` type which is a function that given a `Page` object and a timeout will return a promise that resolves to an `Ok<Page>` or an `Err<string>`. The former will be the case when the condition is met within the timeout, and the latter will be the case when the timeout is exceeded before the condition is met.

Awaiters are used similarly to the old `wait` property of the scraper options and the `Wait` enum:

```ts
scraper.scrape("https://example.com", {
  awaiter: Awaiter.ready()
});
```

### Screenshots

One now also has the option of instructing the scraper to take a screenshot of the page as it looks once the `Awaiter` considers it loaded. This is done using the new `Screenshot` class:

```ts
scraper.scrape("https://example.com", {
  screenshot: Screenshot.of("example.png")
});
```

### Timeouts

Timeouts are now modelled using the `Timeout` class of the new @siteimprove/alfa-time package:

```ts
scraper.scrape("https://example.com", {
  timeout: Timeout.of(10000)
});
```

### Credentials

Credentials are now modelled using the `Credentials` class:

```ts
scraper.scrape("https://example.com", {
  credentials: Credentials.of("username", "password")
});
```

### Device parameters

An entire `Device` object must now be passed rather than just a `Viewport` and a `Display` object:

```ts
scraper.scrape("https://example.com", {
  device: Device.standard()
});
```

The scraper now also attempts to emulate the device type, such as `screen` and `print`, when possible.

## @siteimprove/alfa-cli

### `alfa audit`

In response to the changes introduced to the scraper, the `--wait` flag has now been removed from the `audit` command in favour of a set of `--await-[condition]` flags:

- `--await-state=(ready | loaded | idle)`
- `--await-duration=milliseconds`
- `--await-selector=selector`
- `--await-xpath=expression`

The following flags have also been introduced to make the new screenshot functionality of the scraper available:

- `--screenshot=path`
- `--[no-]screenshot-background`
- `--screenshot-quality=0-100`
- `--screenshot-type=(png|jpeg)`

For more details on the available flags, make sure to check out `alfa audit --help`.

### `alfa scrape`

This newly introduced command is used behind the scenes by the `audit` command and is responsible for scraping a webpage to a serialisable format that Alfa can consume. With the introduction of this command, the `audit` command now also has the option of consuming a serialised page from stdin, which can be provided by the `scrape` command:

```console
$ alfa scrape https://example.com | alfa audit
```