### PR TITLE
Lazy load syntax definitions

### DIFF
--- a/packages/alfa-highlight/package.json
+++ b/packages/alfa-highlight/package.json
@@ -20,7 +20,8 @@
   ],
   "dependencies": {
     "chalk": "^2.4.2",
-    "emphasize": "^2.0.0"
+    "emphasize": "^2.0.0",
+    "highlight.js": "^9.18.1"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/alfa-highlight/src/syntax.ts
+++ b/packages/alfa-highlight/src/syntax.ts
@@ -1,6 +1,6 @@
 /// <reference path="../types/emphasize.d.ts" />
 
-import * as emphasize from "emphasize";
+import * as emphasize from "emphasize/lib/core";
 
 import { mark } from "./marker";
 
@@ -49,6 +49,28 @@ const sheet: emphasize.Sheet = {
   formula: mark.inverse,
 };
 
-export function syntax(language: string, value: string): string {
+export async function syntax(language: string, value: string): Promise<string> {
+  // Register the syntax for the language to highlight. By default, _every_
+  // supported language from highlight.js is loaded, which is fairly expensive.
+  // We therefore only load languages as they're needed.
+  await syntax.register(language);
+
   return mark.reset(emphasize.highlight(language, value, sheet).value);
+}
+
+export namespace syntax {
+  const registered = new Set<string>();
+
+  export async function register(language: string): Promise<void> {
+    if (registered.has(language)) {
+      return;
+    }
+
+    registered.add(language);
+
+    emphasize.registerLanguage(
+      language,
+      await import(`highlight.js/lib/languages/${language}`)
+    );
+  }
 }

--- a/packages/alfa-highlight/types/emphasize.d.ts
+++ b/packages/alfa-highlight/types/emphasize.d.ts
@@ -1,4 +1,10 @@
 declare module "emphasize" {
+  import * as emphasize from "emphasize/lib/core";
+
+  export = emphasize;
+}
+
+declare module "emphasize/lib/core" {
   namespace emphasize {
     interface Sheet {
       readonly [key: string]: (value: string) => string;
@@ -15,6 +21,8 @@ declare module "emphasize" {
       value: string,
       sheet?: Sheet
     ): HighlightResult;
+
+    function registerLanguage(name: string, syntax: unknown): void;
   }
 
   export = emphasize;


### PR DESCRIPTION
During my profiling of initialisation times, I discovered that eagerly loading syntax definitions for the 185-ish languages supported by highlight.js isn't particularly fast as it takes ~100 ms. This pull request fixes that by only loading syntax definitions as they're needed. The changes are breaking as the `syntax()` function now returns a promise.