### PR TITLE
Add scripting and user preferences as `Device` parameters

### DIFF
--- a/packages/alfa-cli/bin/alfa/commands/scrape.ts
+++ b/packages/alfa-cli/bin/alfa/commands/scrape.ts
@@ -9,7 +9,7 @@ import { error } from "@oclif/errors";
 
 import * as parser from "@oclif/parser";
 
-import { Device, Display, Viewport } from "@siteimprove/alfa-device";
+import { Device, Display, Scripting, Viewport } from "@siteimprove/alfa-device";
 import { Header, Cookie } from "@siteimprove/alfa-http";
 import {
   Awaiter,
@@ -67,10 +67,10 @@ export default class Scrape extends Command {
       description: "The pixel density of the browser",
     }),
 
-    javascript: flags.boolean({
+    scripting: flags.boolean({
       default: true,
       allowNo: true,
-      description: "Whether or not JavaScript is enabled",
+      description: "Whether or not scripts, such as JavaScript, are evaluated",
     }),
 
     username: flags.string({
@@ -200,7 +200,8 @@ export default class Scrape extends Command {
     const device = Device.of(
       Device.Type.Screen,
       Viewport.of(flags.width, flags.height, orientation),
-      Display.of(flags.resolution)
+      Display.of(flags.resolution),
+      Scripting.of(flags.scripting)
     );
 
     const credentials =
@@ -279,7 +280,6 @@ export default class Scrape extends Command {
         screenshot,
         headers,
         cookies,
-        javascript: flags.javascript,
       }
     );
 

--- a/packages/alfa-device/package.json
+++ b/packages/alfa-device/package.json
@@ -20,7 +20,9 @@
   "dependencies": {
     "@siteimprove/alfa-equatable": "^0.2.0",
     "@siteimprove/alfa-hash": "^0.2.0",
-    "@siteimprove/alfa-json": "^0.2.0"
+    "@siteimprove/alfa-iterable": "^0.2.0",
+    "@siteimprove/alfa-json": "^0.2.0",
+    "@siteimprove/alfa-map": "^0.2.0"
   },
   "devDependencies": {
     "@siteimprove/alfa-test": "^0.2.0"

--- a/packages/alfa-device/src/index.ts
+++ b/packages/alfa-device/src/index.ts
@@ -1,3 +1,5 @@
 export * from "./device";
 export * from "./display";
+export * from "./preference";
+export * from "./scripting";
 export * from "./viewport";

--- a/packages/alfa-device/src/preference.ts
+++ b/packages/alfa-device/src/preference.ts
@@ -1,0 +1,135 @@
+import { Equatable } from "@siteimprove/alfa-equatable";
+import { Hash, Hashable } from "@siteimprove/alfa-hash";
+import { Serializable } from "@siteimprove/alfa-json";
+
+import * as json from "@siteimprove/alfa-json";
+
+/**
+ * @see https://drafts.csswg.org/mediaqueries-5/#mf-user-preferences
+ */
+export class Preference<N extends Preference.Name = Preference.Name>
+  implements Equatable, Hashable, Serializable {
+  public static of<N extends Preference.Name>(
+    name: N,
+    value: Preference.Value<N>
+  ): Preference<N> {
+    return new Preference(name, value);
+  }
+
+  private readonly _name: N;
+  private readonly _value: Preference.Value<N>;
+
+  private constructor(name: N, value: Preference.Value<N>) {
+    this._name = name;
+    this._value = value;
+  }
+
+  public get name(): N {
+    return this._name;
+  }
+
+  public get value(): Preference.Value<N> {
+    return this._value;
+  }
+
+  public equals(value: unknown): value is this {
+    return (
+      value instanceof Preference &&
+      value._name === this._name &&
+      value._value === this._value
+    );
+  }
+
+  public hash(hash: Hash): void {
+    Hash.writeString(hash, this._name);
+    Hash.writeString(hash, this._value);
+  }
+
+  public toJSON(): Preference.JSON {
+    return {
+      name: this._name,
+      value: this._value,
+    };
+  }
+}
+
+export namespace Preference {
+  export interface JSON {
+    [key: string]: json.JSON;
+    name: string;
+    value: string;
+  }
+
+  export function isPreference<N extends Name>(
+    value: unknown,
+    name?: N
+  ): value is Preference<N> {
+    return (
+      value instanceof Preference && (name === undefined || value.name === name)
+    );
+  }
+
+  export function from<N extends Name>(json: JSON): Preference<N> {
+    return Preference.of(json.name as N, json.value as Preference.Value<N>);
+  }
+
+  export type Name = keyof Preferences;
+
+  export type Value<N extends Name = Name> = Preferences[N];
+
+  interface Preferences {
+    /**
+     * @see https://drafts.csswg.org/mediaqueries-5/#forced-colors
+     */
+    "forced-colors": "none" | "active";
+
+    /**
+     * @see https://drafts.csswg.org/mediaqueries-5/#inverted
+     */
+    inverted: "none" | "inverted";
+
+    /**
+     * @see https://drafts.csswg.org/mediaqueries-5/#prefers-color-scheme
+     *
+     * @remarks
+     * For consistency, "no-preference" is also included.
+     */
+    "prefers-color-scheme": "no-preference" | "light" | "dark";
+
+    /**
+     * @see https://drafts.csswg.org/mediaqueries-5/#prefers-contrast
+     *
+     * @remarks
+     * For consistency, "no-preference" is also included.
+     */
+    "prefers-contrast": "no-preference" | "high" | "low";
+
+    /**
+     * @see https://drafts.csswg.org/mediaqueries-5/#prefers-reduced-motion
+     */
+    "prefers-reduced-motion": "no-preference" | "reduce";
+
+    /**
+     * @see https://drafts.csswg.org/mediaqueries-5/#prefers-reduced-transparency
+     */
+    "prefers-reduced-transparency": "no-preference" | "reduce";
+  }
+
+  export function initial<N extends Name>(name: N): Value<N> {
+    function initial(name: Name): Value {
+      switch (name) {
+        case "forced-colors":
+        case "inverted":
+          return "none";
+
+        case "prefers-color-scheme":
+        case "prefers-contrast":
+        case "prefers-reduced-motion":
+        case "prefers-reduced-transparency":
+          return "no-preference";
+      }
+    }
+
+    return initial(name) as Value<N>;
+  }
+}

--- a/packages/alfa-device/src/scripting.ts
+++ b/packages/alfa-device/src/scripting.ts
@@ -1,0 +1,59 @@
+import { Equatable } from "@siteimprove/alfa-equatable";
+import { Hash, Hashable } from "@siteimprove/alfa-hash";
+import { Serializable } from "@siteimprove/alfa-json";
+
+import * as json from "@siteimprove/alfa-json";
+
+/**
+ * @see https://drafts.csswg.org/mediaqueries-5/#mf-scripting
+ *
+ * @remarks
+ * As noted in Media Queries Level 5, a future level of CSS may extend the
+ * scripting feature to allow fine-grained detection of which script is allowed
+ * to run. While the `Scripting` class therefore currently seems very sparse, we
+ * foresee a need to extend it in the future.
+ */
+export class Scripting implements Equatable, Hashable, Serializable {
+  public static of(enabled: boolean): Scripting {
+    return new Scripting(enabled);
+  }
+
+  private readonly _enabled: boolean;
+
+  private constructor(enabled: boolean) {
+    this._enabled = enabled;
+  }
+
+  public get enabled(): boolean {
+    return this._enabled;
+  }
+
+  public equals(value: unknown): value is this {
+    return value instanceof Scripting && value._enabled === this._enabled;
+  }
+
+  public hash(hash: Hash): void {
+    Hash.writeBoolean(hash, this._enabled);
+  }
+
+  public toJSON(): Scripting.JSON {
+    return {
+      enabled: this._enabled,
+    };
+  }
+}
+
+export namespace Scripting {
+  export interface JSON {
+    [key: string]: json.JSON;
+    enabled: boolean;
+  }
+
+  export function isScripting(value: unknown): value is Scripting {
+    return value instanceof Scripting;
+  }
+
+  export function from(json: JSON): Scripting {
+    return Scripting.of(json.enabled);
+  }
+}

--- a/packages/alfa-device/tsconfig.json
+++ b/packages/alfa-device/tsconfig.json
@@ -5,6 +5,8 @@
     "src/device.ts",
     "src/display.ts",
     "src/index.ts",
+    "src/preference.ts",
+    "src/scripting.ts",
     "src/viewport.ts"
   ],
   "references": [
@@ -15,7 +17,13 @@
       "path": "../alfa-hash"
     },
     {
+      "path": "../alfa-iterable"
+    },
+    {
       "path": "../alfa-json"
+    },
+    {
+      "path": "../alfa-map"
     },
     {
       "path": "../alfa-test"

--- a/packages/alfa-hash/src/hash.ts
+++ b/packages/alfa-hash/src/hash.ts
@@ -91,4 +91,8 @@ export namespace Hash {
   export function writeFloat64(hash: Hash, data: number): void {
     writeFloat(hash, data, 64);
   }
+
+  export function writeBoolean(hash: Hash, data: boolean): void {
+    writeUint8(hash, data ? 1 : 0);
+  }
 }


### PR DESCRIPTION
In working on #251, I realised that we're currently lacking scripting as a device parameter. This is needed to correctly handle rendering hints for the `<noscript>` element as they depend on whether scripting is enabled or not. This pull request therefore adds scripting as a device parameter and also adds user preferences as these are something we'll be needing.

The changes introduced are breaking as they add two additional required properties to the `Device.JSON` type. The `javascript` option for the `Scraper#scrape()` method has also been removed as the `Device#scripting` property now fulfils this need, and likewise has the `--[no-]javascript` flag in the CLI been renamed `--[no-]scripting` to align things.