### PR TITLE
Refactor `Scraper#scrape()` internals to fix scraping of URLs with hash fragment

### DIFF
--- a/packages/alfa-scraper/package.json
+++ b/packages/alfa-scraper/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@siteimprove/alfa-device": "^0.3.0",
     "@siteimprove/alfa-dom": "^0.3.0",
-    "@siteimprove/alfa-encoding": "^0.3.0",
     "@siteimprove/alfa-equatable": "^0.3.0",
     "@siteimprove/alfa-http": "^0.3.0",
     "@siteimprove/alfa-json": "^0.3.0",

--- a/packages/alfa-scraper/src/scraper.ts
+++ b/packages/alfa-scraper/src/scraper.ts
@@ -127,7 +127,9 @@ export class Scraper {
             .catch(() => null)
             .then((response) => response!);
 
-          const request = response.then((response) => response.request());
+          const request = response
+            .then((response) => response.request())
+            .catch(() => null);
 
           const result = await awaiter(page, timeout);
 

--- a/packages/alfa-scraper/src/scraper.ts
+++ b/packages/alfa-scraper/src/scraper.ts
@@ -8,6 +8,7 @@ import {
   Request,
   Response,
 } from "@siteimprove/alfa-http";
+import { Mapper } from "@siteimprove/alfa-mapper";
 import { Puppeteer } from "@siteimprove/alfa-puppeteer";
 import { Result, Ok, Err } from "@siteimprove/alfa-result";
 import { Timeout } from "@siteimprove/alfa-time";
@@ -34,6 +35,17 @@ export class Scraper {
     })
   ): Promise<Scraper> {
     return new Scraper(await browser);
+  }
+
+  public static async with<T>(
+    mapper: Mapper<Scraper, Promise<T>>,
+    browser?: Promise<puppeteer.Browser>
+  ): Promise<T> {
+    const scraper = await this.of(browser);
+    const result = await mapper(scraper);
+
+    await scraper.close();
+    return result;
   }
 
   private readonly _browser: puppeteer.Browser;

--- a/packages/alfa-scraper/src/scraper.ts
+++ b/packages/alfa-scraper/src/scraper.ts
@@ -124,11 +124,10 @@ export class Scraper {
         try {
           const response = page
             .goto(origin, { timeout: timeout.remaining() })
-            .catch(() => null)
-            .then((response) => response!);
+            .catch(() => null);
 
           const request = response
-            .then((response) => response.request())
+            .then((response) => response!.request())
             .catch(() => null);
 
           const result = await awaiter(page, timeout);
@@ -145,8 +144,8 @@ export class Scraper {
 
           return Ok.of(
             Page.of(
-              parseRequest(await request),
-              await parseResponse(await response),
+              parseRequest((await request)!),
+              await parseResponse((await response)!),
               document,
               device
             )

--- a/packages/alfa-scraper/test/fixture/internal-link.html
+++ b/packages/alfa-scraper/test/fixture/internal-link.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+
+<a href="#foo"></a>
+
+<div id="foo"></div>

--- a/packages/alfa-scraper/test/fixture/location-change-delayed.html
+++ b/packages/alfa-scraper/test/fixture/location-change-delayed.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+
+<script>
+  setTimeout(() => {
+    window.location = "https://example.com";
+  }, 5000);
+</script>

--- a/packages/alfa-scraper/test/fixture/location-change-immediate.html
+++ b/packages/alfa-scraper/test/fixture/location-change-immediate.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+
+<script>
+  window.location = "https://example.com";
+</script>

--- a/packages/alfa-scraper/test/fixture/meta-refresh-delayed.html
+++ b/packages/alfa-scraper/test/fixture/meta-refresh-delayed.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+
+<meta http-equiv="refresh" content="5; https://example.com" />

--- a/packages/alfa-scraper/test/fixture/meta-refresh-immediate.html
+++ b/packages/alfa-scraper/test/fixture/meta-refresh-immediate.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+
+<meta http-equiv="refresh" content="0; https://example.com" />

--- a/packages/alfa-scraper/test/scraper.spec.ts
+++ b/packages/alfa-scraper/test/scraper.spec.ts
@@ -37,3 +37,27 @@ test("#scrape() scrapes a page with a delayed meta refresh", async (t) =>
 
     t.equal(response.url, url);
   }));
+
+test("#scrape() scrapes a page with an immediate location change", async (t) =>
+  await Scraper.with(async (scraper) => {
+    const url = `file://${__dirname}/fixture/location-change-immediate.html`;
+    const result = await scraper.scrape(url);
+
+    t.equal(result.isOk(), true);
+
+    const { response } = result.get();
+
+    t.equal(response.url, "https://example.com/");
+  }));
+
+test("#scrape() scrapes a page with a delayed location change", async (t) =>
+  await Scraper.with(async (scraper) => {
+    const url = `file://${__dirname}/fixture/location-change-delayed.html`;
+    const result = await scraper.scrape(url);
+
+    t.equal(result.isOk(), true);
+
+    const { response } = result.get();
+
+    t.equal(response.url, url);
+  }));

--- a/packages/alfa-scraper/test/scraper.spec.ts
+++ b/packages/alfa-scraper/test/scraper.spec.ts
@@ -1,0 +1,39 @@
+import { test } from "@siteimprove/alfa-test";
+
+import { Scraper } from "../src/scraper";
+
+test("#scrape() scrapes a page with a hash fragment", async (t) =>
+  await Scraper.with(async (scraper) => {
+    const url = `file://${__dirname}/fixture/internal-link.html`;
+    const result = await scraper.scrape(url + "#foo");
+
+    t.equal(result.isOk(), true);
+
+    const { response } = result.get();
+
+    t.equal(response.url, url);
+  }));
+
+test("#scrape() scrapes a page with an immediate meta refresh", async (t) =>
+  await Scraper.with(async (scraper) => {
+    const url = `file://${__dirname}/fixture/meta-refresh-immediate.html`;
+    const result = await scraper.scrape(url);
+
+    t.equal(result.isOk(), true);
+
+    const { response } = result.get();
+
+    t.equal(response.url, "https://example.com/");
+  }));
+
+test("#scrape() scrapes a page with a delayed meta refresh", async (t) =>
+  await Scraper.with(async (scraper) => {
+    const url = `file://${__dirname}/fixture/meta-refresh-delayed.html`;
+    const result = await scraper.scrape(url);
+
+    t.equal(result.isOk(), true);
+
+    const { response } = result.get();
+
+    t.equal(response.url, url);
+  }));

--- a/packages/alfa-scraper/tsconfig.json
+++ b/packages/alfa-scraper/tsconfig.json
@@ -17,9 +17,6 @@
       "path": "../alfa-dom"
     },
     {
-      "path": "../alfa-encoding"
-    },
-    {
       "path": "../alfa-equatable"
     },
     {

--- a/packages/alfa-scraper/tsconfig.json
+++ b/packages/alfa-scraper/tsconfig.json
@@ -6,7 +6,8 @@
     "src/credentials.ts",
     "src/index.ts",
     "src/scraper.ts",
-    "src/screenshot.ts"
+    "src/screenshot.ts",
+    "test/scraper.spec.ts"
   ],
   "references": [
     {


### PR DESCRIPTION
Previously, scraping a page whose URL contained a hash fragment (`https://example.com/#foo`) would fail for reasons that are still not entirely clear. The internals of the `#scrape()` has grown fairly complicated to deal with immediate client side redirects; this has been simplified and requests are now simply retried with the new URL upon encountering a redirect.