### PR TITLE
Implement support for CSS Custom Properties

### DIFF
--- a/packages/alfa-css/src/syntax.ts
+++ b/packages/alfa-css/src/syntax.ts
@@ -1,3 +1,5 @@
+export * from "./syntax/block";
+export * from "./syntax/component";
 export * from "./syntax/declaration";
 export * from "./syntax/lexer";
 export * from "./syntax/token";

--- a/packages/alfa-dom/src/h.ts
+++ b/packages/alfa-dom/src/h.ts
@@ -140,7 +140,13 @@ export namespace h {
 
             value = value.replace(/!important$/, "").trim();
 
-            return Declaration.of(hyphenate(name), value, important);
+            // Hyphenate the declaration name unless it's the name of a custom
+            // property; these we keep as-is.
+            if (!name.startsWith("--")) {
+              name = hyphenate(name);
+            }
+
+            return Declaration.of(name, value, important);
           })
     );
   }

--- a/packages/alfa-either/src/either.ts
+++ b/packages/alfa-either/src/either.ts
@@ -10,7 +10,7 @@ import { Reducer } from "@siteimprove/alfa-reducer";
 import { Left } from "./left";
 import { Right } from "./right";
 
-export interface Either<L, R>
+export interface Either<L, R = L>
   extends Monad<L | R>,
     Functor<L | R>,
     Foldable<L | R>,
@@ -34,5 +34,13 @@ export namespace Either {
 
   export function isEither<L, R>(value: unknown): value is Either<L, R> {
     return Left.isLeft(value) || Right.isRight(value);
+  }
+
+  export function left<L>(value: L): Either<L, never> {
+    return Left.of(value);
+  }
+
+  export function right<R>(value: R): Either<never, R> {
+    return Right.of(value);
   }
 }

--- a/packages/alfa-style/package.json
+++ b/packages/alfa-style/package.json
@@ -23,6 +23,7 @@
     "@siteimprove/alfa-css": "^0.3.0",
     "@siteimprove/alfa-device": "^0.3.0",
     "@siteimprove/alfa-dom": "^0.3.0",
+    "@siteimprove/alfa-either": "^0.3.0",
     "@siteimprove/alfa-equatable": "^0.3.0",
     "@siteimprove/alfa-functor": "^0.3.0",
     "@siteimprove/alfa-iterable": "^0.3.0",

--- a/packages/alfa-style/package.json
+++ b/packages/alfa-style/package.json
@@ -34,6 +34,7 @@
     "@siteimprove/alfa-option": "^0.3.0",
     "@siteimprove/alfa-parser": "^0.3.0",
     "@siteimprove/alfa-record": "^0.3.0",
+    "@siteimprove/alfa-set": "^0.3.0",
     "@siteimprove/alfa-slice": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/alfa-style/src/property.ts
