### PR TITLE
Treat kind attribute as enumerated

### DIFF
--- a/packages/alfa-rules/src/common/applicability/video.ts
+++ b/packages/alfa-rules/src/common/applicability/video.ts
@@ -8,11 +8,10 @@ import { Predicate } from "@siteimprove/alfa-predicate";
 import { isVisible } from "../predicate/is-visible";
 
 import { Question } from "../question";
-import { hasAttribute } from "../predicate/has-attribute";
 
 const { isElement, hasName, hasNamespace } = Element;
 const { filter, map, some } = Iterable;
-const { and, equals } = Predicate;
+const { and } = Predicate;
 
 export function video(
   document: Document,

--- a/packages/alfa-rules/src/common/applicability/video.ts
+++ b/packages/alfa-rules/src/common/applicability/video.ts
@@ -42,6 +42,7 @@ export function video(
                     (trackElement) =>
                       trackElement
                         .attribute("kind")
+                        // @see https://html.spec.whatwg.org/multipage/media.html#attr-track-kind
                         .map(
                           (kind) =>
                             kind

--- a/packages/alfa-rules/src/common/applicability/video.ts
+++ b/packages/alfa-rules/src/common/applicability/video.ts
@@ -39,7 +39,22 @@ export function video(
                   Element.isElement,
                   and(
                     hasName("track"),
-                    hasAttribute("kind", equals(track.kind))
+                    (trackElement) =>
+                      trackElement
+                        .attribute("kind")
+                        .map(
+                          (kind) =>
+                            kind
+                              .enumerate(
+                                "subtitles",
+                                "captions",
+                                "descriptions",
+                                "chapters",
+                                "metadata"
+                              )
+                              .getOr("metadata") // invalid value default
+                        )
+                        .getOr("subtitles") === track.kind // missing value default
                   )
                 )
               )


### PR DESCRIPTION
The `kind` attribute is actually enumerated 🤷 
https://html.spec.whatwg.org/multipage/media.html#attr-track-kind