### PR TITLE
Fix several CSS component syntax and custom property issues

### DIFF
--- a/packages/alfa-css/src/syntax.ts
+++ b/packages/alfa-css/src/syntax.ts
@@ -1,5 +1,6 @@
 export * from "./syntax/block";
 export * from "./syntax/component";
 export * from "./syntax/declaration";
+export * from "./syntax/function";
 export * from "./syntax/lexer";
 export * from "./syntax/token";

--- a/packages/alfa-css/src/syntax/declaration.ts
+++ b/packages/alfa-css/src/syntax/declaration.ts
@@ -2,7 +2,7 @@ import { Equatable } from "@siteimprove/alfa-equatable";
 import { Serializable } from "@siteimprove/alfa-json";
 import { Parser } from "@siteimprove/alfa-parser";
 import { Predicate } from "@siteimprove/alfa-predicate";
-import { Err, Ok } from "@siteimprove/alfa-result";
+import { Err, Result } from "@siteimprove/alfa-result";
 import { Slice } from "@siteimprove/alfa-slice";
 
 import * as json from "@siteimprove/alfa-json";
@@ -10,18 +10,18 @@ import * as json from "@siteimprove/alfa-json";
 import { Component } from "./component";
 import { Token } from "./token";
 
-const { or, not } = Predicate;
+const { not } = Predicate;
 
 /**
  * @see https://drafts.csswg.org/css-syntax/#declaration
  */
