### PR TITLE
Expose elements in accessibility tree if they have a tab index

### DIFF
--- a/packages/alfa-aria/src/node.ts
+++ b/packages/alfa-aria/src/node.ts
@@ -428,10 +428,14 @@ export namespace Node {
             }
           }
 
-          // If the element has neither attributes nor a role nor a tabindex, it is not itself
-          // interesting for accessibility purposes. It is therefore exposed as
-          // a container.
-          if (attributes.isEmpty() && role.isNone() && node.tabIndex().isNone()) {
+          // If the element has neither attributes, a role, nor a tabindex, it
+          // is not itself interesting for accessibility purposes. It is
+          // therefore exposed as a container.
+          if (
+            attributes.isEmpty() &&
+            role.isNone() &&
+            node.tabIndex().isNone()
+          ) {
             return children.map((children) => Container.of(node, children));
           }
 

--- a/packages/alfa-aria/src/node.ts
+++ b/packages/alfa-aria/src/node.ts
@@ -428,10 +428,10 @@ export namespace Node {
             }
           }
 
-          // If the element has neither attributes nor a role, it is not itself
+          // If the element has neither attributes nor a role nor a tabindex, it is not itself
           // interesting for accessibility purposes. It is therefore exposed as
           // a container.
-          if (attributes.isEmpty() && role.isNone()) {
+          if (attributes.isEmpty() && role.isNone() && node.tabIndex().isNone()) {
             return children.map((children) => Container.of(node, children));
           }
 

--- a/packages/alfa-aria/test/node.spec.tsx
+++ b/packages/alfa-aria/test/node.spec.tsx
@@ -231,7 +231,7 @@ test(".from() exposes elements if they have ARIA attributes", t => {
   ]);
 })
 
-test(".from() exposes elements if they are focusable", t => {
+test(".from() exposes elements if they have a tabindex", t => {
   const foo = <div tabindex={0}></div>;
 
   t.deepEqual(Node.from(foo, device).toJSON(), [
@@ -240,4 +240,27 @@ test(".from() exposes elements if they are focusable", t => {
       [],
     ],
   ]);
-})
+
+  const iframe = <iframe/>; // focusable by default, and no role
+
+  t.deepEqual(Node.from(iframe, device).toJSON(), [
+    [
+      Element.of(iframe, None, None).toJSON(),
+      [],
+    ],
+  ]);
+});
+
+test(".from() does not expose elements that have no role, attribute nor tabindex", t => {
+  const text = h.text("Hello world");
+  const foo = <div>{text}</div>
+
+  t.deepEqual(Node.from(foo, device).toJSON(), [
+    [
+      Container.of(foo,
+        [Text.of(text, Name.of("Hello world", [Name.Source.data(text)]))]
+      ).toJSON(),
+      []
+    ]
+  ])
+});

--- a/packages/alfa-aria/test/node.spec.tsx
+++ b/packages/alfa-aria/test/node.spec.tsx
@@ -206,61 +206,59 @@ test(`.from() correctly handles circular aria-owns references between ancestors
   ]);
 });
 
-test(".from() exposes elements if they have a role", t => {
+test(".from() exposes elements if they have a role", (t) => {
   const foo = <button></button>;
 
   t.deepEqual(Node.from(foo, device).toJSON(), [
-    [
-      Element.of(foo, Option.of(Role.of("button")), None).toJSON(),
-      [],
-    ],
+    [Element.of(foo, Option.of(Role.of("button")), None).toJSON(), []],
   ]);
-})
+});
 
-test(".from() exposes elements if they have ARIA attributes", t => {
+test(".from() exposes elements if they have ARIA attributes", (t) => {
   const foo = <div aria-label="foo"></div>;
 
   t.deepEqual(Node.from(foo, device).toJSON(), [
     [
-      Element.of(foo, None, Option.of(Name.of("foo",
-        [Name.Source.Label.of(foo.attribute("aria-label").get())])),
+      Element.of(
+        foo,
+        None,
+        Option.of(
+          Name.of("foo", [
+            Name.Source.Label.of(foo.attribute("aria-label").get()),
+          ])
+        ),
         [Attribute.of("aria-label", "foo")]
       ).toJSON(),
       [],
     ],
   ]);
-})
+});
 
-test(".from() exposes elements if they have a tabindex", t => {
+test(".from() exposes elements if they have a tabindex", (t) => {
   const foo = <div tabindex={0}></div>;
 
   t.deepEqual(Node.from(foo, device).toJSON(), [
-    [
-      Element.of(foo, None, None).toJSON(),
-      [],
-    ],
+    [Element.of(foo, None, None).toJSON(), []],
   ]);
 
-  const iframe = <iframe/>; // focusable by default, and no role
+  const iframe = <iframe />; // Focusable by default, and no role
 
   t.deepEqual(Node.from(iframe, device).toJSON(), [
-    [
-      Element.of(iframe, None, None).toJSON(),
-      [],
-    ],
+    [Element.of(iframe, None, None).toJSON(), []],
   ]);
 });
 
-test(".from() does not expose elements that have no role, attribute nor tabindex", t => {
+test(`.from() does not expose elements that have no role, ARIA attributes, nor
+      tabindex`, (t) => {
   const text = h.text("Hello world");
-  const foo = <div>{text}</div>
+  const foo = <div>{text}</div>;
 
   t.deepEqual(Node.from(foo, device).toJSON(), [
     [
-      Container.of(foo,
-        [Text.of(text, Name.of("Hello world", [Name.Source.data(text)]))]
-      ).toJSON(),
-      []
-    ]
-  ])
+      Container.of(foo, [
+        Text.of(text, Name.of("Hello world", [Name.Source.data(text)])),
+      ]).toJSON(),
+      [],
+    ],
+  ]);
 });

--- a/packages/alfa-aria/test/node.spec.tsx
+++ b/packages/alfa-aria/test/node.spec.tsx
@@ -205,3 +205,39 @@ test(`.from() correctly handles circular aria-owns references between ancestors
     ],
   ]);
 });
