### PR TITLE
Add `Document#frame` property to better model embedded documents

### DIFF
--- a/packages/alfa-dom/src/node.ts
+++ b/packages/alfa-dom/src/node.ts
@@ -286,7 +286,10 @@ export namespace Node {
         return Comment.fromComment(node as Comment.JSON, parent);
 
       case "document":
-        return Document.fromDocument(node as Document.JSON);
+        return Document.fromDocument(
+          node as Document.JSON,
+          parent.filter(Element.isElement)
+        );
 
       case "type":
         return Type.fromType(node as Type.JSON, parent);

--- a/packages/alfa-dom/src/node/document.ts
+++ b/packages/alfa-dom/src/node/document.ts
@@ -3,32 +3,43 @@ import { None, Option } from "@siteimprove/alfa-option";
 
 import { Node } from "../node";
 import { Sheet } from "../style/sheet";
+import { Element } from "./element";
 
 export class Document extends Node {
   public static of(
     children: Mapper<Node, Iterable<Node>>,
-    style: Iterable<Sheet> = []
+    style: Iterable<Sheet> = [],
+    frame: Option<Element> = None
   ): Document {
-    return new Document(children, style);
+    return new Document(children, style, frame);
   }
 
-  public static empty(): Document {
-    return new Document(() => [], []);
+  private static _empty: Document = new Document(() => [], [], None);
+
+  public static empty(frame: Option<Element> = None): Document {
+    return frame.isNone() ? this._empty : new Document(() => [], [], frame);
   }
 
   private readonly _style: Array<Sheet>;
+  private readonly _frame: Option<Element>;
 
   private constructor(
     children: Mapper<Node, Iterable<Node>>,
-    style: Iterable<Sheet>
+    style: Iterable<Sheet>,
+    frame: Option<Element>
   ) {
     super(children, None);
 
     this._style = Array.from(style);
+    this._frame = frame;
   }
 
   public get style(): Iterable<Sheet> {
     return this._style;
+  }
+
+  public get frame(): Option<Element> {
+    return this._frame;
   }
 
   public path(): string {
@@ -63,13 +74,17 @@ export namespace Document {
     return value instanceof Document;
   }
 
-  export function fromDocument(document: JSON): Document {
+  export function fromDocument(
+    document: JSON,
+    frame: Option<Element> = None
+  ): Document {
     return Document.of(
       (self) => {
         const parent = Option.of(self);
         return document.children.map((child) => Node.fromNode(child, parent));
       },
-      document.style.map((style) => Sheet.fromSheet(style))
+      document.style.map((style) => Sheet.fromSheet(style)),
+      frame
     );
   }
 }

--- a/packages/alfa-dom/src/node/element.ts
+++ b/packages/alfa-dom/src/node/element.ts
@@ -28,7 +28,7 @@ export class Element extends Node implements Slot, Slotable {
     style: Option<Block> = None,
     parent: Option<Node> = None,
     shadow: Option<Mapper<Element, Shadow>> = None,
-    content: Option<Document> = None
+    content: Option<Mapper<Element, Document>> = None
   ): Element {
     return new Element(
       namespace,
@@ -62,7 +62,7 @@ export class Element extends Node implements Slot, Slotable {
     style: Option<Block>,
     parent: Option<Node>,
     shadow: Option<Mapper<Element, Shadow>>,
-    content: Option<Document>
+    content: Option<Mapper<Element, Document>>
   ) {
     super(children, parent);
 
@@ -74,7 +74,7 @@ export class Element extends Node implements Slot, Slotable {
     this._attributes = Array.from(attributes(this));
     this._style = style;
     this._shadow = self.apply(shadow);
-    this._content = content;
+    this._content = self.apply(content);
 
     this._id = this.attribute("id").map((attr) => attr.value);
 
@@ -344,8 +344,8 @@ export namespace Element {
       Option.from(element.shadow).map((shadow) => (self) =>
         Shadow.fromShadow(shadow, self)
       ),
-      Option.from(element.content).map((content) =>
-        Document.fromDocument(content)
+      Option.from(element.content).map((content) => (self) =>
+        Document.fromDocument(content, Option.of(self))
       )
     );
   }


### PR DESCRIPTION
The `Element#content` property is currently used for modelling elements that allow embedded content, such as `<iframe>` and `<object>` elements. However, we did not have a property for modelling such a relation from the perspective of the embedded content itself, such as a `Document` node inside an `<iframe>` element. This pull request adds the `Document#frame` property for that purpose, modelled after [`Window.frameElement`](https://developer.mozilla.org/en-US/docs/Web/API/Window/frameElement).