### PR TITLE
Add `Future#get()` and accept thunked promises in `Future.from()`

### DIFF
--- a/packages/alfa-future/src/future.ts
+++ b/packages/alfa-future/src/future.ts
@@ -27,6 +27,20 @@ export abstract class Future<T> implements Monad<T>, Functor<T> {
     }
   }
 
+  public get(): T {
+    let step: Future<T> = this;
+
+    while (true) {
+      const next = step.step();
+
+      if (step !== next) {
+        step = next;
+      } else {
+        return next.get();
+      }
+    }
+  }
+
   public isNow(): boolean {
     return this instanceof Now;
   }
@@ -51,6 +65,8 @@ export abstract class Future<T> implements Monad<T>, Functor<T> {
 }
 
 export namespace Future {
+  export type Maybe<T> = T | Future<T>;
+
   export function isFuture<T>(value: unknown): value is Future<T> {
     return value instanceof Future;
   }
@@ -71,8 +87,10 @@ export namespace Future {
     return suspend(() => now(thunk()));
   }
 
-  export function from<T>(promise: Promise<T>): Future<T> {
-    return Future.defer((callback) => promise.then(callback));
+  export function from<T>(promise: Promise<T> | Thunk<Promise<T>>): Future<T> {
+    return Future.defer((callback) =>
+      (typeof promise === "function" ? promise() : promise).then(callback)
+    );
   }
 
   export function traverse<T, U>(
@@ -116,6 +134,10 @@ class Now<T> extends Future<T> {
     callback(this._value);
   }
 
+  public get(): T {
+    return this._value;
+  }
+
   public map<U>(mapper: Mapper<T, U>): Future<U> {
     return new Now(mapper(this._value));
   }
@@ -143,6 +165,10 @@ class Defer<T> extends Future<T> {
 
   public then(callback: Callback<T>): void {
     this._continuation((value) => defer(() => callback(value)));
+  }
+
+  public get(): never {
+    throw new Error("Attempted to .get() from deferred future");
   }
 
   public flatMap<U>(mapper: Mapper<T, Future<U>>): Future<U> {
@@ -179,6 +205,10 @@ namespace Defer {
       this._continuation((value) =>
         defer(() => this._mapper(value).then(callback))
       );
+    }
+
+    public get(): never {
+      throw new Error("Attempted to .get() from deferred future");
     }
 
     public flatMap<U>(mapper: Mapper<T, Future<U>>): Future<U> {

--- a/packages/alfa-future/test/future.spec.ts
+++ b/packages/alfa-future/test/future.spec.ts
@@ -119,6 +119,16 @@ test("#flatMap() does not overflow for long nested defer() chains", async (t) =>
   t.equal(await n, 100000);
 });
 
+test("#get() returns the value of a non-deferred future", (t) => {
+  let n = Future.now(0);
+
+  for (let i = 0; i < 10; i++) {
+    n = n.flatMap((i) => Future.now(i + 1));
+  }
+
+  t.equal(n.get(), 10);
+});
+
 test(".traverse() traverses a list of values and lifts them to a future of lists", async (t) => {
   t.deepEqual(
     await Future.traverse([1, 2, 3, 4], (n) =>
@@ -151,6 +161,12 @@ test(".from() converts a promise to a future", async (t) => {
   const future = Future.from(
     new Promise<number>((resolve) => resolve(2))
   );
+
+  t.equal(await future, 2);
+});
+
+test(".from() converts a thunked promise to a future", async (t) => {
+  const future = Future.from(async () => 2);
 
   t.equal(await future, 2);
 });


### PR DESCRIPTION
This pull requests implements the functionality that originally sparked the implementation of the current `Future<T>` type: The ability to synchronously resolve non-deferred futures. This is needed for the upcoming redesign of the `@siteimprove/alfa-assert` package tracked by #270.