### PR TITLE
Use dynamic import rather than `require()` for loading formatters

### DIFF
--- a/packages/alfa-cli/bin/alfa/command/audit/run.ts
+++ b/packages/alfa-cli/bin/alfa/command/audit/run.ts
@@ -26,7 +26,7 @@ export const run: Command.Runner<typeof Flags, typeof Arguments> = async ({
   flags,
   args: { url: target },
 }) => {
-  const formatter = Formatter.load<Input, Target, Question>(flags.format);
+  const formatter = await Formatter.load<Input, Target, Question>(flags.format);
 
   if (formatter.isErr()) {
     return formatter;

--- a/packages/alfa-formatter/package.json
+++ b/packages/alfa-formatter/package.json
@@ -19,8 +19,7 @@
   ],
   "dependencies": {
     "@siteimprove/alfa-act": "^0.2.0",
-    "@siteimprove/alfa-result": "^0.2.0",
-    "@types/node": "^14.0.11"
+    "@siteimprove/alfa-result": "^0.2.0"
   },
   "devDependencies": {
     "@siteimprove/alfa-test": "^0.2.0"

--- a/packages/alfa-formatter/src/formatter.ts
+++ b/packages/alfa-formatter/src/formatter.ts
@@ -1,18 +1,16 @@
-/// <reference types="node" />
-
 import { Outcome } from "@siteimprove/alfa-act";
-import { Result, Ok, Err } from "@siteimprove/alfa-result";
+import { Result, Err } from "@siteimprove/alfa-result";
 
-export type Formatter<I, T, Q> = (
+export type Formatter<I, T = unknown, Q = never> = (
   input: I,
   outcomes: Iterable<Outcome<I, T, Q>>
 ) => string;
 
 export namespace Formatter {
-  export function load<I, T, Q>(
+  export async function load<I, T = unknown, Q = never>(
     name: string,
     defaultScope: string = "@siteimprove"
-  ): Result<Formatter<I, T, Q>, string> {
+  ): Promise<Result<Formatter<I, T, Q>, string>> {
     let scope: string | undefined;
 
     if (name.startsWith("@")) {
@@ -32,7 +30,9 @@ export namespace Formatter {
 
     for (const pattern of patterns) {
       try {
-        return Ok.of(require(pattern).default());
+        const module = await import(pattern);
+
+        return Result.of(module.default());
       } catch {
         continue;
       }


### PR DESCRIPTION
These will still compile to CJS per our TypeScript configuration but will remove the dependency on Node.js and allow us to compile to native modules in the future. This change is breaking as it turns loading of formatters into an async operation.