### PR TITLE
Pass rules during construction of `Audit` class rather than after

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ On their own, each of these packages do very little, but when put together they 
 At a high level, Alfa consumes implementations of rules specified in the [Accessibility Conformance Testing (ACT) Rules Format](https://www.w3.org/TR/act-rules-format/) and produces audit results in the [Evaluation and Report Language (EARL) Schema](https://www.w3.org/TR/EARL10-Schema/) encoded as [JSON-LD](https://www.w3.org/TR/json-ld/). More often than not, your only interaction with Alfa will look similar to this:
 
 ```ts
-import { Audit } from "@siteimprove/alfa-act";
+import { Audit, Rule } from "@siteimprove/alfa-act";
 
-const input = {};
-const rules = [];
+const input: I;
+const rules: Iterable<Rule<I, T, Q>>;
 
 const outcomes = await Audit.of(input, rules).evaluate();
 ```
@@ -53,7 +53,7 @@ import { Audit } from "@siteimprove/alfa-act";
 
 import rules from "@siteimprove/alfa-rules";
 
-const input = {};
+const input: I;
 
 const outcomes = await Audit.of(input, rules).evaluate();
 ```

--- a/README.md
+++ b/README.md
@@ -40,74 +40,39 @@ At a high level, Alfa consumes implementations of rules specified in the [Access
 ```ts
 import { Audit } from "@siteimprove/alfa-act";
 
-const input = { ... };
+const input = {};
+const rules = [];
 
-Audit.of(input)
-  // Add the rules we want to evaluate
-  .add(ruleA)
-  .add(ruleB)
-  .add(...)
-
-  // Evaluate the input
-  .evaluate()
-
-  // Translate the results to EARL
-  .then(outcomes => {
-    const earl = [...outcomes].map(outcome => outcome.toEARL());
-  });
+const outcomes = await Audit.of(input, rules).evaluate();
 ```
 
 Alfa is completely pluggable with regards to rules and only prescribes the implementation format. As such, there is nothing to configure when it comes to rules; simply pass in the rules you wish to run and results will be provided for those rules. To get you started, Alfa ships with a solid set of rules based on the [Web Content Accessibility Guidelines (WCAG)](https://www.w3.org/TR/WCAG/):
 
 ```ts
 import { Audit } from "@siteimprove/alfa-act";
-import { Rules } from "@siteimprove/alfa-rules";
 
-const input = { ... };
+import rules from "@siteimprove/alfa-rules";
 
-let audit = Audit.of(input);
+const input = {};
 
-for (const [, rule] of Rules) {
-  audit = audit.add(rule);
-}
-
-audit.evaluate().then(outcomes => {
-  // ...
-});
+const outcomes = await Audit.of(input, rules).evaluate();
 ```
 
 The last piece we are missing is input. Which specific input that needs to be supplied when running an audit will depend on the rules that are part of the audit as each rule specifies the input it requires. For the default WCAG rule set, the input will be a web page. To get you started, Alfa ships with a scraper that given a URL will fetch a representation of the page that can be used as input to the default rules:
 
 ```ts
 import { Audit } from "@siteimprove/alfa-act";
-import { Rules } from "@siteimprove/alfa-rules";
 import { Scraper } from "@siteimprove/alfa-scraper";
+
+import rules from "@siteimprove/alfa-rules";
 
 const scraper = await Scraper.of();
 
-scraper
-  .scrape("https://example.com")
-  .then((result) => {
-    if (result.isErr()) {
-      throw result.getErr();
-    } else {
-      return result.get();
-    }
-  })
-  .then((page) => {
-    let audit = Audit.of(input);
+for (const input of await scraper.scrape("http://example.com")) {
+  const outcomes = await Audit.of(input, rules).evaluate();
+}
 
-    for (const [, rule] of Rules) {
-      audit = audit.add(rule);
-    }
-
-    audit.evaluate().then((outcomes) => {
-      // ...
-    });
-  })
-  .finally(() => {
-    scraper.close();
-  });
+scraper.close();
 ```
 
 ## Integrations

--- a/packages/alfa-act/src/audit.ts
+++ b/packages/alfa-act/src/audit.ts
@@ -11,23 +11,20 @@ import { Rule } from "./rule";
 export class Audit<I, T = unknown, Q = never> {
   public static of<I, T = unknown, Q = never>(
     input: I,
+    rules: Iterable<Rule<I, T, Q>>,
     oracle: Oracle<Q> = () => Future.now(None)
   ): Audit<I, T, Q> {
-    return new Audit(input, oracle, List.empty());
+    return new Audit(input, List.from(rules), oracle);
   }
 
   private readonly _input: I;
-  private readonly _oracle: Oracle<Q>;
   private readonly _rules: List<Rule<I, T, Q>>;
+  private readonly _oracle: Oracle<Q>;
 
-  private constructor(input: I, oracle: Oracle<Q>, rules: List<Rule<I, T, Q>>) {
+  private constructor(input: I, rules: List<Rule<I, T, Q>>, oracle: Oracle<Q>) {
     this._input = input;
-    this._oracle = oracle;
     this._rules = rules;
-  }
-
-  public add(rule: Rule<I, T, Q>): Audit<I, T, Q> {
-    return new Audit(this._input, this._oracle, this._rules.append(rule));
+    this._oracle = oracle;
   }
 
   public evaluate(): Future<Iterable<Outcome<I, T, Q>>> {

--- a/packages/alfa-act/src/rule.ts
+++ b/packages/alfa-act/src/rule.ts
@@ -158,7 +158,7 @@ export namespace Rule {
         applicability(): Iterable<Interview<Q, T, Option.Maybe<T>>>;
         expectations(
           target: T
-        ): { [key: string]: Interview<Q, T, Option<Result<Diagnostic>>> };
+        ): { [key: string]: Interview<Q, T, Option.Maybe<Result<Diagnostic>>> };
       };
     }
   }
@@ -251,7 +251,7 @@ export namespace Rule {
       (input: Readonly<I>): {
         expectations(
           outcomes: Sequence<Outcome.Applicable<I, T, Q>>
-        ): { [key: string]: Interview<Q, T, Option<Result<Diagnostic>>> };
+        ): { [key: string]: Interview<Q, T, Option.Maybe<Result<Diagnostic>>> };
       };
     }
   }
@@ -266,7 +266,7 @@ export namespace Rule {
 function resolve<I, T, Q>(
   target: T,
   expectations: Record<{
-    [key: string]: Interview<Q, T, Option<Result<Diagnostic>>>;
+    [key: string]: Interview<Q, T, Option.Maybe<Result<Diagnostic>>>;
   }>,
   rule: Rule<I, T, Q>,
   oracle: Oracle<Q>
@@ -281,7 +281,12 @@ function resolve<I, T, Q>(
       (expectations, [id, expectation]) =>
         expectations.flatMap((expectations) =>
           expectation.map((expectation) =>
-            expectations.append([id, expectation])
+            expectations.append([
+              id,
+              Option.isOption(expectation)
+                ? expectation
+                : Option.of(expectation),
+            ])
           )
         ),
       Option.of(List.empty<[string, Option<Result<Diagnostic>>]>())

--- a/packages/alfa-cli/bin/alfa/command/audit/run.ts
+++ b/packages/alfa-cli/bin/alfa/command/audit/run.ts
@@ -9,7 +9,7 @@ import { Formatter } from "@siteimprove/alfa-formatter";
 import { Iterable } from "@siteimprove/alfa-iterable";
 import { None } from "@siteimprove/alfa-option";
 import { Ok } from "@siteimprove/alfa-result";
-import { Rules, Question } from "@siteimprove/alfa-rules";
+import rules, { Question } from "@siteimprove/alfa-rules";
 import { Page } from "@siteimprove/alfa-web";
 
 import { Oracle } from "../../oracle";
@@ -19,14 +19,11 @@ import type { Flags } from "./flags";
 
 import * as scrape from "../scrape/run";
 
-type Input = Page;
-type Target = Node | Iterable<Node>;
-
 export const run: Command.Runner<typeof Flags, typeof Arguments> = async ({
   flags,
   args: { url: target },
 }) => {
-  const formatter = await Formatter.load<Input, Target, Question>(flags.format);
+  const formatter = await Formatter.load(flags.format);
 
   if (formatter.isErr()) {
     return formatter;
@@ -56,12 +53,10 @@ export const run: Command.Runner<typeof Flags, typeof Arguments> = async ({
 
   const page = Page.from(JSON.parse(json));
 
-  const audit = Rules.reduce(
-    (audit, rule) => audit.add(rule),
-    Audit.of<Input, Target, Question>(
-      page,
-      flags.interactive ? Oracle(page) : undefined
-    )
+  const audit = Audit.of(
+    page,
+    rules,
+    flags.interactive ? Oracle(page) : undefined
   );
 
   let outcomes = await audit.evaluate();

--- a/packages/alfa-rules/src/index.ts
+++ b/packages/alfa-rules/src/index.ts
@@ -1,7 +1,22 @@
+import { Rule } from "@siteimprove/alfa-act";
 import { Record } from "@siteimprove/alfa-record";
 
 import * as rules from "./rules";
 
+type Rules = Record.Value<typeof rules>;
+
+/**
+ * An immutable record of individual rules. The type of each individual rule is
+ * preserved in the record.
+ */
 export const Rules = Record.of(rules);
+
+/**
+ * A list of all available rules joined under a single type. The type of each
+ * rule is not preserved in the list as the types have been flattened.
+ */
+export default [...Rules.values()] as Iterable<
+  Rule<Rule.Input<Rules>, Rule.Target<Rules>, Rule.Question<Rules>>
+>;
 
 export * from "./common/question";


### PR DESCRIPTION
With most of the variance issues surrounding rules sorted out, I no longer see a reason to pass rules to the `Audit` class _after_ its construction. In fact, this has caused other issues due to the lack of type inference meaning that callers have had to explicitly annotate the target (`T`) and question (`Q`) type parameters as only the input (`I`) type would be inferred:

```ts
const rules: Array<Rule<Input, Type, Question>>;

let audit = Audit.of<Input, Type, Question>(input);

for (const rule of rules) {
  audit = audit.add(rule);
}
```

This pull request solves that by requiring that rules be passed _during_ construction of the `Audit` class:

```ts
const rules: Array<Rule<Input, Type, Question>>;

const audit = Audit.of(input, rules);
```

This pull request also makes it possible to easily add the rules from `@siteimprove/alfa-rules` package to audits by exposing the available rules as a list with a single, flattened `Rule` type:

https://github.com/Siteimprove/alfa/blob/3ce068fbf0be8920295ef74405da69bc1176b6a9/packages/alfa-rules/src/index.ts#L14-L20

That is, rather than the type being an `Iterable` of a massive union of the individual rule types, which causes the type inference algorithm to only consider the _first_ member of this union and complaining that the rest don't match, the type is instead:

```ts
Iterable<Rule<Page, Document | Element | Iterable<Element> | Text | Attribute, Question>>
```