### PR TITLE
Avoid discarding rules when adding to `RuleTree`

### DIFF
--- a/packages/alfa-cascade/src/rule-tree.ts
+++ b/packages/alfa-cascade/src/rule-tree.ts
@@ -138,10 +138,6 @@ export namespace RuleTree {
       children: Array<RuleTree.Node>,
       parent: Option<Node>
     ): RuleTree.Node {
-      if (parent.some((parent) => parent._selector.equals(selector))) {
-        return parent.get();
-      }
-
       for (const child of children) {
         if (child._selector.equals(selector)) {
           return this.add(

--- a/packages/alfa-cascade/src/selector-map.ts
+++ b/packages/alfa-cascade/src/selector-map.ts
@@ -110,7 +110,7 @@ export class SelectorMap {
         order++;
 
         for (const part of selector.get()) {
-          this.add(rule, part, rule.style, origin, order);
+          this._add(rule, part, rule.style, origin, order);
         }
       }
 
@@ -179,7 +179,7 @@ export class SelectorMap {
     return nodes;
   }
 
-  private add(
+  private _add(
     rule: Rule,
     selector: Selector,
     declarations: Iterable<Declaration>,


### PR DESCRIPTION
The rule tree would inadvertently discard rules if their selector matched one already in the tree. I'm fearing this _might_ be a case of me running into a [Chesterton's fence](https://en.wikipedia.org/wiki/Wikipedia:Chesterton%27s_fence) that I put up myself so a little more digging may be a good idea 🙈 