### PR TITLE
Use `Awaiter.loaded` as the default in `Scraper#scrape()`

### DIFF
--- a/packages/alfa-scraper/src/scraper.ts
+++ b/packages/alfa-scraper/src/scraper.ts
@@ -48,7 +48,7 @@ export class Scraper {
   ): Promise<Result<Page, string>> {
     const {
       timeout = Timeout.of(10000),
-      awaiter = Awaiter.ready(),
+      awaiter = Awaiter.loaded(),
       device = Device.standard(),
       credentials = null,
       screenshot = null,


### PR DESCRIPTION
Previously, `Awaiter.ready` was used as the default in `Scraper#scrape()` which ran the risk of stylesheets not being available when the page was determined to be done loading. This pull request fixes that by changing the default to `Awaiter.loaded`.