### PR TITLE
Improve ARIA `Node` construction performance

### DIFF
--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -174,13 +174,13 @@ const labels = Cache.empty<Node, Sequence<Element>>();
 const nameFromLabel = (element: Element, device: Device, state: Name.State) => {
   const root = element.root();
 
+  const elements = root.inclusiveDescendants().filter(isElement);
+
   for (const id of element.id) {
     const target = ids
       .get(root, () =>
         Map.from(
-          root
-            .inclusiveDescendants()
-            .filter(isElement)
+          elements
             .collect((element) =>
               element.id.map((id) => [id, element] as const)
             )
@@ -197,9 +197,7 @@ const nameFromLabel = (element: Element, device: Device, state: Name.State) => {
   }
 
   const targets = labels
-    .get(root, () =>
-      root.inclusiveDescendants().filter(and(isElement, hasName("label")))
-    )
+    .get(root, () => elements.filter(hasName("label")))
     .filter(
       or(
         (label) => label.descendants().includes(element),

--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -1,11 +1,14 @@
 import { Branched } from "@siteimprove/alfa-branched";
+import { Cache } from "@siteimprove/alfa-cache";
 import { Browser } from "@siteimprove/alfa-compatibility";
 import { Device } from "@siteimprove/alfa-device";
-import { Element, Namespace } from "@siteimprove/alfa-dom";
+import { Node, Element, Namespace } from "@siteimprove/alfa-dom";
 import { Iterable } from "@siteimprove/alfa-iterable";
+import { Map } from "@siteimprove/alfa-map";
 import { Mapper } from "@siteimprove/alfa-mapper";
 import { None, Option } from "@siteimprove/alfa-option";
 import { Predicate } from "@siteimprove/alfa-predicate";
+import { Sequence } from "@siteimprove/alfa-sequence";
 import { Scope, Table } from "@siteimprove/alfa-table";
 
 import { Attribute } from "./attribute";
@@ -154,10 +157,7 @@ const nameFromChild = (predicate: Predicate<Element>) => (
   state: Name.State
 ) => {
   for (const child of element.children().find(and(isElement, predicate))) {
-    return Name.fromDescendants(child, device, {
-      ...state,
-      visited: state.visited.add(child),
-    }).map((name) =>
+    return Name.fromDescendants(child, device, state.visit(child)).map((name) =>
       name.map((name) =>
         Name.of(name.value, [Name.Source.descendant(element, name)])
       )
@@ -167,13 +167,27 @@ const nameFromChild = (predicate: Predicate<Element>) => (
   return Branched.of(None);
 };
 
+const ids = Cache.empty<Node, Map<string, Element>>();
+
+const labels = Cache.empty<Node, Sequence<Element>>();
+
 const nameFromLabel = (element: Element, device: Device, state: Name.State) => {
   const root = element.root();
 
   for (const id of element.id) {
-    const target = root
-      .descendants()
-      .find(and(isElement, (element) => element.id.includes(id)));
+    const target = ids
+      .get(root, () =>
+        Map.from(
+          root
+            .inclusiveDescendants()
+            .filter(isElement)
+            .collect((element) =>
+              element.id.map((id) => [id, element] as const)
+            )
+            .reverse()
+        )
+      )
+      .get(id);
 
     if (target.includes(element)) {
       continue;
@@ -182,29 +196,26 @@ const nameFromLabel = (element: Element, device: Device, state: Name.State) => {
     }
   }
 
-  const labels = root.descendants().filter(
-    and(
-      isElement,
-      and(
-        hasName("label"),
-        or(
-          (label) => label.descendants().includes(element),
-          (label) =>
-            label
-              .attribute("for")
-              .some((attribute) => element.id.includes(attribute.value))
-        )
-      )
+  const targets = labels
+    .get(root, () =>
+      root.inclusiveDescendants().filter(and(isElement, hasName("label")))
     )
-  );
+    .filter(
+      or(
+        (label) => label.descendants().includes(element),
+        (label) =>
+          label
+            .attribute("for")
+            .some((attribute) => element.id.includes(attribute.value))
+      )
+    );
 
-  return Branched.traverse(labels, (element) =>
-    Name.fromNode(element, device, {
-      ...state,
-      isRecursing: true,
-      isReferencing: false,
-      isDescending: false,
-    }).map((name) => [name, element] as const)
+  return Branched.traverse(targets, (element) =>
+    Name.fromNode(
+      element,
+      device,
+      state.recurse(true).reference(false).descend(false)
+    ).map((name) => [name, element] as const)
   )
     .map((names) =>
       [...names]

--- a/packages/alfa-aria/src/name.ts
+++ b/packages/alfa-aria/src/name.ts
@@ -399,6 +399,12 @@ export namespace Name {
     public visit(element: Element): State {
       const visited = this._visited.add(element);
 
+      // `Set#add()` returns the previous instance if attempting to add a value
+      // already present in the set. When this happens, we re-use the existing
+      // `State` instance as it hasn't changed. While we could also have used
+      // `Set#has()` before attempting to add the element to the set, doing so
+      // would cost us two lookups, rather than just one, as we would also need
+      // to add the element if not already present.
       if (this._visited === visited) {
         return this;
       }

--- a/packages/alfa-aria/src/node.ts
+++ b/packages/alfa-aria/src/node.ts
@@ -229,7 +229,7 @@ export namespace Node {
     // then the tree that the node participates in has already been built, but
     // the node itself is not included within the resulting accessibility tree.
     if (_cache.has(root)) {
-      return _cache.get(node, () => Branched.of(Inert.of(node)))
+      return _cache.get(node, () => Branched.of(Inert.of(node)));
     }
 
     // Before we start constructing the accessibility tree, we need to resolve

--- a/packages/alfa-aria/src/node.ts
+++ b/packages/alfa-aria/src/node.ts
@@ -428,6 +428,13 @@ export namespace Node {
             }
           }
 
+          // If the element has neither attributes nor a role, it is not itself
+          // interesting for accessibility purposes. It is therefore exposed as
+          // a container.
+          if (attributes.isEmpty() && role.isNone()) {
+            return children.map((children) => Container.of(node, children));
+          }
+
           return children.flatMap((children) =>
             Name.from(node, device).map((name) =>
               Element.of(node, role, name, attributes.values(), children)

--- a/packages/alfa-aria/src/role.ts
+++ b/packages/alfa-aria/src/role.ts
@@ -28,7 +28,19 @@ export class Role<N extends Role.Name = Role.Name>
     let role = roles.get(name);
 
     if (role === undefined) {
-      role = new Role(name);
+      const { inherited } = Roles[name];
+
+      const attributes = new Set(
+        [...Roles[name].attributes].map(([attribute]) => attribute)
+      );
+
+      for (const parent of inherited) {
+        for (const attribute of Role.of(parent).attributes) {
+          attributes.add(attribute);
+        }
+      }
+
+      role = new Role(name, [...attributes]);
       roles.set(name, role);
     }
 
@@ -36,9 +48,11 @@ export class Role<N extends Role.Name = Role.Name>
   }
 
   private readonly _name: N;
+  private readonly _attributes: Array<Attribute.Name>;
 
-  private constructor(name: N) {
+  private constructor(name: N, attributes: Array<Attribute.Name>) {
     this._name = name;
+    this._attributes = attributes;
   }
 
   public get name(): N {
@@ -49,19 +63,7 @@ export class Role<N extends Role.Name = Role.Name>
    * Get all attributes supported by this role and its inherited roles.
    */
   public get attributes(): Iterable<Attribute.Name> {
-    const { inherited } = Roles[this._name];
-
-    const attributes = new Set(
-      [...Roles[this._name].attributes].map(([attribute]) => attribute)
-    );
-
-    for (const parent of inherited) {
-      for (const attribute of Role.of(parent).attributes) {
-        attributes.add(attribute);
-      }
-    }
-
-    return attributes;
+    return this._attributes[Symbol.iterator]();
   }
 
   /**

--- a/packages/alfa-aria/test/node.spec.tsx
+++ b/packages/alfa-aria/test/node.spec.tsx
@@ -12,6 +12,7 @@ import { Role } from "../src/role";
 import { Node } from "../src/node";
 import { Element } from "../src/node/element";
 import { Text } from "../src/node/text";
+import { Container } from "../src/node/container";
 import { Inert } from "../src/node/inert";
 
 const device = Device.standard();
@@ -197,13 +198,9 @@ test(`.from() correctly handles circular aria-owns references between ancestors
 
   t.deepEqual(Node.from(bar, device).toJSON(), [
     [
-      Element.of(
-        bar,
-        None,
-        None,
-        [],
-        [Element.of(foo, None, None, [Attribute.of("aria-owns", "bar")])]
-      ).toJSON(),
+      Container.of(bar, [
+        Element.of(foo, None, None, [Attribute.of("aria-owns", "bar")]),
+      ]).toJSON(),
       [],
     ],
   ]);

--- a/packages/alfa-rules/src/common/predicate/is-ignored.ts
+++ b/packages/alfa-rules/src/common/predicate/is-ignored.ts
@@ -4,6 +4,13 @@ import { Predicate } from "@siteimprove/alfa-predicate";
 
 import * as aria from "@siteimprove/alfa-aria";
 
+/**
+ * Check if a node is ignored in the accessibility tree.
+ *
+ * @remarks
+ * It's possible for a node itself to be ignored in the accessibility tree while
+ * still having children that aren't.
+ */
 export function isIgnored<T extends Node>(device: Device): Predicate<T> {
   return (node) =>
     aria.Node.from(node, device).some((node) => node.isIgnored());

--- a/packages/alfa-rules/src/common/predicate/is-perceivable.ts
+++ b/packages/alfa-rules/src/common/predicate/is-perceivable.ts
@@ -7,6 +7,15 @@ import { isVisible } from "./is-visible";
 
 const { and, not } = Predicate;
 
+/**
+ * Check if a node is perceivable.
+ *
+ * @remarks
+ * A node is considered perceivable if it's visible and has inclusive
+ * descendants that are not ignored in the accessibility tree.
+ */
 export function isPerceivable<T extends Node>(device: Device): Predicate<T> {
-  return and(isVisible(device), not(isIgnored(device)));
+  return and(isVisible(device), (node) =>
+    node.inclusiveDescendants().some(not(isIgnored(device)))
+  );
 }

--- a/packages/alfa-rules/test/sia-r21/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r21/rule.spec.tsx
@@ -11,14 +11,11 @@ import { passed, failed, inapplicable } from "../common/outcome";
 const { isElement } = Element;
 
 test("evaluates() passes an element with a single valid role", async (t) => {
-  const document = Document.of([<div role="button">Button</div>]);
+  const button = <button role="button">Button</button>;
 
-  const target = document
-    .children()
-    .find(isElement)
-    .get()
-    .attribute("role")
-    .get();
+  const document = Document.of([button]);
+
+  const target = button.attribute("role").get();
 
   t.deepEqual(await evaluate(R21, { document }), [
     passed(R21, target, {
@@ -28,14 +25,11 @@ test("evaluates() passes an element with a single valid role", async (t) => {
 });
 
 test("evaluates() passes an element with multiple valid roles", async (t) => {
-  const document = Document.of([<div role="button link">Button</div>]);
+  const button = <button role="button link">Button</button>;
 
-  const target = document
-    .children()
-    .find(isElement)
-    .get()
-    .attribute("role")
-    .get();
+  const document = Document.of([button]);
+
+  const target = button.attribute("role").get();
 
   t.deepEqual(await evaluate(R21, { document }), [
     passed(R21, target, {
@@ -45,14 +39,11 @@ test("evaluates() passes an element with multiple valid roles", async (t) => {
 });
 
 test("evaluates() fails an element with an invalid role", async (t) => {
-  const document = Document.of([<div role="btn">Button</div>]);
+  const button = <button role="btn">Button</button>;
 
-  const target = document
-    .children()
-    .find(isElement)
-    .get()
-    .attribute("role")
-    .get();
+  const document = Document.of([button]);
+
+  const target = button.attribute("role").get();
 
   t.deepEqual(await evaluate(R21, { document }), [
     failed(R21, target, {
@@ -62,14 +53,11 @@ test("evaluates() fails an element with an invalid role", async (t) => {
 });
 
 test("evaluates() fails an element with both a valid and an invalid role", async (t) => {
-  const document = Document.of([<div role="btn link">Button</div>]);
+  const button = <button role="btn link">Button</button>;
 
-  const target = document
-    .children()
-    .find(isElement)
-    .get()
-    .attribute("role")
-    .get();
+  const document = Document.of([button]);
+
+  const target = button.attribute("role").get();
 
   t.deepEqual(await evaluate(R21, { document }), [
     failed(R21, target, {
@@ -79,13 +67,17 @@ test("evaluates() fails an element with both a valid and an invalid role", async
 });
 
 test("evaluate() is inapplicable when there is no role attribute", async (t) => {
-  const document = Document.of([<button>Button</button>]);
+  const button = <button>Button</button>;
+
+  const document = Document.of([button]);
 
   t.deepEqual(await evaluate(R21, { document }), [inapplicable(R21)]);
 });
 
 test("evaluate() is inapplicable when a role attribute is only whitespace", async (t) => {
-  const document = Document.of([<div role=" " />]);
+  const button = <button role=" " />;
+
+  const document = Document.of([button]);
 
   t.deepEqual(await evaluate(R21, { document }), [inapplicable(R21)]);
 });

--- a/packages/alfa-rules/test/sia-r82/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r82/rule.spec.tsx
@@ -1,8 +1,7 @@
 import { jsx } from "@siteimprove/alfa-dom/jsx";
 import { test } from "@siteimprove/alfa-test";
 
-import { Document, Element } from "@siteimprove/alfa-dom";
-import { Predicate } from "@siteimprove/alfa-predicate";
+import { Document } from "@siteimprove/alfa-dom";
 
 import R82, { Outcomes } from "../../src/sia-r82/rule";
 
@@ -10,31 +9,25 @@ import { evaluate } from "../common/evaluate";
 import { oracle } from "../common/oracle";
 import { passed, failed } from "../common/outcome";
 
-const { isElement, hasName } = Element;
-const { and } = Predicate;
+const input = <input type="text"></input>;
+
+const perceivableError = <span>Visible error</span>;
+
+const invisibleError = <span hidden>Invisible error</span>;
+
+const ignoredError = <span aria-hidden="true">Ignored error</span>;
 
 const document = Document.of([
   <form>
     <label>
       Input
-      <input type="text"></input>
+      {input}
     </label>
-    <span>Visible error</span>
-    <span hidden>Invisible error</span>
-    <span aria-hidden="true">Ignored error</span>
+    {perceivableError}
+    {invisibleError}
+    {ignoredError}
   </form>,
 ]);
-
-const input = document
-  .descendants()
-  .find(and(isElement, hasName("input")))
-  .get();
-
-const [
-  perceivableError,
-  invisibleError,
-  ignoredError,
-] = document.descendants().filter(and(isElement, hasName("span")));
 
 test("evaluate() passes when a form field has no error indicator", async (t) => {
   t.deepEqual(


### PR DESCRIPTION
This pull request improves the construction performance of ARIA `Node` instances by introducing the following changes:

- When computing names for form controls with connected `<label>` elements, the list of `<label>` element is re-used, rather than re-computed, for each document scope.

- The `State` interface used for encoding the name computation state is now a class whose methods attempt to re-use the current `State` instance whenever possible to reduce allocations and pressure on the garbage collector.

- The attributes supported by `Role` instances are now computed and stored on construction.

- Elements without ARIA attributes and roles are now included as `Container` instances, hence skipping an expensive name computation as these elements shouldn't be included in the accessibility tree.

The last point also revealed an issue in the `isPerceivable()` predicate as it wasn't correctly accounting for elements that weren't included in the accessibility tree themselves but had children that were.