-export class Declaration implements Equatable, Serializable {
+export class Declaration implements Iterable<Token>, Equatable, Serializable {
   public static of(
     name: string,
-    value: Array<Token>,
+    value: Iterable<Token>,
     important = false
   ): Declaration {
-    return new Declaration(name, value, important);
+    return new Declaration(name, Array.from(value), important);
   }
 
   private readonly _name: string;
@@ -44,6 +44,21 @@ export class Declaration implements Equatable, Serializable {
 
   public get important(): boolean {
     return this._important;
+  }
+
+  public *[Symbol.iterator](): Iterator<Token> {
+    // <name>:
+    yield Token.Ident.of(this._name);
+    yield Token.Colon.of();
+
+    // <value>
+    yield* this._value;
+
+    if (this._important) {
+      // !important
+      yield Token.Delim.of(0x21);
+      yield Token.Ident.of("important");
+    }
   }
 
   public equals(value: unknown): value is this {
@@ -83,11 +98,10 @@ export namespace Declaration {
    * @see https://drafts.csswg.org/css-syntax/#consume-a-declaration
    */
   export const consume: Parser<Slice<Token>, Declaration, string> = (input) => {
-    const name = input.get(0).get().toString();
+    const name = input.get(0).filter(Token.isIdent).get().value;
+    const value: Array<Token> = [];
 
     input = input.slice(1);
-
-    const value: Array<Token> = [];
 
     while (input.get(0).some(Token.isWhitespace)) {
       input = input.slice(1);
@@ -103,7 +117,7 @@ export namespace Declaration {
       input = input.slice(1);
     }
 
-    while (input.length !== 0) {
+    while (input.length > 0) {
       const [remainder, component] = Component.consume(input).get();
 
       input = remainder;
@@ -135,7 +149,7 @@ export namespace Declaration {
       }
     }
 
-    return Ok.of([input, Declaration.of(name, value, important)] as const);
+    return Result.of([input, Declaration.of(name, value, important)]);
   };
 
   /**
@@ -148,7 +162,7 @@ export namespace Declaration {
 
     let next = input.get(0);
 
-    if (next.every(not(Token.isIdent))) {
+    if (next.none(Token.isIdent)) {
       return Err.of("Expected an ident");
     }
 
@@ -165,30 +179,26 @@ export namespace Declaration {
   > = (input) => {
     const declarations: Array<Declaration> = [];
 
-    while (true) {
-      const next = input.get(0);
-
-      if (next.isNone()) {
-        return Ok.of([input, declarations] as const);
-      }
+    while (input.length > 0) {
+      const next = input.get(0).get();
 
       input = input.slice(1);
 
-      if (next.some(or(Token.isWhitespace, Token.isSemicolon))) {
+      if (Token.isWhitespace(next) || Token.isSemicolon(next)) {
         continue;
       }
 
-      if (next.some(Token.isIdent)) {
-        const tokens: Array<Token> = [next.get()];
+      if (Token.isIdent(next)) {
+        const value: Array<Token> = [next];
 
         while (input.get(0).some(not(Token.isSemicolon))) {
           const [remainder, component] = Component.consume(input).get();
 
           input = remainder;
-          tokens.push(...component);
+          value.push(...component);
         }
 
-        const result = consume(Slice.of(tokens));
+        const result = consume(Slice.of(value));
 
         if (result.isOk()) {
           declarations.push(result.get()[1]);
@@ -201,6 +211,8 @@ export namespace Declaration {
         }
       }
     }
+
+    return Result.of([input, declarations]);
   };
 
   /**

--- a/packages/alfa-css/src/syntax/function.ts
+++ b/packages/alfa-css/src/syntax/function.ts
@@ -1,0 +1,100 @@
+import { Equatable } from "@siteimprove/alfa-equatable";
+import { Serializable } from "@siteimprove/alfa-json";
+import { Parser } from "@siteimprove/alfa-parser";
+import { Slice } from "@siteimprove/alfa-slice";
+import { Result } from "@siteimprove/alfa-result";
+
+import * as json from "@siteimprove/alfa-json";
+
+import { Component } from "./component";
+import { Token } from "./token";
+
+/**
+ * @see https://drafts.csswg.org/css-syntax/#function
+ */
+export class Function implements Iterable<Token>, Equatable, Serializable {
+  public static of(name: string, value: Iterable<Token>): Function {
+    return new Function(name, Array.from(value));
+  }
+
+  private readonly _name: string;
+  private readonly _value: Array<Token>;
+
+  private constructor(name: string, value: Array<Token>) {
+    this._name = name;
+    this._value = value;
+  }
+
+  public get name(): string {
+    return this._name;
+  }
+
+  public get value(): Array<Token> {
+    return this._value;
+  }
+
+  public *[Symbol.iterator](): Iterator<Token> {
+    // <name>(
+    yield Token.Function.of(this._name);
+
+    // <value>
+    yield* this._value;
+
+    // )
+    yield Token.CloseParenthesis.of();
+  }
+
+  public equals(value: unknown): value is this {
+    return (
+      value instanceof Function &&
+      value._name === this._name &&
+      value._value.length === this._value.length &&
+      value._value.every((token, i) => token.equals(this._value[i]))
+    );
+  }
+
+  public toJSON(): Function.JSON {
+    return {
+      name: this._name,
+      value: this._value.map((token) => token.toJSON()),
+    };
+  }
+
+  public toString(): string {
+    return `${this._name}(${this._value.join("")})`;
+  }
+}
+
+export namespace Function {
+  export interface JSON {
+    [key: string]: json.JSON;
+    name: string;
+    value: Array<Token.JSON>;
+  }
+
+  /**
+   * @see https://drafts.csswg.org/css-syntax/#consume-a-function
+   */
+  export const consume: Parser<Slice<Token>, Function> = (input) => {
+    const name = input.get(0).filter(Token.isFunction).get().value;
+    const value: Array<Token> = [];
+
+    input = input.slice(1);
+
+    while (input.length > 0) {
+      const next = input.get(0).get();
+
+      if (Token.isCloseParenthesis(next)) {
+        input = input.slice(1);
+        break;
+      }
+
+      const [remainder, component] = Component.consume(input).get();
+
+      input = remainder;
+      value.push(...component);
+    }
+
+    return Result.of([input, Function.of(name, value)]);
+  };
+}

--- a/packages/alfa-css/src/syntax/token.ts
+++ b/packages/alfa-css/src/syntax/token.ts
@@ -155,6 +155,10 @@ export namespace Token {
       return this._value;
     }
 
+    public get mirror(): CloseParenthesis {
+      return CloseParenthesis.of();
+    }
+
     public equals(value: unknown): value is this {
       return value instanceof Function && value._value === this._value;
     }
@@ -908,6 +912,10 @@ export namespace Token {
       return "open-parenthesis";
     }
 
+    public get mirror(): CloseParenthesis {
+      return CloseParenthesis.of();
+    }
+
     public equals(value: unknown): value is this {
       return value instanceof OpenParenthesis;
     }
@@ -946,6 +954,10 @@ export namespace Token {
 
     public get type(): "close-parenthesis" {
       return "close-parenthesis";
+    }
+
+    public get mirror(): OpenParenthesis {
+      return OpenParenthesis.of();
     }
 
     public equals(value: unknown): value is this {
@@ -990,6 +1002,10 @@ export namespace Token {
       return "open-square-bracket";
     }
 
+    public get mirror(): CloseSquareBracket {
+      return CloseSquareBracket.of();
+    }
+
     public equals(value: unknown): value is this {
       return value instanceof OpenSquareBracket;
     }
@@ -1030,6 +1046,10 @@ export namespace Token {
 
     public get type(): "close-square-bracket" {
       return "close-square-bracket";
+    }
+
+    public get mirror(): OpenSquareBracket {
+      return OpenSquareBracket.of();
     }
 
     public equals(value: unknown): value is this {
@@ -1074,6 +1094,10 @@ export namespace Token {
       return "open-curly-bracket";
     }
 
+    public get mirror(): CloseCurlyBracket {
+      return CloseCurlyBracket.of();
+    }
+
     public equals(value: unknown): value is this {
       return value instanceof OpenCurlyBracket;
     }
@@ -1114,6 +1138,10 @@ export namespace Token {
 
     public get type(): "close-curly-bracket" {
       return "close-curly-bracket";
+    }
+
+    public get mirror(): OpenCurlyBracket {
+      return OpenCurlyBracket.of();
     }
 
     public equals(value: unknown): value is this {

--- a/packages/alfa-css/test/syntax/declaration.spec.ts
+++ b/packages/alfa-css/test/syntax/declaration.spec.ts
@@ -41,3 +41,22 @@ test(".consume() consumes an important declaration", (t) => {
     important: true,
   });
 });
+
+test(".consume() consumes a declaration value with a block", (t) => {
+  consume(t, "foo: (bar) !important", {
+    name: "foo",
+    value: [
+      {
+        type: "open-parenthesis",
+      },
+      {
+        type: "ident",
+        value: "bar",
+      },
+      {
+        type: "close-parenthesis",
+      },
+    ],
+    important: true,
+  });
+});

--- a/packages/alfa-css/tsconfig.json
+++ b/packages/alfa-css/tsconfig.json
@@ -7,6 +7,7 @@
     "src/syntax/block.ts",
     "src/syntax/component.ts",
     "src/syntax/declaration.ts",
+    "src/syntax/function.ts",
     "src/syntax/lexer.ts",
     "src/syntax/token.ts",
     "src/value.ts",

--- a/packages/alfa-style/package.json
+++ b/packages/alfa-style/package.json
@@ -28,6 +28,7 @@
     "@siteimprove/alfa-functor": "^0.3.0",
     "@siteimprove/alfa-iterable": "^0.3.0",
     "@siteimprove/alfa-json": "^0.3.0",
+    "@siteimprove/alfa-map": "^0.3.0",
     "@siteimprove/alfa-mapper": "^0.3.0",
     "@siteimprove/alfa-math": "^0.3.0",
     "@siteimprove/alfa-monad": "^0.3.0",

--- a/packages/alfa-style/src/style.ts
+++ b/packages/alfa-style/src/style.ts
@@ -6,6 +6,7 @@ import { Element, Declaration, Document, Shadow } from "@siteimprove/alfa-dom";
 import { Either } from "@siteimprove/alfa-either";
 import { Iterable } from "@siteimprove/alfa-iterable";
 import { Serializable } from "@siteimprove/alfa-json";
+import { Map } from "@siteimprove/alfa-map";
 import { None, Option } from "@siteimprove/alfa-option";
 import { Parser } from "@siteimprove/alfa-parser";
 import { Record } from "@siteimprove/alfa-record";
@@ -27,60 +28,75 @@ export class Style implements Serializable {
     device: Device,
     parent: Option<Style> = None
   ): Style {
-    return new Style(Array.from(declarations), device, parent);
-  }
-
-  private static _empty = new Style([], Device.standard(), None);
-
-  public static empty(): Style {
-    return this._empty;
-  }
-
-  private readonly _device: Device;
-  private readonly _parent: Option<Style>;
-  private readonly _variables = new Map<string, Array<Token>>();
-
-  // We cache cascaded and computed properties but not specified properties as
-  // these are inexpensive to resolve from cascaded and computed properties.
-  // Cascaded properties on the other hand require parsing, which is expensive,
-  // and computed properties require absolutization, which is also expensive.
-  private readonly _cascaded = new Map<Name, Value>();
-  private readonly _computed = new Map<Name, Value>();
-
-  private constructor(
-    declarations: Array<Declaration>,
-    device: Device,
-    parent: Option<Style>
-  ) {
-    this._device = device;
-    this._parent = parent;
+    declarations = Array.from(declarations);
 
     // First pass: Resolve cascading variables which will be used in the second
     // pass.
+    let variables = Map.empty<string, Value<Array<Token>>>();
+
     for (const declaration of declarations) {
       const { name, value } = declaration;
 
-      if (name.startsWith("--") && !this._variables.has(name)) {
-        this._variables.set(name, Lexer.lex(value));
+      if (name.startsWith("--")) {
+        if (
+          variables
+            .get(name)
+            .every((previous) => shouldOverride(previous.source, declaration))
+        ) {
+          const tokens = Lexer.lex(value);
+
+          variables = variables.set(
+            name,
+            Value.of(tokens, Option.of(declaration))
+          );
+        }
+      }
+    }
+
+    // Pre-substitute the resolved cascading variables from above, replacing
+    // any `var()` function references with their substituted tokens.
+    for (const [name, variable] of variables) {
+      const value = substitute(variable.value, variables, parent);
+
+      // If the replaced value is invalid, remove the variable entirely.
+      if (value.isNone()) {
+        variables = variables.delete(name);
+      }
+
+      // Otherwise, use the replaced value as the new value of the variable.
+      else {
+        variables = variables.set(
+          name,
+          Value.of(value.get().get(), variable.source)
+        );
       }
     }
 
     // Second pass: Resolve cascading properties using the cascading variables
     // from the first pass.
+    let properties = Map.empty<Name, Value>();
+
     for (const declaration of declarations) {
       const { name, value } = declaration;
 
       if (Property.isName(name)) {
-        const previous = this._cascaded.get(name);
-
         if (
-          previous === undefined ||
-          shouldOverride(previous.source, declaration)
+          properties
+            .get(name)
+            .every((previous) => shouldOverride(previous.source, declaration))
         ) {
           const property = Property.get(name);
 
-          for (const result of this._parseLonghand(property, value)) {
-            this._cascaded.set(name, Value.of(result, Option.of(declaration)));
+          for (const result of parseLonghand(
+            property,
+            value,
+            variables,
+            parent
+          )) {
+            properties = properties.set(
+              name,
+              Value.of(result, Option.of(declaration))
+            );
           }
         }
       }
@@ -88,20 +104,63 @@ export class Style implements Serializable {
       if (Property.Shorthand.isName(name)) {
         const shorthand = Property.Shorthand.get(name);
 
-        for (const result of this._parseShorthand(shorthand, value)) {
+        for (const result of parseShorthand(
+          shorthand,
+          value,
+          variables,
+          parent
+        )) {
           for (const [name, value] of result) {
-            const previous = this._cascaded.get(name);
-
             if (
-              previous === undefined ||
-              shouldOverride(previous.source, declaration)
+              properties
+                .get(name)
+                .every((previous) =>
+                  shouldOverride(previous.source, declaration)
+                )
             ) {
-              this._cascaded.set(name, Value.of(value, Option.of(declaration)));
+              properties = properties.set(
+                name,
+                Value.of(value, Option.of(declaration))
+              );
             }
           }
         }
       }
     }
+
+    return new Style(device, parent, variables, properties);
+  }
+
+  private static _empty = new Style(
+    Device.standard(),
+    None,
+    Map.empty(),
+    Map.empty()
+  );
+
+  public static empty(): Style {
+    return this._empty;
+  }
+
+  private readonly _device: Device;
+  private readonly _parent: Option<Style>;
+  private readonly _variables: Map<string, Value<Array<Token>>>;
+  private readonly _properties: Map<Name, Value>;
+
+  // We cache computed properties but not specified properties as these are
+  // inexpensive to resolve from cascaded and computed properties.
+  private readonly _computed = Cache.empty<Name, Value>();
+
+  private constructor(
+    device: Device,
+    parent: Option<Style>,
+    variables: Map<string, Value<Array<Token>>>,
+    properties: Map<Name, Value>
+  ) {
+    this._device = device;
+    this._parent = parent;
+    this._variables = variables;
+    this._properties = properties;
   }
 
   public get device(): Device {
@@ -112,14 +171,20 @@ export class Style implements Serializable {
     return this._parent.getOrElse(() => Style._empty);
   }
 
+  public get variables(): Iterable<[string, Value<Array<Token>>]> {
+    return this._variables;
+  }
+
+  public get properties(): Iterable<[string, Value]> {
+    return this._properties;
+  }
+
   public root(): Style {
     return this._parent.map((parent) => parent.root()).getOr(this);
   }
 
   public cascaded<N extends Name>(name: N): Option<Value<Style.Cascaded<N>>> {
-    return Option.from(
-      this._cascaded.get(name) as Value<Style.Cascaded<N>> | undefined
-    );
+    return this._properties.get(name) as Option<Value<Style.Cascaded<N>>>;
   }
 
   public specified<N extends Name>(name: N): Value<Style.Specified<N>> {
@@ -165,17 +230,9 @@ export class Style implements Serializable {
       return this.initial(name);
     }
 
-    let value = this._computed.get(name) as
-      | Value<Style.Computed<N>>
-      | undefined;
-
-    if (value === undefined) {
-      value = Property.get(name).compute(this) as Value<Style.Computed<N>>;
-
-      this._computed.set(name, value);
-    }
-
-    return value;
+    return this._computed.get(name, () =>
+      Property.get(name).compute(this)
+    ) as Value<Style.Computed<N>>;
   }
 
   public initial<N extends Name>(name: N): Value<Style.Initial<N>> {
@@ -187,199 +244,26 @@ export class Style implements Serializable {
   }
 
   public toJSON(): Style.JSON {
-    return {};
-  }
-
-  private _parseLonghand<N extends Property.Name>(
-    property: Property.WithName<N>,
-    value: string
-  ) {
-    const tokens = this._substitute(Lexer.lex(value));
-
-    if (tokens.isNone()) {
-      return Option.of(Keyword.of("unset"));
-    }
-
-    const result = left(
-      either(
-        Keyword.parse("initial", "inherit", "unset"),
-        property.parse as Parser<Slice<Token>, Property.Value.Parsed<N>, string>
-      ),
-      eof(() => "Expected end of input")
-    )(Slice.of(tokens.get().get()))
-      .map(([, value]) => value)
-      .ok();
-
-    if (result.isNone() && tokens.get().isRight()) {
-      return Option.of(Keyword.of("unset"));
-    }
-
-    return result;
-  }
-
-  private _parseShorthand<N extends Property.Shorthand.Name>(
-    shorthand: Property.Shorthand.WithName<N>,
-    value: string
-  ) {
-    const tokens = this._substitute(Lexer.lex(value));
-
-    if (tokens.isNone()) {
-      return Option.of(
-        Record.from(
-          Iterable.map(shorthand.properties, (property) => [
-            property,
-            Keyword.of("unset"),
-          ])
-        )
-      );
-    }
-
-    const result = left(
-      either(
-        Keyword.parse("initial", "inherit", "unset"),
-        shorthand.parse as Parser<
-          Slice<Token>,
-          Record<{ [N in Property.Name]?: Property.Value.Parsed<N> }>,
-          string
-        >
-      ),
-      eof(() => "Expected end of input")
-    )(Slice.of(tokens.get().get()))
-      .map(([, value]) => {
-        if (Keyword.isKeyword(value)) {
-          return Record.from(
-            Iterable.map(shorthand.properties, (property) => [property, value])
-          );
-        }
-
-        return value;
-      })
-      .ok();
-
-    if (result.isNone() && tokens.get().isRight()) {
-      return Option.of(
-        Record.from(
-          Iterable.map(shorthand.properties, (property) => [
-            property,
-            Keyword.of("unset"),
-          ])
-        )
-      );
-    }
-
-    return result;
-  }
-
-  /**
-   * Resolve a cascading variable with an optional fallback. The value of the
-   * variable, if defined, will have `var()` functions fully substituted.
-   *
-   * @remarks
-   * This method uses a set of visited names to detect cyclic dependencies
-   * between cascading variables. The set is local to each `Style` instance as
-   * cyclic references can only occur between cascading variables defined on the
-   * same element.
-   */
-  private _variable(
-    name: string,
-    fallback: Option<Array<Token>> = None,
-    visited = Set.empty<string>()
-  ): Option<Array<Token>> {
-    return Option.from(this._variables.get(name))
-      .or(fallback)
-      .map((tokens) =>
-        this._substitute(tokens, visited.add(name)).map((substituted) =>
-          substituted.get()
-        )
-      )
-      .getOrElse(() =>
-        this._parent.flatMap((parent) =>
-          parent
-            ._variable(name)
-            .flatMap((tokens) =>
-              parent._substitute(tokens).map((substituted) => substituted.get())
-            )
-        )
-      );
-  }
-
-  /**
-   * The maximum allowed number of tokens that declaration values with `var()`
-   * functions may expand to.
-   *
-   * @see https://drafts.csswg.org/css-variables/#long-variables
-   */
-  private static _substitutionLimit = 1024;
-
-  /**
-   * Substitute `var()` functions in an array of tokens. If any tokens are
-   * substituted, the result will be wrapped in `Right`, otherwise `Left`. If
-   * any syntactically invalid `var()` functions are encountered, `None` is
-   * returned.
-   *
-   * @see https://drafts.csswg.org/css-variables/#substitute-a-var
-   *
-   * @remarks
-   * This method uses a set of visited names to detect cyclic dependencies
-   * between cascading variables. The set is local to each `Style` instance as
-   * cyclic references can only occur between cascading variables defined on the
-   * same element.
-   */
-  private _substitute(
-    tokens: Array<Token>,
-    visited = Set.empty<string>()
-  ): Option<Either<Array<Token>>> {
-    const replaced: Array<Token> = [];
-
-    let offset = 0;
-    let substituted = false;
-
-    while (offset < tokens.length) {
-      const next = tokens[offset];
-
-      if (next.type === "function" && next.value === "var") {
-        const result = parseVar(Slice.of(tokens, offset));
-
-        if (result.isErr()) {
-          return None;
-        }
-
-        const [remainder, [name, fallback]] = result.get();
-
-        if (visited.has(name.value)) {
-          return None;
-        }
-
-        const value = this._variable(name.value, fallback, visited);
-
-        if (value.isNone()) {
-          return None;
-        }
-
-        replaced.push(...value.get());
-        offset = remainder.offset;
-        substituted = true;
-      } else {
-        replaced.push(next);
-        offset++;
-      }
-    }
-
-    // If substitution occurred and the number of replaced tokens has exceeded
-    // the substitution limit, bail out.
-    if (substituted && replaced.length > Style._substitutionLimit) {
-      return None;
-    }
-
-    return Option.of(
-      substituted ? Either.right(replaced) : Either.left(replaced)
-    );
+    return {
+      device: this._device.toJSON(),
+      variables: [...this._variables].map(([name, value]) => [
+        name,
+        value.toJSON(),
+      ]),
+      properties: [...this._properties].map(([name, value]) => [
+        name,
+        value.toJSON(),
+      ]),
+    };
   }
 }
 
 export namespace Style {
   export interface JSON {
     [key: string]: json.JSON;
+    device: Device.JSON;
+    variables: Array<[string, Value.JSON]>;
+    properties: Array<[string, Value.JSON]>;
   }
 
   const cache = Cache.empty<Device, Cache<Element, Style>>();
@@ -436,6 +320,240 @@ function shouldOverride(
   return (
     next.important && previous.every((declaration) => !declaration.important)
   );
+}
+
+function parseLonghand<N extends Property.Name>(
+  property: Property.WithName<N>,
+  value: string,
+  variables: Map<string, Value<Array<Token>>>,
+  parent: Option<Style>
+) {
+  const tokens = substitute(Lexer.lex(value), variables, parent);
+
+  if (tokens.isNone()) {
+    return Option.of(Keyword.of("unset"));
+  }
+
+  const result = left(
+    either(
+      Keyword.parse("initial", "inherit", "unset"),
+      property.parse as Parser<Slice<Token>, Property.Value.Parsed<N>, string>
+    ),
+    eof(() => "Expected end of input")
+  )(Slice.of(trim(tokens.get().get())))
+    .map(([, value]) => value)
+    .ok();
+
+  if (result.isNone() && tokens.get().isRight()) {
+    return Option.of(Keyword.of("unset"));
+  }
+
+  return result;
+}
+
+function parseShorthand<N extends Property.Shorthand.Name>(
+  shorthand: Property.Shorthand.WithName<N>,
+  value: string,
+  variables: Map<string, Value<Array<Token>>>,
+  parent: Option<Style>
+) {
+  const tokens = substitute(Lexer.lex(value), variables, parent);
+
+  if (tokens.isNone()) {
+    return Option.of(
+      Record.from(
+        Iterable.map(shorthand.properties, (property) => [
+          property,
+          Keyword.of("unset"),
+        ])
+      )
+    );
+  }
+
+  const result = left(
+    either(
+      Keyword.parse("initial", "inherit", "unset"),
+      shorthand.parse as Parser<
+        Slice<Token>,
+        Record<{ [N in Property.Name]?: Property.Value.Parsed<N> }>,
+        string
+      >
+    ),
+    eof(() => "Expected end of input")
+  )(Slice.of(trim(tokens.get().get())))
+    .map(([, value]) => {
+      if (Keyword.isKeyword(value)) {
+        return Record.from(
+          Iterable.map(shorthand.properties, (property) => [property, value])
+        );
+      }
+
+      return value;
+    })
+    .ok();
+
+  if (result.isNone() && tokens.get().isRight()) {
+    return Option.of(
+      Record.from(
+        Iterable.map(shorthand.properties, (property) => [
+          property,
+          Keyword.of("unset"),
+        ])
+      )
+    );
+  }
+
+  return result;
+}
+
+/**
+ * Resolve a cascading variable with an optional fallback. The value of the
+ * variable, if defined, will have `var()` functions fully substituted.
+ *
+ * @remarks
+ * This method uses a set of visited names to detect cyclic dependencies
+ * between cascading variables. The set is local to each `Style` instance as
+ * cyclic references can only occur between cascading variables defined on the
+ * same element.
+ */
+function resolve(
+  name: string,
+  variables: Map<string, Value<Array<Token>>>,
+  parent: Option<Style>,
+  fallback: Option<Array<Token>> = None,
+  visited = Set.empty<string>()
+): Option<Array<Token>> {
+  return (
+    variables
+      .get(name)
+      .map((value) =>
+        // The initial value of a custom property is the "guaranteed-invalid"
+        // value. We therefore reject the value of the variable if it's the
+        // keyword `initial`.
+        // https://drafts.csswg.org/css-variables/#guaranteed-invalid
+        Option.of(value.value).reject((tokens) =>
+          Keyword.parse("initial")(Slice.of(tokens)).isOk()
+        )
+      )
+
+      // If the value of the variable is invalid, as indicated by it being
+      // `None`, we instead use the fallback value, if available.
+      // https://drafts.csswg.org/css-variables/#invalid-variables
+      .orElse(() =>
+        fallback
+          // Substitute any additional cascading variables within the fallback
+          // value.
+          .map((tokens) =>
+            substitute(
+              tokens,
+              variables,
+              parent,
+              visited.add(name)
+            ).map((substituted) => substituted.get())
+          )
+      )
+
+      .getOrElse(() =>
+        parent.flatMap((parent) => {
+          const variables = Map.from(parent.variables);
+          const grandparent =
+            parent.parent === Style.empty() ? None : Option.of(parent.parent);
+
+          return resolve(name, variables, grandparent).flatMap((tokens) =>
+            substitute(tokens, variables, grandparent).map((substituted) =>
+              substituted.get()
+            )
+          );
+        })
+      )
+  );
+}
+
+/**
+ * The maximum allowed number of tokens that declaration values with `var()`
+ * functions may expand to.
+ *
+ * @see https://drafts.csswg.org/css-variables/#long-variables
+ */
+const substitutionLimit = 1024;
+
+/**
+ * Substitute `var()` functions in an array of tokens. If any tokens are
+ * substituted, the result will be wrapped in `Right`, otherwise `Left`. If
+ * any syntactically invalid `var()` functions are encountered, `None` is
+ * returned.
+ *
+ * @see https://drafts.csswg.org/css-variables/#substitute-a-var
+ *
+ * @remarks
+ * This method uses a set of visited names to detect cyclic dependencies
+ * between cascading variables. The set is local to each `Style` instance as
+ * cyclic references can only occur between cascading variables defined on the
+ * same element.
+ */
+function substitute(
+  tokens: Array<Token>,
+  variables: Map<string, Value<Array<Token>>>,
+  parent: Option<Style>,
+  visited = Set.empty<string>()
+): Option<Either<Array<Token>>> {
+  const replaced: Array<Token> = [];
+
+  let offset = 0;
+  let substituted = false;
+
+  while (offset < tokens.length) {
+    const next = tokens[offset];
+
+    if (next.type === "function" && next.value === "var") {
+      const result = parseVar(Slice.of(tokens, offset));
+
+      if (result.isErr()) {
+        return None;
+      }
+
+      const [remainder, [name, fallback]] = result.get();
+
+      if (visited.has(name.value)) {
+        return None;
+      }
+
+      const value = resolve(name.value, variables, parent, fallback, visited);
+
+      if (value.isNone()) {
+        return None;
+      }
+
+      replaced.push(...value.get());
+      offset = remainder.offset;
+      substituted = true;
+    } else {
+      replaced.push(next);
+      offset++;
+    }
+  }
+
+  // If substitution occurred and the number of replaced tokens has exceeded
+  // the substitution limit, bail out.
+  if (substituted && replaced.length > substitutionLimit) {
+    return None;
+  }
+
+  return Option.of(
+    substituted ? Either.right(replaced) : Either.left(replaced)
+  );
+}
+
+function trim(tokens: Array<Token>): Array<Token> {
+  while (tokens.length > 0 && Token.isWhitespace(tokens[0])) {
+    tokens.splice(0, 1);
+  }
+
+  while (tokens.length > 0 && Token.isWhitespace(tokens[tokens.length - 1])) {
+    tokens.splice(tokens.length - 1, 1);
+  }
+
+  return tokens;
 }
 
 /**

--- a/packages/alfa-style/tsconfig.json
+++ b/packages/alfa-style/tsconfig.json
@@ -54,6 +54,9 @@
       "path": "../alfa-json"
     },
     {
+      "path": "../alfa-map"
+    },
+    {
       "path": "../alfa-mapper"
     },
     {


### PR DESCRIPTION
This pull request first and foremost fixes two issues in our handling of custom properties:

- Guaranteed-invalid values, including the `initial` keyword.
- `!important` custom properties.

It also fixes a bug in parsing CSS component values when blocks are involved. Namely, the ending token of blocks (`)`, `]`, or `}`) was not included in the final component value.