### PR TITLE
Ignore header cells of presentational tables in SIA-R46

### DIFF
--- a/packages/alfa-rules/src/sia-r46/rule.ts
+++ b/packages/alfa-rules/src/sia-r46/rule.ts
@@ -10,10 +10,10 @@ import { Page } from "@siteimprove/alfa-web";
 import { expectation } from "../common/expectation";
 
 import { hasRole } from "../common/predicate/has-role";
-import { isPerceivable } from "../common/predicate/is-perceivable";
+import { isIgnored } from "../common/predicate/is-ignored";
 
 const { isElement, hasName, hasNamespace } = Element;
-const { and, equals } = Predicate;
+const { and, equals, not } = Predicate;
 
 export default Rule.Atomic.of<Page, Element>({
   uri: "https://siteimprove.github.io/sanshikan/rules/sia-r46.html",
@@ -30,7 +30,7 @@ export default Rule.Atomic.of<Page, Element>({
               and(
                 hasNamespace(Namespace.HTML),
                 hasName("table"),
-                isPerceivable(device)
+                not(isIgnored(device))
               )
             )
           );
@@ -44,7 +44,7 @@ export default Rule.Atomic.of<Page, Element>({
                 // The table model only works if the element is a th.
                 hasName("th"),
                 hasRole("rowheader", "columnheader"),
-                isPerceivable(device)
+                not(isIgnored(device))
               )
             )
           );

--- a/packages/alfa-rules/src/sia-r46/rule.ts
+++ b/packages/alfa-rules/src/sia-r46/rule.ts
@@ -11,6 +11,7 @@ import { expectation } from "../common/expectation";
 
 import { hasRole } from "../common/predicate/has-role";
 import { isIgnored } from "../common/predicate/is-ignored";
+import { isPerceivable } from "../common/predicate/is-perceivable";
 
 const { isElement, hasName, hasNamespace } = Element;
 const { and, equals, not } = Predicate;
@@ -44,7 +45,7 @@ export default Rule.Atomic.of<Page, Element>({
                 // The table model only works if the element is a th.
                 hasName("th"),
                 hasRole("rowheader", "columnheader"),
-                not(isIgnored(device))
+                isPerceivable(device)
               )
             )
           );

--- a/packages/alfa-rules/test/sia-r46/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r46/rule.spec.tsx
@@ -108,3 +108,18 @@ test("evaluate() is inapplicable if there is no header cell", async (t) => {
 
   t.deepEqual(await evaluate(R46, { document }), [inapplicable(R46)]);
 });
+
+test("evaluate() is inapplicable if the table element is ignored", async (t) => {
+  const document = Document.of([
+    <table role="presentation">
+      <tr>
+        <th>Column A</th>
+      </tr>
+      <tr>
+        <td>Cell A</td>
+      </tr>
+    </table>,
+  ]);
+
+  t.deepEqual(await evaluate(R46, { document }), [inapplicable(R46)]);
+});


### PR DESCRIPTION
Ignore tables and headers that are presentational, even if they have non-presentational children.
Closes #390.