### PR TITLE
Prevent infinite instantiation of `Interview` type

### DIFF
--- a/packages/alfa-act/src/interview.ts
+++ b/packages/alfa-act/src/interview.ts
@@ -5,9 +5,26 @@ import { Oracle } from "./oracle";
 import { Question } from "./question";
 import { Rule } from "./rule";
 
-export type Interview<Q, S, T> =
+/**
+ * As `Interview` is a recursive type that models nested chains of `Question`s,
+ * we need to limit the depth to which this recursion can happen to avoid the
+ * TypeScript compiler going into an infinite type resolution loop. This is done
+ * by maintaining a pointer, `D extends number` that down to -1 at which point
+ * the recursion will stop. Given a pointer `D`, the `Depths` tuple provides
+ * `D - 1 = Depths[D]`.
+ */
+type Depths = [-1, 0, 1, 2];
+
+export type Interview<Q, S, T, D extends number = 3> =
   | T
-  | { [K in keyof Q]: Question<K, Q[K], S, Interview<Q, S, T>> }[keyof Q];
+  | {
+      [K in keyof Q]: Question<
+        K,
+        Q[K],
+        S,
+        D extends -1 ? T : Interview<Q, S, T, Depths[D]>
+      >;
+    }[keyof Q];
 
 export namespace Interview {
   export function conduct<I, T, Q, A>(

--- a/packages/alfa-act/src/rule.ts
+++ b/packages/alfa-act/src/rule.ts
@@ -149,7 +149,7 @@ export namespace Rule {
 
     export interface Evaluate<I, T, Q> {
       (input: Readonly<I>): {
-        applicability(): Iterable<Interview<Q, T, T | Option<T>>>;
+        applicability(): Iterable<Interview<Q, T, Option.Maybe<T>>>;
         expectations(
           target: T
         ): { [key: string]: Interview<Q, T, Option<Result<Diagnostic>>> };

--- a/packages/alfa-rules/src/common/applicability/audio.ts
+++ b/packages/alfa-rules/src/common/applicability/audio.ts
@@ -18,7 +18,7 @@ export function audio(
   document: Document,
   device: Device,
   options: audio.Options = {}
-): Iterable<Interview<Question, Element, Element | Option<Element>>> {
+): Iterable<Interview<Question, Element, Option<Element>>> {
   return map(
     filter(
       document.descendants({ flattened: true, nested: true }),

--- a/packages/alfa-rules/src/common/applicability/video.ts
+++ b/packages/alfa-rules/src/common/applicability/video.ts
@@ -18,7 +18,7 @@ export function video(
   document: Document,
   device: Device,
   options: video.Options = {}
-): Iterable<Interview<Question, Element, Element | Option<Element>>> {
+): Iterable<Interview<Question, Element, Option<Element>>> {
   const { audio, track } = options;
 
   return map(

--- a/packages/alfa-rules/src/sia-r23/rule.ts
+++ b/packages/alfa-rules/src/sia-r23/rule.ts
@@ -1,8 +1,8 @@
-import { Rule, Diagnostic } from "@siteimprove/alfa-act";
+import { Rule, Diagnostic, Interview } from "@siteimprove/alfa-act";
 import { Element } from "@siteimprove/alfa-dom";
-import { Some } from "@siteimprove/alfa-option";
+import { Option } from "@siteimprove/alfa-option";
 import { Predicate } from "@siteimprove/alfa-predicate";
-import { Err, Ok } from "@siteimprove/alfa-result";
+import { Result, Err, Ok } from "@siteimprove/alfa-result";
 import { Page } from "@siteimprove/alfa-web";
 
 import { audio } from "../common/applicability/audio";
@@ -25,53 +25,55 @@ export default Rule.Atomic.of<Page, Element, Question>({
 
       expectations(target) {
         return {
-          1: Question.of(
-            "transcript",
-            "node",
-            target,
-            `Where is the transcript of the \`<audio>\` element?`
-          ).map((transcript) => {
-            if (transcript.isNone()) {
-              return Question.of(
-                "transcript-link",
-                "node",
-                target,
-                `Where is the link pointing to the transcript of the \`<audio>\`
-                element?`
-              ).map((transcriptLink) => {
-                if (transcriptLink.isNone()) {
-                  return Some.of(Outcomes.HasNoTranscript);
-                }
-
-                if (
-                  transcriptLink
-                    .filter(and(Element.isElement, isPerceivable(device)))
-                    .isNone()
-                ) {
-                  return Some.of(Outcomes.HasNonPerceivableTranscriptLink);
-                }
-
+          1: <Interview<Question, Element, Option<Result<Diagnostic>>>>(
+            Question.of(
+              "transcript",
+              "node",
+              target,
+              `Where is the transcript of the \`<audio>\` element?`
+            ).map((transcript) => {
+              if (transcript.isNone()) {
                 return Question.of(
-                  "transcript-perceivable",
-                  "boolean",
+                  "transcript-link",
+                  "node",
                   target,
-                  `Is the transcript of the \`<audio>\` element perceivable?`
-                ).map((isPerceivable) =>
-                  expectation(
-                    isPerceivable,
-                    () => Outcomes.HasPerceivableTranscript,
-                    () => Outcomes.HasNonPerceivableTranscript
-                  )
-                );
-              });
-            }
+                  `Where is the link pointing to the transcript of the \`<audio>\`
+                element?`
+                ).map((transcriptLink) => {
+                  if (transcriptLink.isNone()) {
+                    return Option.of(Outcomes.HasNoTranscript);
+                  }
 
-            return expectation(
-              transcript.some(and(Element.isElement, isPerceivable(device))),
-              () => Outcomes.HasPerceivableTranscript,
-              () => Outcomes.HasNonPerceivableTranscript
-            );
-          }),
+                  if (
+                    transcriptLink
+                      .filter(and(Element.isElement, isPerceivable(device)))
+                      .isNone()
+                  ) {
+                    return Option.of(Outcomes.HasNonPerceivableTranscriptLink);
+                  }
+
+                  return Question.of(
+                    "transcript-perceivable",
+                    "boolean",
+                    target,
+                    `Is the transcript of the \`<audio>\` element perceivable?`
+                  ).map((isPerceivable) =>
+                    expectation(
+                      isPerceivable,
+                      () => Outcomes.HasPerceivableTranscript,
+                      () => Outcomes.HasNonPerceivableTranscript
+                    )
+                  );
+                });
+              }
+
+              return expectation(
+                transcript.some(and(Element.isElement, isPerceivable(device))),
+                () => Outcomes.HasPerceivableTranscript,
+                () => Outcomes.HasNonPerceivableTranscript
+              );
+            })
+          ),
         };
       },
     };

--- a/packages/alfa-rules/src/sia-r39/rule.ts
+++ b/packages/alfa-rules/src/sia-r39/rule.ts
@@ -5,6 +5,8 @@ import { Predicate } from "@siteimprove/alfa-predicate";
 import { Err, Ok, Result } from "@siteimprove/alfa-result";
 import { Page } from "@siteimprove/alfa-web";
 
+import { expectation } from "../common/expectation";
+
 import { hasAccessibleName } from "../common/predicate/has-accessible-name";
 import { hasInputType } from "../common/predicate/has-input-type";
 import { isIgnored } from "../common/predicate/is-ignored";
@@ -56,9 +58,11 @@ export default Rule.Atomic.of<Page, Element, Question>({
             `Does the accessible name of the \`<${target.name}>\` element
             describe its purpose?`
           ).map((nameDescribesPurpose) =>
-            nameDescribesPurpose
-              ? Some.of(Outcomes.NameIsDescriptive(target.name))
-              : Some.of(Outcomes.NameIsNotDescriptive(target.name))
+            expectation(
+              nameDescribesPurpose,
+              () => Outcomes.NameIsDescriptive(target.name),
+              () => Outcomes.NameIsNotDescriptive(target.name)
+            )
           ),
         };
       },

--- a/packages/alfa-rules/src/sia-r82/rule.ts
+++ b/packages/alfa-rules/src/sia-r82/rule.ts
@@ -55,29 +55,33 @@ export default Rule.Atomic.of<Page, Element, Question>({
         ).map((indicators) => [...indicators]);
 
         return {
-          1: indicators.map((indicators) =>
-            expectation(
-              indicators.length === 0,
-              () => Outcomes.HasNoErrorIndicator,
-              () =>
-                identifiesTarget(
-                  indicators,
-                  Outcomes.NoErrorIndicatorIdentifiesTarget,
-                  device
-                )
+          1: <Interview<Question, Element, Option<Result<Diagnostic>>>>(
+            indicators.map((indicators) =>
+              expectation(
+                indicators.length === 0,
+                () => Outcomes.HasNoErrorIndicator,
+                () =>
+                  identifiesTarget(
+                    indicators,
+                    Outcomes.NoErrorIndicatorIdentifiesTarget,
+                    device
+                  )
+              )
             )
           ),
 
-          2: indicators.map((indicators) =>
-            expectation(
-              indicators.length === 0,
-              () => Outcomes.HasNoErrorIndicator,
-              () =>
-                describesResolution(
-                  indicators,
-                  Outcomes.NoErrorIndicatorDescribesResolution,
-                  device
-                )
+          2: <Interview<Question, Element, Option<Result<Diagnostic>>>>(
+            indicators.map((indicators) =>
+              expectation(
+                indicators.length === 0,
+                () => Outcomes.HasNoErrorIndicator,
+                () =>
+                  describesResolution(
+                    indicators,
+                    Outcomes.NoErrorIndicatorDescribesResolution,
+                    device
+                  )
+              )
             )
           ),
         };
@@ -134,7 +138,7 @@ function identifiesTarget(
   indicators: Array<Node>,
   error: Err<Diagnostic>,
   device: Device
-): Interview<Question, Node, Option.Maybe<Result<Diagnostic>>> {
+): Interview<Question, Node, Result<Diagnostic>> {
   const indicator = indicators[0];
 
   if (indicator === undefined) {
@@ -163,7 +167,7 @@ function describesResolution(
   indicators: Array<Node>,
   error: Err<Diagnostic>,
   device: Device
-): Interview<Question, Node, Option.Maybe<Result<Diagnostic>>> {
+): Interview<Question, Node, Result<Diagnostic>> {
   const indicator = indicators[0];
 
   if (indicator === undefined) {


### PR DESCRIPTION
This pull request fixes a compiler crash in TypeScript 3.9 due to the recursive construction of the `Interview` type. This is fixed by limiting the depth of the recursion.

See https://github.com/microsoft/TypeScript/issues/38825.

Before:

https://github.com/Siteimprove/alfa/blob/f77af337f1ea1bc0ef5d100fbd2a06d34d2f32ef/packages/alfa-act/src/interview.ts#L8-L10

After:

https://github.com/Siteimprove/alfa/blob/907a9be4fb50c95307e1352a15fa9c22bfef8d79/packages/alfa-act/src/interview.ts#L16-L27