### PR TITLE
Move presentational role conflict resolution down to Role.from

### DIFF
--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -57,11 +57,7 @@ export class Feature<N extends string = string> {
 }
 
 export namespace Feature {
-  export type Aspect<T, A extends Array<unknown> = []> = Mapper<
-    Element,
-    T,
-    A
-  >;
+  export type Aspect<T, A extends Array<unknown> = []> = Mapper<Element, T, A>;
 
   export interface Status {
     readonly obsolete: boolean;
@@ -71,7 +67,7 @@ export namespace Feature {
     /**
      * @internal
      */
-    readonly allowPresentational?: boolean;
+    readonly allowPresentational: boolean;
   }
 
   const features = Cache.empty<Namespace, Cache<string, Feature>>();
@@ -309,9 +305,10 @@ Feature.register(
 
 Feature.register(
   Namespace.HTML,
-  Feature.of("img", (element, { allowPresentational = true }) =>
+  Feature.of("img", (element, { allowPresentational }) =>
     Option.of(
-      allowPresentational && element.attribute("alt").some((alt) => alt.value === "")
+      allowPresentational &&
+        element.attribute("alt").some((alt) => alt.value === "")
         ? "presentation"
         : "img"
     )

--- a/packages/alfa-aria/src/node.ts
+++ b/packages/alfa-aria/src/node.ts
@@ -232,9 +232,6 @@ export namespace Node {
           accessibleNode = Branched.of(Container.of(node));
         } else {
           accessibleNode = Role.from(node)
-            .flatMap((role) => {
-              return Branched.of(role);
-            })
             .flatMap<Node>((role) => {
               if (role.some(Role.isPresentational)) {
                 return Branched.of(Container.of(node));

--- a/packages/alfa-aria/src/node.ts
+++ b/packages/alfa-aria/src/node.ts
@@ -233,23 +233,10 @@ export namespace Node {
         } else {
           accessibleNode = Role.from(node)
             .flatMap((role) => {
-              // If the element has a presentational role, but is not allowed to
-              // be presentational, we fall back to its implicit role by not
-              // considering its explicit role.
-              if (
-                role.some(isPresentational) &&
-                !isAllowedPresentational(node)
-              ) {
-                return Role.from(node, {
-                  explicit: false,
-                  allowPresentational: false,
-                });
-              }
-
               return Branched.of(role);
             })
             .flatMap<Node>((role) => {
-              if (role.some(isPresentational)) {
+              if (role.some(Role.isPresentational)) {
                 return Branched.of(Container.of(node));
               }
 
@@ -323,29 +310,3 @@ export namespace Node {
     });
   }
 }
-
-const isPresentational: Predicate<Role> = property(
-  "name",
-  equals("presentation", "none")
-);
-
-/**
- * Determine if an element is allowed to be presentational.
- *
- * @see https://w3c.github.io/aria/#conflict_resolution_presentation_none
- */
-const isAllowedPresentational: Predicate<dom.Element> = (element) => {
-  if (element.tabIndex().isSome()) {
-    return false;
-  }
-
-  return Role.lookup("roletype").some((role) => {
-    for (const attribute of role.characteristics.supports) {
-      if (element.attribute(attribute).isSome()) {
-        return false;
-      }
-    }
-
-    return true;
-  });
-};

--- a/packages/alfa-aria/src/role.ts
+++ b/packages/alfa-aria/src/role.ts
@@ -129,7 +129,6 @@ export namespace Role {
   /**
    * @see https://www.w3.org/TR/wai-aria/#roles_categorization
    */
-
   export enum Category {
     /**
      * @see https://www.w3.org/TR/wai-aria/#abstract_roles

--- a/packages/alfa-aria/src/role.ts
+++ b/packages/alfa-aria/src/role.ts
@@ -254,22 +254,22 @@ export namespace Role {
                   const role = Role.lookup(name);
 
                   if (
-                    // If the role is not abstract…
+                    // If the role is not abstract...
                     role.some(
                       (role) => role.category !== Role.Category.Abstract
                     ) &&
-                    // …and it's not a presentational role in a forbidden context…
+                    // ...and it's not a presentational role in a forbidden context...
                     !(
                       role.some(Role.isPresentational) &&
                       !isAllowedPresentational
                     )
                   ) {
-                    // …then we got ourselves a valid explicit role…
+                    // ...then we got ourselves a valid explicit role...
                     return role;
                   }
                 }
               }
-              // …otherwise, default to implicit role computation.
+              // ...otherwise, default to implicit role computation.
               return None;
             })
             .orElse(() => {

--- a/packages/alfa-aria/src/role.ts
+++ b/packages/alfa-aria/src/role.ts
@@ -233,7 +233,8 @@ export namespace Role {
   ): Branched<Option<Role>, Browser> {
     const role = element.attribute("role").map((attr) => attr.value.trim());
 
-    const allowedPresentational = options.allowPresentational ?? isAllowedPresentational(element);
+    const allowedPresentational =
+      options.allowPresentational ?? isAllowedPresentational(element);
 
     return (
       Branched.of<Option<string>, Browser>(
@@ -279,8 +280,7 @@ export namespace Role {
                   return feature.flatMap((feature) =>
                     feature
                       .role(element, {
-                        allowPresentational:
-                          allowedPresentational,
+                        allowPresentational: allowedPresentational,
                       })
                       .flatMap(Role.lookup)
                   );

--- a/packages/alfa-aria/src/role.ts
+++ b/packages/alfa-aria/src/role.ts
@@ -12,7 +12,7 @@ import { Feature } from "./feature";
 import { Attribute } from "./attribute";
 
 const { some } = Iterable;
-const { equals, or, not, property, test } = Predicate;
+const { equals, or } = Predicate;
 
 export class Role<N extends string = string> implements Equatable {
   public static of<N extends string>(


### PR DESCRIPTION
We've built ourselves a nice footgun by putting the conflict resolution in `Node.build` which is bypassed by many functions such as `hasRole` calling `Role.from` directly…

Moving the resolution deeper to where role computation actually happens clean that up. And also avoids `Node.build` doing a double roundtrip to `Role.from`.

Also removing the default value of `isAllowedPresentational` from the individual features to eliminate the risk of them disagreeing on that…