### PR TITLE
Introduce HyperScript-like DSL for constructing DOM

### DIFF
--- a/packages/alfa-aria/test/get-name.spec.tsx
+++ b/packages/alfa-aria/test/get-name.spec.tsx
@@ -35,7 +35,7 @@ test("getName() computes the text alternative of a button with text within a spa
 test("getName() ignores non-visible nodes", (t) => {
   const button = Element.fromElement(
     <button>
-      Button <span style="display: none">Hidden</span>
+      Button <span style={{ display: "none" }}>Hidden</span>
     </button>
   );
 

--- a/packages/alfa-dom/h.ts
+++ b/packages/alfa-dom/h.ts
@@ -1,0 +1,1 @@
+export * from "./src/h";

--- a/packages/alfa-dom/package.json
+++ b/packages/alfa-dom/package.json
@@ -20,7 +20,6 @@
     "src/**/*.d.ts"
   ],
   "dependencies": {
-    "@siteimprove/alfa-css": "^0.2.0",
     "@siteimprove/alfa-earl": "^0.2.0",
     "@siteimprove/alfa-equatable": "^0.2.0",
     "@siteimprove/alfa-iterable": "^0.2.0",
@@ -29,8 +28,7 @@
     "@siteimprove/alfa-mapper": "^0.2.0",
     "@siteimprove/alfa-option": "^0.2.0",
     "@siteimprove/alfa-predicate": "^0.2.0",
-    "@siteimprove/alfa-sequence": "^0.2.0",
-    "@siteimprove/alfa-slice": "^0.2.0"
+    "@siteimprove/alfa-sequence": "^0.2.0"
   },
   "devDependencies": {
     "@siteimprove/alfa-test": "^0.2.0"

--- a/packages/alfa-dom/src/h.ts
+++ b/packages/alfa-dom/src/h.ts
@@ -31,58 +31,68 @@ export function h(
   children: Array<Node.JSON | string> = [],
   style: Array<Declaration.JSON> | Record<string, string> = []
 ): Element.JSON {
-  attributes = Array.isArray(attributes)
-    ? attributes
-    : entries(attributes).reduce<Array<Attribute.JSON>>(
-        (attributes, [name, value]) => {
-          if (value === false) {
-            return attributes;
-          }
-
-          return [
-            ...attributes,
-            h.attribute(hyphenate(name), value === true ? "" : value),
-          ];
-        },
-        []
-      );
-
-  style = h.block(style);
-
-  if (style.length > 0) {
-    attributes = [
-      ...attributes,
-      h.attribute("style", Block.fromBlock(style).toString()),
-    ];
-  }
-
-  const json: Element.JSON = {
-    type: "element",
-    namespace: Namespace.HTML,
-    prefix: null,
-    name,
-    attributes,
-    children: children.map((child) =>
-      typeof child === "string" ? h.text(child) : child
-    ),
-    style,
-    shadow: null,
-    content: null,
-  };
-
-  switch (name) {
-    case "svg":
-      rename(json, Namespace.SVG);
-      break;
-
-    case "math":
-      rename(json, Namespace.MathML);
-  }
-
-  return json;
+  return h.element(Namespace.HTML, null, name, attributes, children, style);
 }
 
 export namespace h {
+  export function element(
+    namespace: string | null,
+    prefix: string | null,
+    name: string,
+    attributes: Array<Attribute.JSON> | Record<string, string | boolean> = [],
+    children: Array<Node.JSON | string> = [],
+    style: Array<Declaration.JSON> | Record<string, string> = []
+  ): Element.JSON {
+    attributes = Array.isArray(attributes)
+      ? attributes
+      : entries(attributes).reduce<Array<Attribute.JSON>>(
+          (attributes, [name, value]) => {
+            if (value === false) {
+              return attributes;
+            }
+
+            return [
+              ...attributes,
+              h.attribute(hyphenate(name), value === true ? "" : value),
+            ];
+          },
+          []
+        );
+
+    style = h.block(style);
+
+    if (style.length > 0) {
+      attributes = [
+        ...attributes,
+        h.attribute("style", Block.fromBlock(style).toString()),
+      ];
+    }
+
+    const json: Element.JSON = {
+      type: "element",
+      namespace,
+      prefix,
+      name,
+      attributes,
+      children: children.map((child) =>
+        typeof child === "string" ? h.text(child) : child
+      ),
+      style,
+      shadow: null,
+      content: null,
+    };
+
+    switch (name) {
+      case "svg":
+        rename(json, Namespace.SVG);
+        break;
+
+      case "math":
+        rename(json, Namespace.MathML);
+    }
+
+    return json;
+  }
   export function attribute(name: string, value: string): Attribute.JSON {
     return {
       type: "attribute",

--- a/packages/alfa-dom/src/h.ts
+++ b/packages/alfa-dom/src/h.ts
@@ -84,11 +84,11 @@ export namespace h {
 
     switch (name) {
       case "svg":
-        rename(json, Namespace.SVG);
+        renamespace(json, Namespace.SVG);
         break;
 
       case "math":
-        rename(json, Namespace.MathML);
+        renamespace(json, Namespace.MathML);
     }
 
     return json;
@@ -280,12 +280,12 @@ function hyphenate(value: string): string {
   return value.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
 }
 
-function rename(element: Element.JSON, namespace: Namespace): void {
+function renamespace(element: Element.JSON, namespace: Namespace): void {
   element.namespace = namespace;
 
   for (const child of element.children) {
     if (child.type === "element") {
-      rename(child as Element.JSON, namespace);
+      renamespace(child as Element.JSON, namespace);
     }
   }
 }

--- a/packages/alfa-dom/src/h.ts
+++ b/packages/alfa-dom/src/h.ts
@@ -1,0 +1,260 @@
+import { Namespace } from "./namespace";
+
+import { Node } from "./node";
+import { Attribute } from "./node/attribute";
+import { Document } from "./node/document";
+import { Element } from "./node/element";
+import { Fragment } from "./node/fragment";
+import { Text } from "./node/text";
+import { Type } from "./node/type";
+
+import { Block } from "./style/block";
+import { Declaration } from "./style/declaration";
+import {
+  Rule,
+  FontFaceRule,
+  KeyframeRule,
+  KeyframesRule,
+  MediaRule,
+  NamespaceRule,
+  PageRule,
+  StyleRule,
+  SupportsRule,
+} from "./style/rule";
+import { Sheet } from "./style/sheet";
+
+const { entries } = Object;
+
+export function h(
+  name: string,
+  attributes: Array<Attribute.JSON> | Record<string, string | boolean> = [],
+  children: Array<Node.JSON | string> = [],
+  style: Array<Declaration.JSON> | Record<string, string> = []
+): Element.JSON {
+  attributes = Array.isArray(attributes)
+    ? attributes
+    : entries(attributes).reduce<Array<Attribute.JSON>>(
+        (attributes, [name, value]) => {
+          if (value === false) {
+            return attributes;
+          }
+
+          return [
+            ...attributes,
+            h.attribute(hyphenate(name), value === true ? "" : value),
+          ];
+        },
+        []
+      );
+
+  style = h.block(style);
+
+  if (style.length > 0) {
+    attributes = [
+      ...attributes,
+      h.attribute("style", Block.fromBlock(style).toString()),
+    ];
+  }
+
+  return {
+    type: "element",
+    namespace: Namespace.HTML,
+    prefix: null,
+    name,
+    attributes,
+    children: children.map((child) =>
+      typeof child === "string" ? h.text(child) : child
+    ),
+    style,
+    shadow: null,
+    content: null,
+  };
+}
+
+export namespace h {
+  export function attribute(name: string, value: string): Attribute.JSON {
+    return {
+      type: "attribute",
+      namespace: null,
+      prefix: null,
+      name,
+      value,
+    };
+  }
+
+  export function text(data: string): Text.JSON {
+    return {
+      type: "text",
+      data,
+    };
+  }
+
+  export function document(
+    children: Array<Node.JSON | string>,
+    style: Array<Sheet.JSON> = []
+  ): Document.JSON {
+    return {
+      type: "document",
+      children: children.map((child) =>
+        typeof child === "string" ? text(child) : child
+      ),
+      style,
+    };
+  }
+
+  export function type(
+    name: string,
+    publicId: string | null = null,
+    systemId: string | null = null
+  ): Type.JSON {
+    return {
+      type: "type",
+      name,
+      publicId,
+      systemId,
+    };
+  }
+
+  export function fragment(children: Array<Node.JSON | string>): Fragment.JSON {
+    return {
+      type: "fragment",
+      children: children.map((child) =>
+        typeof child === "string" ? text(child) : child
+      ),
+    };
+  }
+
+  export function sheet(
+    rules: Array<Rule.JSON>,
+    disabled: boolean = false,
+    condition: string | null = null
+  ): Sheet.JSON {
+    return {
+      rules,
+      disabled,
+      condition,
+    };
+  }
+
+  export function block(
+    declarations: Array<Declaration.JSON> | Record<string, string>
+  ): Block.JSON {
+    return Array.isArray(declarations)
+      ? declarations
+      : entries(declarations).map(([name, value]) => {
+          const important = value.endsWith("!important");
+
+          value = value.replace(/\s+?!important$/, "");
+
+          return {
+            name: hyphenate(name),
+            value,
+            important,
+          };
+        });
+  }
+
+  export function declaration(
+    name: string,
+    value: string,
+    important: boolean = false
+  ): Declaration.JSON {
+    return {
+      name,
+      value,
+      important,
+    };
+  }
+
+  export namespace rule {
+    export function fontFace(
+      declarations: Array<Declaration.JSON> | Record<string, string>
+    ): FontFaceRule.JSON {
+      return {
+        type: "font-face",
+        style: block(declarations),
+      };
+    }
+
+    export function keyframe(
+      key: string,
+      declarations: Array<Declaration.JSON> | Record<string, string>
+    ): KeyframeRule.JSON {
+      return {
+        type: "keyframe",
+        key,
+        style: block(declarations),
+      };
+    }
+
+    export function keyframes(
+      name: string,
+      rules: Array<Rule.JSON>
+    ): KeyframesRule.JSON {
+      return {
+        type: "keyframes",
+        name,
+        rules,
+      };
+    }
+
+    export function media(
+      condition: string,
+      rules: Array<Rule.JSON>
+    ): MediaRule.JSON {
+      return {
+        type: "media",
+        condition,
+        rules,
+      };
+    }
+
+    export function namespace(
+      namespace: string,
+      prefix: string | null = null
+    ): NamespaceRule.JSON {
+      return {
+        type: "namespace",
+        namespace,
+        prefix,
+      };
+    }
+
+    export function page(
+      selector: string,
+      declarations: Array<Declaration.JSON> | Record<string, string>
+    ): PageRule.JSON {
+      return {
+        type: "page",
+        selector,
+        style: block(declarations),
+      };
+    }
+
+    export function style(
+      selector: string,
+      declarations: Array<Declaration.JSON> | Record<string, string>
+    ): StyleRule.JSON {
+      return {
+        type: "style",
+        selector,
+        style: block(declarations),
+      };
+    }
+
+    export function supports(
+      condition: string,
+      rules: Array<Rule.JSON>
+    ): SupportsRule.JSON {
+      return {
+        type: "supports",
+        condition,
+        rules,
+      };
+    }
+  }
+}
+
+function hyphenate(value: string): string {
+  return value.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
+}

--- a/packages/alfa-dom/src/h.ts
+++ b/packages/alfa-dom/src/h.ts
@@ -56,7 +56,7 @@ export function h(
     ];
   }
 
-  return {
+  const json: Element.JSON = {
     type: "element",
     namespace: Namespace.HTML,
     prefix: null,
@@ -69,6 +69,17 @@ export function h(
     shadow: null,
     content: null,
   };
+
+  switch (name) {
+    case "svg":
+      rename(json, Namespace.SVG);
+      break;
+
+    case "math":
+      rename(json, Namespace.MathML);
+  }
+
+  return json;
 }
 
 export namespace h {
@@ -257,4 +268,14 @@ export namespace h {
 
 function hyphenate(value: string): string {
   return value.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
+}
+
+function rename(element: Element.JSON, namespace: Namespace): void {
+  element.namespace = namespace;
+
+  for (const child of element.children) {
+    if (child.type === "element") {
+      rename(child as Element.JSON, namespace);
+    }
+  }
 }

--- a/packages/alfa-dom/src/index.ts
+++ b/packages/alfa-dom/src/index.ts
@@ -1,3 +1,5 @@
+export * from "./h";
+export * from "./jsx";
 export * from "./namespace";
 export * from "./node";
 export * from "./node/attribute";

--- a/packages/alfa-dom/tsconfig.json
+++ b/packages/alfa-dom/tsconfig.json
@@ -2,7 +2,9 @@
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "../tsconfig.json",
   "files": [
+    "h.ts",
     "jsx.ts",
+    "src/h.ts",
     "src/index.ts",
     "src/jsx.ts",
     "src/namespace.ts",

--- a/packages/alfa-dom/tsconfig.json
+++ b/packages/alfa-dom/tsconfig.json
@@ -42,9 +42,6 @@
   ],
   "references": [
     {
-      "path": "../alfa-css"
-    },
-    {
       "path": "../alfa-earl"
     },
     {
@@ -70,9 +67,6 @@
     },
     {
       "path": "../alfa-sequence"
-    },
-    {
-      "path": "../alfa-slice"
     },
     {
       "path": "../alfa-test"

--- a/packages/alfa-rules/test/sia-r45/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r45/rule.spec.tsx
@@ -26,7 +26,7 @@ test(`evaluate() passes when tokens in headers list refer to cells in the same
         </thead>
         <tbody>
           <tr>
-            <td colSpan={2} headers="header1 header2">
+            <td colspan={2} headers="header1 header2">
               15%
             </td>
           </tr>
@@ -64,7 +64,7 @@ test(`evaluate() fails when some tokens in headers list do not refer to cells in
         </thead>
         <tbody>
           <tr>
-            <td colSpan={2} headers="header1 header2">
+            <td colspan={2} headers="header1 header2">
               15%
             </td>
           </tr>
@@ -102,7 +102,7 @@ test(`evaluate() fails when some token in the headers list refer to the cell
         </thead>
         <tbody>
           <tr>
-            <td id="cell" colSpan={2} headers="header cell">
+            <td id="cell" colspan={2} headers="header cell">
               15%
             </td>
           </tr>
@@ -139,7 +139,7 @@ test("evaluate() is inapplicable when there is no headers attribute", async (t) 
         </thead>
         <tbody>
           <tr>
-            <td colSpan={2}>15%</td>
+            <td colspan={2}>15%</td>
           </tr>
         </tbody>
       </table>,

--- a/packages/alfa-rules/test/sia-r69/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r69/rule.spec.tsx
@@ -24,7 +24,9 @@ const rgb = (r: number, g: number, b: number, a: number = 1) =>
 test("evaluate() passes a text node that has sufficient contrast", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="background-color: black; color: white">Hello world</html>,
+      <html style={{ backgroundColor: "black", color: "white" }}>
+        Hello world
+      </html>,
       Option.of(self)
     ),
   ]);
@@ -43,11 +45,11 @@ test("evaluate() passes a text node that has sufficient contrast", async (t) => 
 test("evaluate() correctly handles semi-transparent backgrounds", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="background-color: black; color: white">
-        <div style="background-color: rgb(100%, 100%, 100%, 15%)">
+      <html style={{ backgroundColor: "black", color: "white" }}>
+        <div style={{ backgroundColor: "rgb(100%, 100%, 100%, 15%)" }}>
           Sufficient contrast
         </div>
-        <div style="background-color: rgb(100%, 100%, 100%, 50%)">
+        <div style={{ backgroundColor: "rgb(100%, 100%, 100%, 50%)" }}>
           Insufficient contrast
         </div>
       </html>,
@@ -74,9 +76,11 @@ test("evaluate() correctly handles semi-transparent backgrounds", async (t) => {
 test("evaluate() correctly handles semi-transparent foregrounds", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="background-color: black">
-        <div style="color: rgb(100%, 100%, 100%, 85%)">Sufficient contrast</div>
-        <div style="color: rgb(100%, 100%, 100%, 40%)">
+      <html style={{ backgroundColor: "black" }}>
+        <div style={{ color: "rgb(100%, 100%, 100%, 85%)" }}>
+          Sufficient contrast
+        </div>
+        <div style={{ color: "rgb(100%, 100%, 100%, 40%)" }}>
           Insufficient contrast
         </div>
       </html>,
@@ -103,7 +107,9 @@ test("evaluate() correctly handles semi-transparent foregrounds", async (t) => {
 test("evaluate() passes an 18pt text node with sufficient contrast", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="background-color: black; color: #606060; font-size: 18pt">
+      <html
+        style={{ backgroundColor: "black", color: "#606060", fontSize: "18pt" }}
+      >
         Hello world
       </html>,
       Option.of(self)
@@ -128,7 +134,14 @@ test("evaluate() passes an 18pt text node with sufficient contrast", async (t) =
 test("evaluate() passes an 14pt, bold text node with sufficient contrast", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="background-color: black; color: #606060; font-size: 14pt; font-weight: bold">
+      <html
+        style={{
+          backgroundColor: "black",
+          color: "#606060",
+          fontSize: "14pt",
+          fontWeight: "bold",
+        }}
+      >
         Hello world
       </html>,
       Option.of(self)
@@ -169,7 +182,7 @@ test("evaluate() passes a text node using the user agent default styles", async 
 test("evaluate() correctly resolves the `currentcolor` keyword", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="background-color: currentcolor; color: white">
+      <html style={{ backgroundColor: "currentcolor", color: "white" }}>
         Hello world
       </html>,
       Option.of(self)
@@ -190,7 +203,7 @@ test("evaluate() correctly resolves the `currentcolor` keyword", async (t) => {
 test("evaluate() correctly resolves the `currentcolor` keyword to the user agent default", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="background-color: currentcolor">Hello world</html>,
+      <html style={{ backgroundColor: "currentcolor" }}>Hello world</html>,
       Option.of(self)
     ),
   ]);
@@ -209,7 +222,7 @@ test("evaluate() correctly resolves the `currentcolor` keyword to the user agent
 test("evaluate() correctly handles circular `currentcolor` references", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="color: currentcolor">Hello world</html>,
+      <html style={{ color: "currentcolor" }}>Hello world</html>,
       Option.of(self)
     ),
   ]);
@@ -250,7 +263,7 @@ test("evaluate() is inapplicable to text nodes in disabled groups", async (t) =>
 test("evaluate() passes when a background color with sufficient contrast is input", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="color: #000; background-image: url('foo.png')">
+      <html style={{ color: "#000", backgroundImage: "url('foo.png')" }}>
         Hello world
       </html>,
       Option.of(self)
@@ -280,7 +293,7 @@ test("evaluate() passes when a background color with sufficient contrast is inpu
 test("evaluate() fails when a background color with insufficient contrast is input", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="color: #000; background-image: url('foo.png')">
+      <html style={{ color: "#000", backgroundImage: "url('foo.png')" }}>
         Hello world
       </html>,
       Option.of(self)

--- a/packages/alfa-rules/test/sia-r71/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r71/rule.spec.tsx
@@ -39,7 +39,7 @@ test("evaluate() fails a paragraph whose text is justified", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
       <html>
-        <p style="text-align: justify">Hello world</p>
+        <p style={{ textAlign: "justify" }}>Hello world</p>
       </html>,
       Option.of(self)
     ),
@@ -60,7 +60,7 @@ test("evaluate() fails a paragraph whose text is justified", async (t) => {
 test("evaluate() fails a paragraph whose text is justified by inheritance", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="text-align: justify">
+      <html style={{ textAlign: "justify" }}>
         <p>Hello world</p>
       </html>,
       Option.of(self)

--- a/packages/alfa-rules/test/sia-r72/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r72/rule.spec.tsx
@@ -39,7 +39,7 @@ test("evaluate() fails a paragraph whose text is uppercased", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
       <html>
-        <p style="text-transform: uppercase">Hello world</p>
+        <p style={{ textTransform: "uppercase" }}>Hello world</p>
       </html>,
       Option.of(self)
     ),
@@ -60,7 +60,7 @@ test("evaluate() fails a paragraph whose text is uppercased", async (t) => {
 test("evaluate() fails a paragraph whose text is uppercased by inheritance", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="text-transform: uppercase">
+      <html style={{ textTransform: "uppercase" }}>
         <p>Hello world</p>
       </html>,
       Option.of(self)

--- a/packages/alfa-rules/test/sia-r73/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r73/rule.spec.tsx
@@ -8,7 +8,7 @@ import { Predicate } from "@siteimprove/alfa-predicate";
 import R73, { Outcomes } from "../../src/sia-r73/rule";
 
 import { evaluate } from "../common/evaluate";
-import { passed, failed, inapplicable } from "../common/outcome";
+import { passed, failed } from "../common/outcome";
 
 const { and } = Predicate;
 const { isElement, hasName } = Element;
@@ -17,7 +17,7 @@ test("evaluate() passes a paragraph whose line height is at least 1.5", async (t
   const document = Document.of((self) => [
     Element.fromElement(
       <html>
-        <p style="line-height: 1.5">Hello world</p>
+        <p style={{ lineHeight: "1.5" }}>Hello world</p>
       </html>,
       Option.of(self)
     ),
@@ -40,7 +40,7 @@ test(`evaluate() passes a paragraph whose line height is at least 1.5 times the
   const document = Document.of((self) => [
     Element.fromElement(
       <html>
-        <p style="font-size: 16px; line-height: 24px">Hello world</p>
+        <p style={{ fontSize: "16px", lineHeight: "24px" }}>Hello world</p>
       </html>,
       Option.of(self)
     ),
@@ -62,7 +62,7 @@ test("evaluate() fails a paragraph whose line height is less than 1.5", async (t
   const document = Document.of((self) => [
     Element.fromElement(
       <html>
-        <p style="line-height: 1.2">Hello world</p>
+        <p style={{ lineHeight: "1.2" }}>Hello world</p>
       </html>,
       Option.of(self)
     ),
@@ -85,7 +85,7 @@ test(`evaluate() fails a paragraph whose line height is less than 1.5 times the
   const document = Document.of((self) => [
     Element.fromElement(
       <html>
-        <p style="font-size: 16px; line-height: 22px">Hello world</p>
+        <p style={{ fontSize: "16px", lineHeight: "22px" }}>Hello world</p>
       </html>,
       Option.of(self)
     ),
@@ -107,7 +107,7 @@ test(`evaluate() fails a paragraph whose line height is "normal"`, async (t) => 
   const document = Document.of((self) => [
     Element.fromElement(
       <html>
-        <p style="line-height: normal">Hello world</p>
+        <p style={{ lineHeight: "normal" }}>Hello world</p>
       </html>,
       Option.of(self)
     ),

--- a/packages/alfa-rules/test/sia-r74/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r74/rule.spec.tsx
@@ -15,7 +15,7 @@ test(`evaluate() passes an element with a font size specified using a relative
       length`, async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="font-size: 1em">Hello world</html>,
+      <html style={{ fontSize: "1em" }}>Hello world</html>,
       Option.of(self)
     ),
   ]);
@@ -33,7 +33,7 @@ test(`evaluate() fails an element with a font size specified using an absolute
       length`, async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="font-size: 16px">Hello world</html>,
+      <html style={{ fontSize: "16px" }}>Hello world</html>,
       Option.of(self)
     ),
   ]);
@@ -49,7 +49,10 @@ test(`evaluate() fails an element with a font size specified using an absolute
 
 test("evaluate() is inapplicable to an element that has no text", async (t) => {
   const document = Document.of((self) => [
-    Element.fromElement(<html style="font-size: 16px"></html>, Option.of(self)),
+    Element.fromElement(
+      <html style={{ fontSize: "16px" }}></html>,
+      Option.of(self)
+    ),
   ]);
 
   t.deepEqual(await evaluate(R74, { document }), [inapplicable(R74)]);
@@ -58,7 +61,7 @@ test("evaluate() is inapplicable to an element that has no text", async (t) => {
 test("evaluate() is inapplicable to an element that isn't visible", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="font-size: 16px" hidden>
+      <html style={{ fontSize: "16px" }} hidden>
         Hello world
       </html>,
       Option.of(self)

--- a/packages/alfa-rules/test/sia-r75/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r75/rule.spec.tsx
@@ -14,7 +14,7 @@ const { isElement, hasName } = Element;
 test("evaluate() passes an element with a font size not smaller than 9 pixels", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="font-size: medium">Hello world</html>,
+      <html style={{ fontSize: "medium" }}>Hello world</html>,
       Option.of(self)
     ),
   ]);
@@ -31,7 +31,7 @@ test("evaluate() passes an element with a font size not smaller than 9 pixels", 
 test("evaluate() fails an element with a font size smaller than 9 pixels", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="font-size: 8px">Hello world</html>,
+      <html style={{ fontSize: "8px" }}>Hello world</html>,
       Option.of(self)
     ),
   ]);
@@ -49,8 +49,8 @@ test(`evaluate() fails an element with an accumulated font size smaller than 9
       pixels`, async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="font-size: 10px">
-        <p style="font-size: smaller">Hello world</p>
+      <html style={{ fontSize: "10px" }}>
+        <p style={{ fontSize: "smaller" }}>Hello world</p>
       </html>,
       Option.of(self)
     ),

--- a/packages/alfa-rules/test/sia-r80/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r80/rule.spec.tsx
@@ -15,7 +15,7 @@ test(`evaluate() passes an element with a line height specified using a relative
       length`, async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="line-height: 1.5em">Hello world</html>,
+      <html style={{ lineHeight: "1.5em" }}>Hello world</html>,
       Option.of(self)
     ),
   ]);
@@ -33,7 +33,7 @@ test(`evaluate() fails an element with a line height specified using an absolute
       length`, async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="line-height: 24px">Hello world</html>,
+      <html style={{ lineHeight: "24px" }}>Hello world</html>,
       Option.of(self)
     ),
   ]);
@@ -50,7 +50,7 @@ test(`evaluate() fails an element with a line height specified using an absolute
 test("evaluate() is inapplicable to an element that has no text", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="line-height: 24px"></html>,
+      <html style={{ lineHeight: "24px" }}></html>,
       Option.of(self)
     ),
   ]);
@@ -61,7 +61,7 @@ test("evaluate() is inapplicable to an element that has no text", async (t) => {
 test("evaluate() is inapplicable to an element that isn't visible", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="line-height: 24px" hidden>
+      <html style={{ lineHeight: "24px" }} hidden>
         Hello world
       </html>,
       Option.of(self)

--- a/packages/alfa-rules/test/sia-r83/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r83/rule.spec.tsx
@@ -14,7 +14,13 @@ const { isText } = Text;
 test("evaluate() passes a text node that truncates overflow using ellipsis", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <div style="overflow: hidden; white-space: nowrap; text-overflow: ellipsis;">
+      <div
+        style={{
+          overflow: "hidden",
+          whiteSpace: "nowrap",
+          textOverflow: "ellipsis",
+        }}
+      >
         Hello world
       </div>,
       Option.of(self)
@@ -35,7 +41,7 @@ test(`evaluate() passes a text node that hides overflow by wrapping text using
       \`line-height\` property`, async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <div style="overflow: hidden; height: 1.5em; line-height: 1.5;">
+      <div style={{ overflow: "hidden", height: "1.5em", lineHeight: "1.5" }}>
         Hello world
       </div>,
       Option.of(self)
@@ -55,7 +61,9 @@ test(`evaluate() fails a text node that clips overflow by not wrapping text
       using the \`white-space\` property`, async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <div style="overflow: hidden; white-space: nowrap;">Hello world</div>,
+      <div style={{ overflow: "hidden", whiteSpace: "nowrap" }}>
+        Hello world
+      </div>,
       Option.of(self)
     ),
   ]);
@@ -74,7 +82,7 @@ test(`evaluate() fails a text node that clips overflow by not wrapping text
       of the \`line-height\` property`, async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <div style="overflow: hidden; height: 1.5em; line-height: 1.2;">
+      <div style={{ overflow: "hidden", height: "1.5em", lineHeight: "1.2" }}>
         Hello world
       </div>,
       Option.of(self)
@@ -93,7 +101,7 @@ test(`evaluate() fails a text node that clips overflow by not wrapping text
 test("evaluate() is inapplicable to a text node that is not visible", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <div style="overflow: hidden; white-space: nowrap;" hidden>
+      <div style={{ overflow: "hidden", whiteSpace: "nowrap" }} hidden>
         Hello world
       </div>,
       Option.of(self)
@@ -107,7 +115,10 @@ test(`evaluate() is inapplicable to a text node that is excluded from the
       accessibility tree using the \`aria-hidden\` attribute`, async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <div style="overflow: hidden; white-space: nowrap;" aria-hidden="true">
+      <div
+        style={{ overflow: "hidden", whiteSpace: "nowrap" }}
+        aria-hidden="true"
+      >
         Hello world
       </div>,
       Option.of(self)

--- a/packages/alfa-rules/test/sia-r84/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r84/rule.spec.tsx
@@ -15,7 +15,7 @@ const { isElement } = Element;
 test("evaluate() passes a scrollable element that is focusable", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <div style="height: 1.5em; overflow: scroll" tabindex="0">
+      <div style={{ height: "1.5em", overflow: "scroll" }} tabindex="0">
         Hello world
       </div>,
       Option.of(self)
@@ -34,7 +34,7 @@ test("evaluate() passes a scrollable element that is focusable", async (t) => {
 test("evaluate() passes a scrollable element that has a focusable child", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <div style="height: 1.5em; overflow: scroll">
+      <div style={{ height: "1.5em", overflow: "scroll" }}>
         <button>Hello world</button>
       </div>,
       Option.of(self)
@@ -53,7 +53,7 @@ test("evaluate() passes a scrollable element that has a focusable child", async 
 test("evaluate() passes a scrollable element that has a focusable descendant", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <div style="height: 1.5em; overflow: scroll">
+      <div style={{ height: "1.5em", overflow: "scroll" }}>
         <div>
           <button>Hello world</button>
         </div>
@@ -75,7 +75,7 @@ test(`evaluate() fails a scrollable element that is neither focusable nor has
       focusable descendants`, async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <div style="height: 1.5em; overflow: scroll">Hello world</div>,
+      <div style={{ height: "1.5em", overflow: "scroll" }}>Hello world</div>,
       Option.of(self)
     ),
   ]);

--- a/packages/alfa-rules/test/sia-r85/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r85/rule.spec.tsx
@@ -39,7 +39,7 @@ test("evaluate() fails a paragraph whose text is italic", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
       <html>
-        <p style="font-style: italic">Hello world</p>
+        <p style={{ fontStyle: "italic" }}>Hello world</p>
       </html>,
       Option.of(self)
     ),
@@ -60,7 +60,7 @@ test("evaluate() fails a paragraph whose text is italic", async (t) => {
 test("evaluate() fails a paragraph whose text is italic by inheritance", async (t) => {
   const document = Document.of((self) => [
     Element.fromElement(
-      <html style="font-style: italic">
+      <html style={{ fontStyle: "italic" }}>
         <p>Hello world</p>
       </html>,
       Option.of(self)

--- a/packages/alfa-table/test/testcases.tsx
+++ b/packages/alfa-table/test/testcases.tsx
@@ -105,19 +105,19 @@ export namespace simpleRow {
 export namespace complexRow {
   export const element = Element.fromElement(
     <tr>
-      <th id="grade" rowSpan={2}>
+      <th id="grade" rowspan={2}>
         Grade.
       </th>
-      <th id="yield" rowSpan={2}>
+      <th id="yield" rowspan={2}>
         Yield Point.
       </th>
-      <th id="strength" colSpan={2}>
+      <th id="strength" colspan={2}>
         Ultimate tensile strength
       </th>
-      <th id="elong" rowSpan={2}>
+      <th id="elong" rowspan={2}>
         Per cent elong. 50.8mm or 2 in.
       </th>
-      <th id="reduct" rowSpan={2}>
+      <th id="reduct" rowspan={2}>
         Per cent reduct. area.
       </th>
     </tr>
@@ -154,19 +154,19 @@ export namespace simpleRowGroup {
   export const element = Element.fromElement(
     <thead id="thead">
       <tr id="first">
-        <th id="grade" rowSpan={2}>
+        <th id="grade" rowspan={2}>
           Grade.
         </th>
-        <th id="yield" rowSpan={2}>
+        <th id="yield" rowspan={2}>
           Yield Point.
         </th>
-        <th id="strength" colSpan={2}>
+        <th id="strength" colspan={2}>
           Ultimate tensile strength
         </th>
-        <th id="elong" rowSpan={2}>
+        <th id="elong" rowspan={2}>
           Per cent elong. 50.8mm or 2 in.
         </th>
-        <th id="reduct" rowSpan={2}>
+        <th id="reduct" rowspan={2}>
           Per cent reduct. area.
         </th>
       </tr>
@@ -209,24 +209,24 @@ export namespace downwardGrowing {
   export const element = Element.fromElement(
     <thead id="thead">
       <tr id="first">
-        <th id="grade" rowSpan={3}>
+        <th id="grade" rowspan={3}>
           Grade.
         </th>
-        <th id="yield" rowSpan={2}>
+        <th id="yield" rowspan={2}>
           Yield Point.
         </th>
-        <th id="strength" colSpan={2}>
+        <th id="strength" colspan={2}>
           Ultimate tensile strength
         </th>
-        <th id="elong" rowSpan={2}>
+        <th id="elong" rowspan={2}>
           Per cent elong. 50.8mm or 2 in.
         </th>
-        <th id="reduct" rowSpan={0}>
+        <th id="reduct" rowspan={0}>
           Per cent reduct. area.
         </th>
       </tr>
       <tr id="second">
-        <th id="kg-mm" rowSpan={0}>
+        <th id="kg-mm" rowspan={0}>
           kg/mm<sup>2</sup>
         </th>
         <th id="lb-in">
@@ -275,19 +275,19 @@ export namespace smithonian {
       </caption>
       <thead id="thead">
         <tr>
-          <th id="grade" rowSpan={2}>
+          <th id="grade" rowspan={2}>
             Grade.
           </th>
-          <th id="yield" rowSpan={2}>
+          <th id="yield" rowspan={2}>
             Yield Point.
           </th>
-          <th id="strength" colSpan={2}>
+          <th id="strength" colspan={2}>
             Ultimate tensile strength
           </th>
-          <th id="elong" rowSpan={2}>
+          <th id="elong" rowspan={2}>
             Per cent elong. 50.8mm or 2 in.
           </th>
-          <th id="reduct" rowSpan={2}>
+          <th id="reduct" rowspan={2}>
             Per cent reduct. area.
           </th>
         </tr>
@@ -702,7 +702,7 @@ export namespace errors {
   export const emptyCol = Element.fromElement(
     <table>
       <tr>
-        <td id="one-two" colSpan={2}>
+        <td id="one-two" colspan={2}>
           2 columns
         </td>
         <td id="three">third column</td>
@@ -714,7 +714,7 @@ export namespace errors {
   export const emptyRow = Element.fromElement(
     <table>
       <tr>
-        <td rowSpan={2}>2 rows</td>
+        <td rowspan={2}>2 rows</td>
       </tr>
       <tr />
       <tr>
@@ -728,10 +728,10 @@ export namespace errors {
     <table>
       <tr>
         <td>1 row, 1 col</td>
-        <td rowSpan={2}>2 rows</td>
+        <td rowspan={2}>2 rows</td>
       </tr>
       <tr>
-        <td colSpan={2}>2 cols</td>
+        <td colspan={2}>2 cols</td>
       </tr>
     </table>
   );
@@ -1087,11 +1087,11 @@ export namespace colGroupImplicitHeaders {
       <colgroup id="group-mars" span={2} />
       <colgroup id="group-venus" span={2} />
       <tr>
-        <td id="empty" rowSpan={2} />
-        <th id="mars" colSpan={2} scope="colgroup">
+        <td id="empty" rowspan={2} />
+        <th id="mars" colspan={2} scope="colgroup">
           Mars
         </th>
-        <th id="venus" colSpan={2} scope="colgroup">
+        <th id="venus" colspan={2} scope="colgroup">
           Venus
         </th>
       </tr>
@@ -1209,17 +1209,17 @@ export namespace allWeirdImplicitHeaders {
       <colgroup id="group-venus" span={2} />
       <thead id="thead">
         <tr>
-          <th id="empty" rowSpan={2} colSpan={2} />
-          <th id="mars" rowSpan={2} scope="colgroup">
+          <th id="empty" rowspan={2} colspan={2} />
+          <th id="mars" rowspan={2} scope="colgroup">
             Mars
           </th>
-          <th id="mars-produced" rowSpan={2} scope="col">
+          <th id="mars-produced" rowspan={2} scope="col">
             Produced
           </th>
-          <th id="mars-sold" rowSpan={2} scope="col">
+          <th id="mars-sold" rowspan={2} scope="col">
             Sold
           </th>
-          <th id="venus" colSpan={2} scope="colgroup">
+          <th id="venus" colspan={2} scope="colgroup">
             Venus
           </th>
         </tr>
@@ -1234,7 +1234,7 @@ export namespace allWeirdImplicitHeaders {
       </thead>
       <tbody id="stuffed-animals">
         <tr>
-          <th id="stuffed" rowSpan={2} scope="rowgroup">
+          <th id="stuffed" rowspan={2} scope="rowgroup">
             Stuffed animals
           </th>
           <th id="bears">Bears</th>
@@ -1255,7 +1255,7 @@ export namespace allWeirdImplicitHeaders {
       </tbody>
       <tbody id="games-rg">
         <tr>
-          <th id="games" colSpan={2} scope="rowgroup">
+          <th id="games" colspan={2} scope="rowgroup">
             Games
           </th>
           <td id="mars-empty-games" />
@@ -1265,7 +1265,7 @@ export namespace allWeirdImplicitHeaders {
           <td id="venus-sold-games" />
         </tr>
         <tr>
-          <th id="board" colSpan={2} scope="row">
+          <th id="board" colspan={2} scope="row">
             Board Games
           </th>
           <td id="mars-empty-board" />
@@ -1275,7 +1275,7 @@ export namespace allWeirdImplicitHeaders {
           <td id="venus-sold-board">9,000</td>
         </tr>
         <tr>
-          <th id="cards" colSpan={2} scope="row">
+          <th id="cards" colspan={2} scope="row">
             Cards Games
           </th>
           <td id="mars-empty-cards" />


### PR DESCRIPTION
This pull request introduces a [HyperScript](https://github.com/hyperhype/hyperscript)-like DSL of sorts for constructing DOM. It's been in the cards for some time now that we've needed a better approach to constructing DOM, in particular for test cases, as code like the following has become very common practice:

https://github.com/Siteimprove/alfa/blob/a2a909ea04a84615e37cd41dd4c6d9b9de913a47/packages/alfa-rules/test/sia-r1/rule.spec.tsx#L13-L22

The new `h()` function and the associated `h` namespace help alleviate this by allowing code that instead looks like this:

```ts
const document = Document.fromDocument(
  h.document([
    h("html", {}, [
      h("head", {}, [
        h("title", {}, ["Hello world"]),
      ])
    ])
  ])
);
```

This can of course be mixed with JSX as well for an even nicer look:

```tsx
const document = Document.fromDocument(
  h.document([
    <html>
      <head>
        <title>Hello world</title>
      </head>
    </html>
  ])
);
```

This pull request was in particular prompted by the need for also constructing CSSOM for testing the `@siteimprove/alfa-style` package:

```tsx
const document = Document.fromDocument(
  h.document(
    [<div />],
    [
      h.sheet([
        h.rule.style("div", { color: "red" }),
      ]),
    ]
  )
);
```

The changes are breaking as the `jsx()` function has also been modified and now requires that `style` attributes are provided as property-value records to remove the need for declaration parsing which greatly simplifies both the internal code and the exposed interface.