### PR TITLE
Account for presentational role conflict resolution in ARIA feature mappings

### DIFF
--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -309,7 +309,7 @@ Feature.register(
   Feature.of("img", (element, { allowPresentational }) =>
     Option.of(
       element.attribute("alt").some((alt) => alt.value === "") &&
-        allowPresentational
+        (allowPresentational ?? true)
         ? "presentation"
         : "img"
     )

--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -57,10 +57,10 @@ export class Feature<N extends string = string> {
 }
 
 export namespace Feature {
-  export type Aspect<T, U extends unknown = unknown> = Mapper<
+  export type Aspect<T, A extends Array<unknown> = []> = Mapper<
     Element,
     T,
-    Array<U>
+    A
   >;
 
   export interface Status {

--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -67,7 +67,10 @@ export namespace Feature {
     readonly obsolete: boolean;
   }
 
-  export interface roleOptions {
+  export interface RoleOptions {
+    /**
+     * @internal
+     */
     readonly allowPresentational?: boolean;
   }
 

--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -29,7 +29,7 @@ export class Feature<N extends string = string> {
 
   private constructor(
     name: N,
-    role: Feature.Aspect<Option<string>, Feature.roleOptions>,
+    role: Feature.Aspect<Option<string>, [Feature.RoleOptions]>,
     attributes: Feature.Aspect<Map<string, string>>,
     status: Feature.Status
   ) {

--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -10,12 +10,12 @@ import { Scope, Table } from "@siteimprove/alfa-table";
 import { Role } from "./role";
 
 const { hasName, isElement } = Element;
-const { and, equals, test } = Predicate;
+const { and } = Predicate;
 
 export class Feature<N extends string = string> {
   public static of<N extends string>(
     name: N,
-    role: Feature.Aspect<Option<string>> = () => None,
+    role: Feature.Aspect<Option<string>, Role.feature.Options> = () => None,
     attributes: Feature.Aspect<Map<string, string>> = () => Map.empty(),
     status: Feature.Status = { obsolete: false }
   ): Feature<N> {
@@ -23,13 +23,13 @@ export class Feature<N extends string = string> {
   }
 
   private readonly _name: N;
-  private readonly _role: Feature.Aspect<Option<string>>;
+  private readonly _role: Feature.Aspect<Option<string>, Role.feature.Options>;
   private readonly _attributes: Feature.Aspect<Map<string, string>>;
   private readonly _status: Feature.Status;
 
   private constructor(
     name: N,
-    role: Feature.Aspect<Option<string>>,
+    role: Feature.Aspect<Option<string>, Role.feature.Options>,
     attributes: Feature.Aspect<Map<string, string>>,
     status: Feature.Status
   ) {
@@ -43,7 +43,7 @@ export class Feature<N extends string = string> {
     return this._name;
   }
 
-  public get role(): Feature.Aspect<Option<string>> {
+  public get role(): Feature.Aspect<Option<string>, Role.feature.Options> {
     return this._role;
   }
 
@@ -57,7 +57,11 @@ export class Feature<N extends string = string> {
 }
 
 export namespace Feature {
-  export type Aspect<T> = Mapper<Element, T>;
+  export type Aspect<T, U extends unknown = unknown> = Mapper<
+    Element,
+    T,
+    Array<U>
+  >;
 
   export interface Status {
     readonly obsolete: boolean;
@@ -298,9 +302,9 @@ Feature.register(
 
 Feature.register(
   Namespace.HTML,
-  Feature.of("img", (element) =>
+  Feature.of("img", (element, { allowPresentational}) =>
     Option.of(
-      element.attribute("alt").some((alt) => alt.value === "")
+      element.attribute("alt").some((alt) => alt.value === "") && allowPresentational
         ? "presentation"
         : "img"
     )

--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -309,7 +309,7 @@ Feature.register(
 
 Feature.register(
   Namespace.HTML,
-  Feature.of("img", (element, { allowPresentational }) =>
+  Feature.of("img", (element, { allowPresentational = true }) =>
     Option.of(
       element.attribute("alt").some((alt) => alt.value === "") &&
         (allowPresentational ?? true)

--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -43,7 +43,7 @@ export class Feature<N extends string = string> {
     return this._name;
   }
 
-  public get role(): Feature.Aspect<Option<string>, Feature.roleOptions> {
+  public get role(): Feature.Aspect<Option<string>, [Feature.RoleOptions]> {
     return this._role;
   }
 

--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -23,7 +23,7 @@ export class Feature<N extends string = string> {
   }
 
   private readonly _name: N;
-  private readonly _role: Feature.Aspect<Option<string>, Feature.roleOptions>;
+  private readonly _role: Feature.Aspect<Option<string>, [Feature.RoleOptions]>;
   private readonly _attributes: Feature.Aspect<Map<string, string>>;
   private readonly _status: Feature.Status;
 

--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -15,7 +15,7 @@ const { and } = Predicate;
 export class Feature<N extends string = string> {
   public static of<N extends string>(
     name: N,
-    role: Feature.Aspect<Option<string>, Role.feature.Options> = () => None,
+    role: Feature.Aspect<Option<string>, Feature.roleOptions> = () => None,
     attributes: Feature.Aspect<Map<string, string>> = () => Map.empty(),
     status: Feature.Status = { obsolete: false }
   ): Feature<N> {
@@ -23,13 +23,13 @@ export class Feature<N extends string = string> {
   }
 
   private readonly _name: N;
-  private readonly _role: Feature.Aspect<Option<string>, Role.feature.Options>;
+  private readonly _role: Feature.Aspect<Option<string>, Feature.roleOptions>;
   private readonly _attributes: Feature.Aspect<Map<string, string>>;
   private readonly _status: Feature.Status;
 
   private constructor(
     name: N,
-    role: Feature.Aspect<Option<string>, Role.feature.Options>,
+    role: Feature.Aspect<Option<string>, Feature.roleOptions>,
     attributes: Feature.Aspect<Map<string, string>>,
     status: Feature.Status
   ) {
@@ -43,7 +43,7 @@ export class Feature<N extends string = string> {
     return this._name;
   }
 
-  public get role(): Feature.Aspect<Option<string>, Role.feature.Options> {
+  public get role(): Feature.Aspect<Option<string>, Feature.roleOptions> {
     return this._role;
   }
 
@@ -65,6 +65,10 @@ export namespace Feature {
 
   export interface Status {
     readonly obsolete: boolean;
+  }
+
+  export interface roleOptions {
+    readonly allowPresentational?: boolean;
   }
 
   const features = Cache.empty<Namespace, Cache<string, Feature>>();
@@ -302,9 +306,10 @@ Feature.register(
 
 Feature.register(
   Namespace.HTML,
-  Feature.of("img", (element, { allowPresentational}) =>
+  Feature.of("img", (element, { allowPresentational }) =>
     Option.of(
-      element.attribute("alt").some((alt) => alt.value === "") && allowPresentational
+      element.attribute("alt").some((alt) => alt.value === "") &&
+        allowPresentational
         ? "presentation"
         : "img"
     )

--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -15,7 +15,7 @@ const { and } = Predicate;
 export class Feature<N extends string = string> {
   public static of<N extends string>(
     name: N,
-    role: Feature.Aspect<Option<string>, Feature.roleOptions> = () => None,
+    role: Feature.Aspect<Option<string>, [Feature.RoleOptions]> = () => None,
     attributes: Feature.Aspect<Map<string, string>> = () => Map.empty(),
     status: Feature.Status = { obsolete: false }
   ): Feature<N> {

--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -311,8 +311,7 @@ Feature.register(
   Namespace.HTML,
   Feature.of("img", (element, { allowPresentational = true }) =>
     Option.of(
-      element.attribute("alt").some((alt) => alt.value === "") &&
-        (allowPresentational ?? true)
+      allowPresentational && element.attribute("alt").some((alt) => alt.value === "")
         ? "presentation"
         : "img"
     )

--- a/packages/alfa-aria/src/node.ts
+++ b/packages/alfa-aria/src/node.ts
@@ -240,7 +240,10 @@ export namespace Node {
                 role.some(isPresentational) &&
                 !isAllowedPresentational(node)
               ) {
-                return Role.from(node, { explicit: false });
+                return Role.from(node, {
+                  explicit: false,
+                  allowPresentational: false,
+                });
               }
 
               return Branched.of(role);

--- a/packages/alfa-aria/src/role.ts
+++ b/packages/alfa-aria/src/role.ts
@@ -229,8 +229,7 @@ export namespace Role {
    */
   export function from(
     element: Element,
-    options: from.Options = {},
-    featureOptions: feature.Options = {}
+    options: from.Options = {}
   ): Branched<Option<Role>, Browser> {
     const role = element.attribute("role").map((attr) => attr.value.trim());
 
@@ -269,7 +268,11 @@ export namespace Role {
                   const feature = Feature.lookup(namespace, element.name);
 
                   return feature.flatMap((feature) =>
-                    feature.role(element, featureOptions).flatMap(Role.lookup)
+                    feature
+                      .role(element, {
+                        allowPresentational: options.allowPresentational,
+                      })
+                      .flatMap(Role.lookup)
                   );
                 });
               }
@@ -284,11 +287,6 @@ export namespace Role {
     export interface Options {
       readonly explicit?: boolean;
       readonly implicit?: boolean;
-    }
-  }
-
-  export namespace feature {
-    export interface Options {
       readonly allowPresentational?: boolean;
     }
   }

--- a/packages/alfa-aria/src/role.ts
+++ b/packages/alfa-aria/src/role.ts
@@ -284,10 +284,9 @@ export namespace Role {
   }
 
   export namespace from {
-    export interface Options {
+    export interface Options extends Feature.roleOptions {
       readonly explicit?: boolean;
       readonly implicit?: boolean;
-      readonly allowPresentational?: boolean;
     }
   }
 

--- a/packages/alfa-aria/src/role.ts
+++ b/packages/alfa-aria/src/role.ts
@@ -284,7 +284,7 @@ export namespace Role {
   }
 
   export namespace from {
-    export interface Options extends Feature.roleOptions {
+    export interface Options extends Feature.RoleOptions {
       readonly explicit?: boolean;
       readonly implicit?: boolean;
     }

--- a/packages/alfa-aria/src/role.ts
+++ b/packages/alfa-aria/src/role.ts
@@ -229,7 +229,8 @@ export namespace Role {
    */
   export function from(
     element: Element,
-    options: from.Options = {}
+    options: from.Options = {},
+    featureOptions: feature.Options = {}
   ): Branched<Option<Role>, Browser> {
     const role = element.attribute("role").map((attr) => attr.value.trim());
 
@@ -268,7 +269,7 @@ export namespace Role {
                   const feature = Feature.lookup(namespace, element.name);
 
                   return feature.flatMap((feature) =>
-                    feature.role(element).flatMap(Role.lookup)
+                    feature.role(element, featureOptions).flatMap(Role.lookup)
                   );
                 });
               }
@@ -283,6 +284,12 @@ export namespace Role {
     export interface Options {
       readonly explicit?: boolean;
       readonly implicit?: boolean;
+    }
+  }
+
+  export namespace feature {
+    export interface Options {
+      readonly allowPresentational?: boolean;
     }
   }
 


### PR DESCRIPTION
On an `<img alt="" aria-label="foo" />`, Presentational role conflict resolution triggered but returns `none` again as it is the implicit role with `alt=""`.

This should fix it.
Role aspect can now take optional arguments.