### PR TITLE
Allow passing traversal options to `Node#path()`

### DIFF
--- a/packages/alfa-dom/src/node.ts
+++ b/packages/alfa-dom/src/node.ts
@@ -188,12 +188,14 @@ export abstract class Node
    * Get an XPath that uniquely identifies the node across descendants of its
    * root.
    */
-  public path(): string {
-    let path = this._parent.map((parent) => parent.path()).getOr("/");
+  public path(options?: Node.Traversal): string {
+    let path = this.parent(options)
+      .map((parent) => parent.path(options))
+      .getOr("/");
 
     path += path === "/" ? "" : "/";
     path += "node()";
-    path += `[${this.index() + 1}]`;
+    path += `[${this.index(options) + 1}]`;
 
     return path;
   }

--- a/packages/alfa-dom/src/node/attribute.ts
+++ b/packages/alfa-dom/src/node/attribute.ts
@@ -87,8 +87,8 @@ export class Attribute extends Node {
     }
   }
 
-  public path(): string {
-    let path = this.owner.map((owner) => owner.path()).getOr("/");
+  public path(options?: Node.Traversal): string {
+    let path = this.owner.map((owner) => owner.path(options)).getOr("/");
 
     path += path === "/" ? "" : "/";
     path += `@${this._name}`;

--- a/packages/alfa-dom/src/node/comment.ts
+++ b/packages/alfa-dom/src/node/comment.ts
@@ -23,13 +23,15 @@ export class Comment extends Node {
     return this._data;
   }
 
-  public path(): string {
-    let path = this._parent.map((parent) => parent.path()).getOr("/");
+  public path(options?: Node.Traversal): string {
+    let path = this.parent(options)
+      .map((parent) => parent.path(options))
+      .getOr("/");
 
     path += path === "/" ? "" : "/";
     path += "comment()";
 
-    const index = this.preceding().count(Comment.isComment);
+    const index = this.preceding(options).count(Comment.isComment);
 
     path += `[${index + 1}]`;
 

--- a/packages/alfa-dom/src/node/document.ts
+++ b/packages/alfa-dom/src/node/document.ts
@@ -31,7 +31,13 @@ export class Document extends Node {
     return this._style;
   }
 
-  public path(): string {
+  public path(options?: Node.Traversal): string {
+    if (options?.nested) {
+      return this._frame
+        .map((frame) => frame.path(options) + "/document-node()")
+        .getOr("/");
+    }
+
     return "/";
   }
 

--- a/packages/alfa-dom/src/node/element.ts
+++ b/packages/alfa-dom/src/node/element.ts
@@ -249,13 +249,15 @@ export class Element extends Node implements Slot, Slotable {
     return Slot.findSlotables(this);
   }
 
-  public path(): string {
-    let path = this._parent.map((parent) => parent.path()).getOr("/");
+  public path(options?: Node.Traversal): string {
+    let path = this.parent(options)
+      .map((parent) => parent.path(options))
+      .getOr("/");
 
     path += path === "/" ? "" : "/";
     path += this._name;
 
-    const index = this.preceding().count(
+    const index = this.preceding(options).count(
       and(Element.isElement, (element) => element._name === this._name)
     );
 

--- a/packages/alfa-dom/src/node/shadow.ts
+++ b/packages/alfa-dom/src/node/shadow.ts
@@ -58,7 +58,7 @@ export class Shadow extends Node {
 
   public path(options?: Node.Traversal): string {
     if (options?.composed) {
-      return this._host.path(options) + "/shadow()";
+      return this._host.path(options) + "/shadow-root()";
     }
 
     if (options?.flattened) {

--- a/packages/alfa-dom/src/node/shadow.ts
+++ b/packages/alfa-dom/src/node/shadow.ts
@@ -56,7 +56,11 @@ export class Shadow extends Node {
     return None;
   }
 
-  public path(): string {
+  public path(options?: Node.Traversal): string {
+    if (options?.composed || options?.flattened) {
+      return this._host.path(options) + "/shadow()";
+    }
+
     return "/";
   }
 

--- a/packages/alfa-dom/src/node/shadow.ts
+++ b/packages/alfa-dom/src/node/shadow.ts
@@ -57,8 +57,12 @@ export class Shadow extends Node {
   }
 
   public path(options?: Node.Traversal): string {
-    if (options?.composed || options?.flattened) {
+    if (options?.composed) {
       return this._host.path(options) + "/shadow()";
+    }
+
+    if (options?.flattened) {
+      return this._host.path(options);
     }
 
     return "/";

--- a/packages/alfa-dom/src/node/text.ts
+++ b/packages/alfa-dom/src/node/text.ts
@@ -49,13 +49,15 @@ export class Text extends Node implements Slotable {
     return Slotable.findSlot(this);
   }
 
-  public path(): string {
-    let path = this._parent.map((parent) => parent.path()).getOr("/");
+  public path(options?: Node.Traversal): string {
+    let path = this.parent(options)
+      .map((parent) => parent.path(options))
+      .getOr("/");
 
     path += path === "/" ? "" : "/";
     path += "text()";
 
-    const index = this.preceding().count(Text.isText);
+    const index = this.preceding(options).count(Text.isText);
 
     path += `[${index + 1}]`;
 


### PR DESCRIPTION
This pull request makes it possible to pass traversal options to `Node#path()` in order to construct XPath expressions for the various traversal modes that `Node` provides. For example, given a document such as this...

```html
<div>
  #shadow-root
    <span>Hello world!</span>
</div>
```

...the `<span>` element would return the following XPath for `{ composed: true }`:

```
/div[1]/shadow-root()/span[1]
```

...and the following XPath for `{ flattened: true }`:

```
/div[1]/span[1]
```

The `shadow-root()` kind test is a non-standard feature introduced to deal with `Shadow` nodes and has not yet been implemented in `@siteimprove/alfa-xpath`.

For `<iframe>` elements such as this...

```html
<iframe>
  #document
    <html>
      <body>
        <span>Hello world</span>
      </body>
    </html>
```

...the `<span>` element would return the following XPath for `{ nested: true }`:

```
/iframe[1]/document-node()/html[1]/body[1]/span[1]
```

Depends on #244.