+
+test(".from() exposes elements if they have a role", t => {
+  const foo = <button></button>;
+
+  t.deepEqual(Node.from(foo, device).toJSON(), [
+    [
+      Element.of(foo, Option.of(Role.of("button")), None).toJSON(),
+      [],
+    ],
+  ]);
+})
+
+test(".from() exposes elements if they have ARIA attributes", t => {
+  const foo = <div aria-label="foo"></div>;
+
+  t.deepEqual(Node.from(foo, device).toJSON(), [
+    [
+      Element.of(foo, None, Option.of(Name.of("foo",
+        [Name.Source.Label.of(foo.attribute("aria-label").get())])),
+        [Attribute.of("aria-label", "foo")]
+      ).toJSON(),
+      [],
+    ],
+  ]);
+})
+
+test(".from() exposes elements if they are focusable", t => {
+  const foo = <div tabindex={0}></div>;
+
+  t.deepEqual(Node.from(foo, device).toJSON(), [
+    [
+      Element.of(foo, None, None).toJSON(),
+      [],
+    ],
+  ]);
+})

--- a/packages/alfa-rules/test/sia-r13/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r13/rule.spec.tsx
@@ -1,17 +1,15 @@
 import { jsx } from "@siteimprove/alfa-dom/jsx";
 import { test } from "@siteimprove/alfa-test";
 
-import { Document, Element } from "@siteimprove/alfa-dom";
+import { Document } from "@siteimprove/alfa-dom";
 
 import R13, { Outcomes } from "../../src/sia-r13/rule";
 
 import { evaluate } from "../common/evaluate";
 import { passed, failed, inapplicable } from "../common/outcome";
 
-const { isElement } = Element;
-
 test("evaluates() passes an <iframe> with an accessible name given by the title attribute", async (t) => {
-  const iframe = <iframe title="iframe" srcdoc="Hello World!"/>;
+  const iframe = <iframe title="iframe" srcdoc="Hello World!" />;
 
   const document = Document.of([iframe]);
 
@@ -23,7 +21,7 @@ test("evaluates() passes an <iframe> with an accessible name given by the title 
 });
 
 test("evaluates() passes an <iframe> with an accessible name given by the aria-label attribute", async (t) => {
-  const iframe = <iframe aria-label="iframe" srcdoc="Hello World!"/>;
+  const iframe = <iframe aria-label="iframe" srcdoc="Hello World!" />;
 
   const document = Document.of([iframe]);
 
@@ -34,11 +32,10 @@ test("evaluates() passes an <iframe> with an accessible name given by the aria-l
   ]);
 });
 