+++ b/packages/alfa-style/src/property.ts
@@ -95,9 +95,7 @@ export namespace Property {
      *
      * @see https://drafts.csswg.org/css-cascade/#cascaded
      */
-    export type Cascaded<N extends Name> =
-      | Parsed<N>
-      | Keyword<"initial" | "inherit" | "unset">;
+    export type Cascaded<N extends Name> = Declared<N>;
 
     /**
      * Extract the specified type of a named property.

--- a/packages/alfa-style/src/property.ts
+++ b/packages/alfa-style/src/property.ts
@@ -62,6 +62,14 @@ export namespace Property {
   export type Parser<T> = parser.Parser<Slice<Token>, T, string>;
 
   export namespace Value {
+    /**
+     * Extract the parsed type of a named property.
+     *
+     * @remarks
+     * The parsed type differs from the declared type in that the parsed type
+     * must not include the defaulting keywords as these are handled globally
+     * rather than individually.
+     */
     export type Parsed<N extends Name> = WithName<N> extends Property<
       infer T,
       infer U
@@ -69,33 +77,56 @@ export namespace Property {
       ? T
       : never;
 
-    export type Initial<N extends Name> = WithName<N> extends Property<
-      infer T,
-      infer U
-    >
-      ? U
-      : never;
+    /**
+     * Extract the declared type of a named property.
+     *
+     * @see https://drafts.csswg.org/css-cascade/#declared
+     *
+     * @remarks
+     * The declared type includes the parsed type in addition to the defaulting
+     * keywords recognised by all properties.
+     */
+    export type Declared<N extends Name> =
+      | Parsed<N>
+      | Keyword<"initial" | "inherit" | "unset">;
 
-    export type Cascaded<N extends Name> = WithName<N> extends Property<
-      infer T,
-      infer U
-    >
-      ? T | Keyword<"initial" | "inherit">
-      : never;
+    /**
+     * Extract the cascaded type of a named property.
+     *
+     * @see https://drafts.csswg.org/css-cascade/#cascaded
+     */
+    export type Cascaded<N extends Name> =
+      | Parsed<N>
+      | Keyword<"initial" | "inherit" | "unset">;
 
-    export type Specified<N extends Name> = WithName<N> extends Property<
-      infer T,
-      infer U
-    >
-      ? T | U
-      : never;
+    /**
+     * Extract the specified type of a named property.
+     *
+     * @see https://drafts.csswg.org/css-cascade/#specified
+     */
+    export type Specified<N extends Name> = Parsed<N> | Computed<N>;
 
+    /**
+     * Extract the computed type a named property.
+     *
+     * @see https://drafts.csswg.org/css-cascade/#computed
+     */
     export type Computed<N extends Name> = WithName<N> extends Property<
       infer T,
       infer U
     >
       ? U
       : never;
+
+    /**
+     * Extract the initial type of a named property.
+     */
+    export type Initial<N extends Name> = Computed<N>;
+
+    /**
+     * Extract the inherited type of a named property.
+     */
+    export type Inherited<N extends Name> = Computed<N>;
   }
 }
 