-
 test("evaluates() passes an <iframe> with an accessible name given by the aria-labelledby attribute", async (t) => {
   const label = <span id="label">iframe</span>;
 
-  const iframe = <iframe aria-labelledby="label" srcdoc="Hello World!"/>;
+  const iframe = <iframe aria-labelledby="label" srcdoc="Hello World!" />;
 
   const document = Document.of([label, iframe]);
 
@@ -50,7 +47,7 @@ test("evaluates() passes an <iframe> with an accessible name given by the aria-l
 });
 
 test("evaluates() fails an <iframe> with no accessible name", async (t) => {
-  const iframe = <iframe srcdoc="Hello World!"/>;
+  const iframe = <iframe srcdoc="Hello World!" />;
 
   const document = Document.of([iframe]);
 
@@ -60,7 +57,6 @@ test("evaluates() fails an <iframe> with no accessible name", async (t) => {
     }),
   ]);
 });
-
 
 test("evaluate() is inapplicable when there is no <iframe>", async (t) => {
   const button = <button>Button</button>;

--- a/packages/alfa-rules/test/sia-r13/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r13/rule.spec.tsx
@@ -1,0 +1,71 @@
+import { jsx } from "@siteimprove/alfa-dom/jsx";
+import { test } from "@siteimprove/alfa-test";
+
+import { Document, Element } from "@siteimprove/alfa-dom";
+
+import R13, { Outcomes } from "../../src/sia-r13/rule";
+
+import { evaluate } from "../common/evaluate";
+import { passed, failed, inapplicable } from "../common/outcome";
+
+const { isElement } = Element;
+
+test("evaluates() passes an <iframe> with an accessible name given by the title attribute", async (t) => {
+  const iframe = <iframe title="iframe" srcdoc="Hello World!"/>;
+
+  const document = Document.of([iframe]);
+
+  t.deepEqual(await evaluate(R13, { document }), [
+    passed(R13, iframe, {
+      1: Outcomes.HasName,
+    }),
+  ]);
+});
+
+test("evaluates() passes an <iframe> with an accessible name given by the aria-label attribute", async (t) => {
+  const iframe = <iframe aria-label="iframe" srcdoc="Hello World!"/>;
+
+  const document = Document.of([iframe]);
+
+  t.deepEqual(await evaluate(R13, { document }), [
+    passed(R13, iframe, {
+      1: Outcomes.HasName,
+    }),
+  ]);
+});
+
+
+test("evaluates() passes an <iframe> with an accessible name given by the aria-labelledby attribute", async (t) => {
+  const label = <span id="label">iframe</span>;
+
+  const iframe = <iframe aria-labelledby="label" srcdoc="Hello World!"/>;
+
+  const document = Document.of([label, iframe]);
+
+  t.deepEqual(await evaluate(R13, { document }), [
+    passed(R13, iframe, {
+      1: Outcomes.HasName,
+    }),
+  ]);
+});
+
+test("evaluates() fails an <iframe> with no accessible name", async (t) => {
+  const iframe = <iframe srcdoc="Hello World!"/>;
+
+  const document = Document.of([iframe]);
+
+  t.deepEqual(await evaluate(R13, { document }), [
+    failed(R13, iframe, {
+      1: Outcomes.HasNoName,
+    }),
+  ]);
+});
+
+
+test("evaluate() is inapplicable when there is no <iframe>", async (t) => {
+  const button = <button>Button</button>;
+
+  const document = Document.of([button]);
+
+  t.deepEqual(await evaluate(R13, { document }), [inapplicable(R13)]);
+});

--- a/packages/alfa-rules/tsconfig.json
+++ b/packages/alfa-rules/tsconfig.json
@@ -115,6 +115,7 @@
     "test/common/outcome.ts",
     "test/sia-r1/rule.spec.tsx",
     "test/sia-r2/rule.spec.tsx",
+    "test/sia-r13/rule.spec.tsx",
     "test/sia-r21/rule.spec.tsx",
     "test/sia-r24/rule.spec.tsx",
     "test/sia-r38/rule.spec.tsx",


### PR DESCRIPTION
Nodes that have a tab index but no role or ARIA attribute were not exposed in the accessibility tree.  Now they are.

This notably excluded `<iframe>` from the accessibility tree, thus making most of them inapplicable for their relevant rules…