--- a/packages/alfa-style/src/property/overflow.ts
+++ b/packages/alfa-style/src/property/overflow.ts
@@ -61,7 +61,7 @@ export namespace Overflow {
   export const Shorthand = Property.Shorthand.of(
     ["overflow-x", "overflow-y"],
     map(
-      pair(X.parse, option(delimited(Token.parseWhitespace, Y.parse))),
+      pair(X.parse, option(delimited(option(Token.parseWhitespace), Y.parse))),
       (result) => {
         const [x, y] = result;
 

--- a/packages/alfa-style/src/style.ts
+++ b/packages/alfa-style/src/style.ts
@@ -1,8 +1,9 @@
 import { Cache } from "@siteimprove/alfa-cache";
 import { Cascade } from "@siteimprove/alfa-cascade";
-import { Lexer, Keyword, Token } from "@siteimprove/alfa-css";
+import { Lexer, Keyword, Component, Token } from "@siteimprove/alfa-css";
 import { Device } from "@siteimprove/alfa-device";
 import { Element, Declaration, Document, Shadow } from "@siteimprove/alfa-dom";
+import { Either } from "@siteimprove/alfa-either";
 import { Iterable } from "@siteimprove/alfa-iterable";
 import { Serializable } from "@siteimprove/alfa-json";
 import { None, Option } from "@siteimprove/alfa-option";
@@ -15,7 +16,7 @@ import * as json from "@siteimprove/alfa-json";
 import { Property } from "./property";
 import { Value } from "./value";
 
-const { either, left, eof } = Parser;
+const { takeUntil, map, either, option, pair, right, left, eof } = Parser;
 
 type Name = Property.Name;
 
@@ -36,6 +37,7 @@ export class Style implements Serializable {
 
   private readonly _device: Device;
   private readonly _parent: Option<Style>;
+  private readonly _variables = new Map<string, Array<Token>>();
 
   // We cache cascaded and computed properties but not specified properties as
   // these are inexpensive to resolve from cascaded and computed properties.
@@ -52,6 +54,18 @@ export class Style implements Serializable {
     this._device = device;
     this._parent = parent;
 
+    // First pass: Resolve cascading variables which will be used in the second
+    // pass.
+    for (const declaration of declarations) {
+      const { name, value } = declaration;
+
+      if (name.startsWith("--") && !this._variables.has(name)) {
+        this._variables.set(name, Lexer.lex(value));
+      }
+    }
+
+    // Second pass: Resolve cascading properties using the cascading variables
+    // from the first pass.
     for (const declaration of declarations) {
       const { name, value } = declaration;
 
@@ -64,7 +78,7 @@ export class Style implements Serializable {
         ) {
           const property = Property.get(name);
 
-          for (const result of parse(property, value)) {
+          for (const result of this._parseLonghand(property, value)) {
             this._cascaded.set(name, Value.of(result, Option.of(declaration)));
           }
         }
@@ -73,7 +87,7 @@ export class Style implements Serializable {
       if (Property.Shorthand.isName(name)) {
         const shorthand = Property.Shorthand.get(name);
 
-        for (const result of parseShorthand(shorthand, value)) {
+        for (const result of this._parseShorthand(shorthand, value)) {
           for (const [name, value] of result) {
             const previous = this._cascaded.get(name);
 
@@ -101,38 +115,41 @@ export class Style implements Serializable {
     return this._parent.map((parent) => parent.root()).getOr(this);
   }
 
-  public initial<N extends Name>(name: N): Value<Style.Initial<N>>;
-  public initial<N extends Name>(name: N): Value {
-    const property = Property.get(name);
-
-    return Value.of(property.initial);
+  public cascaded<N extends Name>(name: N): Option<Value<Style.Cascaded<N>>> {
+    return Option.from(
+      this._cascaded.get(name) as Value<Style.Cascaded<N>> | undefined
+    );
   }
 
-  public cascaded<N extends Name>(name: N): Option<Value<Style.Cascaded<N>>>;
-  public cascaded<N extends Name>(name: N): Option<Value> {
-    return Option.from(this._cascaded.get(name));
-  }
+  public specified<N extends Name>(name: N): Value<Style.Specified<N>> {
+    const {
+      options: { inherits },
+    } = Property.get(name);
 
-  public specified<N extends Name>(name: N): Value<Style.Specified<N>>;
-  public specified<N extends Name>(name: N): Value {
     return this.cascaded(name)
       .map((cascaded) => {
-        if (Keyword.isKeyword(cascaded.value)) {
-          switch (cascaded.value.value) {
+        const { value, source } = cascaded;
+
+        if (Keyword.isKeyword(value)) {
+          switch (value.value) {
+            // https://drafts.csswg.org/css-cascade/#initial
             case "initial":
               return this.initial(name);
 
+            // https://drafts.csswg.org/css-cascade/#inherit
             case "inherit":
-              return this.parent.computed(name);
+              return this.inherited(name);
+
+            // https://drafts.csswg.org/css-cascade/#inherit-initial
+            case "unset":
+              return inherits ? this.inherited(name) : this.initial(name);
           }
         }
 
-        return cascaded;
+        return Value.of(value, source);
       })
       .getOrElse(() => {
-        const property = Property.get(name);
-
-        if (property.options.inherits === false) {
+        if (inherits === false) {
           return this.initial(name);
         }
 
@@ -142,16 +159,17 @@ export class Style implements Serializable {
       });
   }
 
-  public computed<N extends Name>(name: N): Value<Style.Computed<N>>;
-  public computed<N extends Name>(name: N): Value {
+  public computed<N extends Name>(name: N): Value<Style.Computed<N>> {
     if (this === Style._empty) {
       return this.initial(name);
     }
 
-    let value = this._computed.get(name);
+    let value = this._computed.get(name) as
+      | Value<Style.Computed<N>>
+      | undefined;
 
     if (value === undefined) {
-      value = Property.get(name).compute(this);
+      value = Property.get(name).compute(this) as Value<Style.Computed<N>>;
 
       this._computed.set(name, value);
     }
@@ -159,8 +177,190 @@ export class Style implements Serializable {
     return value;
   }
 
+  public initial<N extends Name>(name: N): Value<Style.Initial<N>> {
+    return Value.of(Property.get(name).initial as Style.Computed<N>);
+  }
+
+  public inherited<N extends Name>(name: N): Value<Style.Inherited<N>> {
+    return this.parent.computed(name);
+  }
+
   public toJSON(): Style.JSON {
     return {};
+  }
+
+  private _parseLonghand<N extends Property.Name>(
+    property: Property.WithName<N>,
+    value: string
+  ) {
+    const tokens = this._substitute(Lexer.lex(value));
+
+    if (tokens.isNone()) {
+      return Option.of(Keyword.of("unset"));
+    }
+
+    const result = left(
+      either(
+        Keyword.parse("initial", "inherit", "unset"),
+        property.parse as Parser<Slice<Token>, Property.Value.Parsed<N>, string>
+      ),
+      eof(() => "Expected end of input")
+    )(Slice.of(tokens.get().get()))
+      .map(([, value]) => value)
+      .ok();
+
+    if (result.isNone() && tokens.get().isRight()) {
+      return Option.of(Keyword.of("unset"));
+    }
+
+    return result;
+  }
+
+  private _parseShorthand<N extends Property.Shorthand.Name>(
+    shorthand: Property.Shorthand.WithName<N>,
+    value: string
+  ) {
+    const tokens = this._substitute(Lexer.lex(value));
+
+    if (tokens.isNone()) {
+      return Option.of(
+        Record.from(
+          Iterable.map(shorthand.properties, (property) => [
+            property,
+            Keyword.of("unset"),
+          ])
+        )
+      );
+    }
+
+    const result = left(
+      either(
+        Keyword.parse("initial", "inherit", "unset"),
+        shorthand.parse as Parser<
+          Slice<Token>,
+          Record<{ [N in Property.Name]?: Property.Value.Parsed<N> }>,
+          string
+        >
+      ),
+      eof(() => "Expected end of input")
+    )(Slice.of(tokens.get().get()))
+      .map(([, value]) => {
+        if (Keyword.isKeyword(value)) {
+          return Record.from(
+            Iterable.map(shorthand.properties, (property) => [property, value])
+          );
+        }
+
+        return value;
+      })
+      .ok();
+
+    if (result.isNone() && tokens.get().isRight()) {
+      return Option.of(
+        Record.from(
+          Iterable.map(shorthand.properties, (property) => [
+            property,
+            Keyword.of("unset"),
+          ])
+        )
+      );
+    }
+
+    return result;
+  }
+
+  /**
+   * Resolve a cascading variable with an optional fallback. The value of the
+   * variable, if defined, will have `var()` functions fully substituted.
+   *
+   * @remarks
+   * This method uses a set of visited names to detect cyclic dependencies
+   * between cascading variables. The set is local to each `Style` instance as
+   * cyclic references can only occur between cascading variables defined on the
+   * same element.
+   */
+  private _variable(
+    name: string,
+    fallback: Option<Array<Token>> = None,
+    visited?: Set<string>
+  ): Option<Array<Token>> {
+    return Option.from(this._variables.get(name))
+      .or(fallback)
+      .map((tokens) =>
+        this._substitute(tokens, visited).map((substituted) =>
+          substituted.get()
+        )
+      )
+      .getOrElse(() =>
+        this._parent.flatMap((parent) =>
+          parent
+            ._variable(name)
+            .flatMap((tokens) =>
+              parent._substitute(tokens).map((substituted) => substituted.get())
+            )
+        )
+      );
+  }
+
+  /**
+   * Substitute `var()` functions in an array of tokens. If any tokens are
+   * substituted, the result will be wrapped in `Right`, otherwise `Left`. If
+   * any syntactically invalid `var()` functions are encountered, `None` is
+   * returned.
+   *
+   * @see https://drafts.csswg.org/css-variables/#substitute-a-var
+   *
+   * @remarks
+   * This method uses a set of visited names to detect cyclic dependencies
+   * between cascading variables. The set is local to each `Style` instance as
+   * cyclic references can only occur between cascading variables defined on the
+   * same element.
+   */
+  private _substitute(
+    tokens: Array<Token>,
+    visited = new Set<string>()
+  ): Option<Either<Array<Token>>> {
+    const replaced: Array<Token> = [];
+
+    let offset = 0;
+    let substituted = false;
+
+    while (offset < tokens.length) {
+      const next = tokens[offset];
+
+      if (next.type === "function" && next.value === "var") {
+        const result = parseVar(Slice.of(tokens, offset));
+
+        if (result.isErr()) {
+          return None;
+        }
+
+        const [remainder, [name, fallback]] = result.get();
+
+        if (visited.has(name.value)) {
+          return None;
+        }
+
+        visited.add(name.value);
+
+        const value = this._variable(name.value, fallback, visited);
+
+        if (value.isNone()) {
+          return None;
+        }
+
+        replaced.push(...value.get());
+        offset = remainder.offset;
+        substituted = true;
+      } else {
+        replaced.push(next);
+        offset++;
+      }
+    }
+
+    return Option.of(
+      substituted ? Either.right(replaced) : Either.left(replaced)
+    );
   }
 }
 
@@ -203,55 +403,17 @@ export namespace Style {
     });
   }
 
-  export type Initial<N extends Name> = Property.Value.Initial<N>;
+  export type Declared<N extends Name> = Property.Value.Declared<N>;
 
   export type Cascaded<N extends Name> = Property.Value.Cascaded<N>;
 
   export type Specified<N extends Name> = Property.Value.Specified<N>;
 
   export type Computed<N extends Name> = Property.Value.Computed<N>;
-}
 
-function parse<N extends Property.Name>(
-  property: Property.WithName<N>,
-  value: string
-) {
-  return left(
-    either(
-      Keyword.parse("initial", "inherit"),
-      property.parse as Parser<Slice<Token>, Property.Value.Parsed<N>, string>
-    ),
-    eof(() => "Expected end of input")
-  )(Slice.of(Lexer.lex(value)))
-    .map(([, value]) => value)
-    .ok();
-}
+  export type Initial<N extends Name> = Property.Value.Initial<N>;
 
-function parseShorthand<N extends Property.Shorthand.Name>(
-  shorthand: Property.Shorthand.WithName<N>,
-  value: string
-) {
-  return left(
-    either(
-      Keyword.parse("initial", "inherit"),
-      shorthand.parse as Parser<
-        Slice<Token>,
-        Record<{ [N in Property.Name]?: Property.Value.Parsed<N> }>,
-        string
-      >
-    ),
-    eof(() => "Expected end of input")
-  )(Slice.of(Lexer.lex(value)))
-    .map(([, value]) => {
-      if (Keyword.isKeyword(value)) {
-        return Record.from(
-          Iterable.map(shorthand.properties, (property) => [property, value])
-        );
-      }
-
-      return value;
-    })
-    .ok();
+  export type Inherited<N extends Name> = Property.Value.Inherited<N>;
 }
 
 function shouldOverride(
@@ -262,3 +424,25 @@ function shouldOverride(
     next.important && previous.every((declaration) => !declaration.important)
   );
 }
+
+/**
+ * @see https://drafts.csswg.org/css-variables/#funcdef-var
+ */
+const parseVar = right(
+  Token.parseFunction("var"),
+  pair(
+    Token.parseIdent((ident) => ident.value.startsWith("--")),
+    left(
+      option(
+        right(
+          pair(Token.parseComma, option(Token.parseWhitespace)),
+          map(
+            takeUntil(Component.consume, Token.parseCloseParenthesis),
+            (components) => [...Iterable.flatten(components)]
+          )
+        )
+      ),
+      Token.parseCloseParenthesis
+    )
+  )
+);

--- a/packages/alfa-style/test/style.spec.tsx
+++ b/packages/alfa-style/test/style.spec.tsx
@@ -362,6 +362,41 @@ test(`#cascaded() expands multiple var() functions in the same declaration`, (t)
   });
 });
 
+test(`#cascaded() expands several var() function references to the same variable`, (t) => {
+  const element = <div />;
+
+  h.document(
+    [element],
+    [
+      h.sheet([
+        h.rule.style("div", {
+          overflow: "var(--hidden) var(--hidden)",
+
+          "--hidden": "hidden",
+        }),
+      ]),
+    ]
+  );
+
+  const style = Style.from(element, Device.standard());
+
+  t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
+    value: {
+      type: "keyword",
+      value: "hidden",
+    },
+    source: h.declaration("overflow", "var(--hidden) var(--hidden)").toJSON(),
+  });
+
+  t.deepEqual(style.cascaded("overflow-y").get().toJSON(), {
+    value: {
+      type: "keyword",
+      value: "hidden",
+    },
+    source: h.declaration("overflow", "var(--hidden) var(--hidden)").toJSON(),
+  });
+});
+
 test(`#cascaded() returns "unset" when a var() function variable isn't defined`, (t) => {
   const element = <div />;
 
@@ -492,6 +527,62 @@ test(`#cascaded() returns "unset" when var() functions contain cyclic references
       value: "unset",
     },
     source: h.declaration("overflow-x", "var(--hidden)").toJSON(),
+  });
+});
+
+test(`#cascaded() returns "unset" when confronted with a billion laughs`, (t) => {
+  const element = <div />;
+
+  h.document(
+    [element],
+    [
+      h.sheet([
+        h.rule.style("div", {
+          overflowX: "var(--prop30)",
+
+          "--prop1": "lol",
+          "--prop2": "var(--prop1) var(--prop1)",
+          "--prop3": "var(--prop2) var(--prop2)",
+          "--prop4": "var(--prop3) var(--prop3)",
+          "--prop5": "var(--prop4) var(--prop4)",
+          "--prop6": "var(--prop5) var(--prop5)",
+          "--prop7": "var(--prop6) var(--prop6)",
+          "--prop8": "var(--prop7) var(--prop7)",
+          "--prop9": "var(--prop8) var(--prop8)",
+          "--prop10": "var(--prop9) var(--prop9)",
+          "--prop11": "var(--prop10) var(--prop10)",
+          "--prop12": "var(--prop11) var(--prop11)",
+          "--prop13": "var(--prop12) var(--prop12)",
+          "--prop14": "var(--prop13) var(--prop13)",
+          "--prop15": "var(--prop14) var(--prop14)",
+          "--prop16": "var(--prop15) var(--prop15)",
+          "--prop17": "var(--prop16) var(--prop16)",
+          "--prop18": "var(--prop17) var(--prop17)",
+          "--prop19": "var(--prop18) var(--prop18)",
+          "--prop20": "var(--prop19) var(--prop19)",
+          "--prop21": "var(--prop20) var(--prop20)",
+          "--prop22": "var(--prop21) var(--prop21)",
+          "--prop23": "var(--prop22) var(--prop22)",
+          "--prop24": "var(--prop23) var(--prop23)",
+          "--prop25": "var(--prop24) var(--prop24)",
+          "--prop26": "var(--prop25) var(--prop25)",
+          "--prop27": "var(--prop26) var(--prop26)",
+          "--prop28": "var(--prop27) var(--prop27)",
+          "--prop29": "var(--prop28) var(--prop28)",
+          "--prop30": "var(--prop29) var(--prop29)",
+        }),
+      ]),
+    ]
+  );
+
+  const style = Style.from(element, Device.standard());
+
+  t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
+    value: {
+      type: "keyword",
+      value: "unset",
+    },
+    source: h.declaration("overflow-x", "var(--prop30)").toJSON(),
   });
 });
 

--- a/packages/alfa-style/tsconfig.json
+++ b/packages/alfa-style/tsconfig.json
@@ -72,6 +72,9 @@
       "path": "../alfa-record"
     },
     {
+      "path": "../alfa-set"
+    },
+    {
       "path": "../alfa-slice"
     },
     {

--- a/packages/alfa-style/tsconfig.json
+++ b/packages/alfa-style/tsconfig.json
@@ -39,6 +39,9 @@
       "path": "../alfa-dom"
     },
     {
+      "path": "../alfa-either"
+    },
+    {
       "path": "../alfa-equatable"
     },
     {


### PR DESCRIPTION
I had a head full of ideas and an evening to spare so I went ahead with an implementation of custom properties. The implementation exposes no additional public API surface and so everything is dealt with transparently behind the scenes. The majority of the code introduced is additional test cases to exercise the many corners of the specification.

I also snuck in a variadic version of `Parser.either()` that should satisfy part of #292.

Closes #293.