### PR TITLE
SIA-R68: Exclude elements with an `aria-busy=true` ancestor

### DIFF
--- a/packages/alfa-rules/src/sia-r68/rule.ts
+++ b/packages/alfa-rules/src/sia-r68/rule.ts
@@ -1,7 +1,7 @@
 import { Rule, Diagnostic } from "@siteimprove/alfa-act";
-import { Node, Role } from "@siteimprove/alfa-aria";
+import { Node as AccNode, Role } from "@siteimprove/alfa-aria";
 import { Device } from "@siteimprove/alfa-device";
-import { Element, Namespace } from "@siteimprove/alfa-dom";
+import { Element, Namespace, Node } from "@siteimprove/alfa-dom";
 import { Iterable } from "@siteimprove/alfa-iterable";
 import { Predicate } from "@siteimprove/alfa-predicate";
 import { Ok, Err } from "@siteimprove/alfa-result";
@@ -9,18 +9,23 @@ import { Page } from "@siteimprove/alfa-web";
 
 import { expectation } from "../common/expectation";
 
+import { hasAttribute } from "../common/predicate/has-attribute";
 import { hasRole } from "../common/predicate/has-role";
 import { isIgnored } from "../common/predicate/is-ignored";
+import { Sequence } from "@siteimprove/alfa-sequence";
+import test = Predicate.test;
 
 const { isElement, hasNamespace } = Element;
-const { and, not } = Predicate;
+const { and, equals, not } = Predicate;
 
 export default Rule.Atomic.of<Page, Element>({
   uri: "https://siteimprove.github.io/sanshikan/rules/sia-r68.html",
   evaluate({ device, document }) {
     return {
       applicability() {
-        return document.descendants({ flattened: true, nested: true }).filter(
+        return visit(
+          document,
+          { flattened: true, nested: true },
           and(
             isElement,
             and(
@@ -28,7 +33,8 @@ export default Rule.Atomic.of<Page, Element>({
               not(isIgnored(device)),
               hasRole((role) => role.hasRequiredChildren())
             )
-          )
+          ),
+          and(isElement, hasAttribute("aria-busy", equals("true")))
         );
       },
 
@@ -59,7 +65,7 @@ export namespace Outcomes {
 
 function hasRequiredChildren(device: Device): Predicate<Element> {
   return (element) =>
-    Node.from(element, device).every((node) =>
+    AccNode.from(element, device).every((node) =>
       node.role
         .filter((role) => role.hasRequiredChildren())
         .every((role) =>
@@ -73,13 +79,13 @@ function hasRequiredChildren(device: Device): Predicate<Element> {
 
 function isRequiredChild(
   requiredChildren: Iterable<Iterable<Role.Name>>
-): Predicate<Node> {
+): Predicate<AccNode> {
   return (node) =>
     [...requiredChildren].some((roles) => isRequiredChild(roles)(node));
 
   function isRequiredChild(
     requiredChildren: Iterable<Role.Name>
-  ): Predicate<Node> {
+  ): Predicate<AccNode> {
     return (node) => {
       const [role, ...rest] = requiredChildren;
 
@@ -96,4 +102,38 @@ function isRequiredChild(
       return false;
     };
   }
+}
+
+/**
+ * Collect all descendants of node that:
+ * * match includeNode; and
+ * * do not have an ancestor matching excludeSubtree; and
+ * * have an ancestor matching collectSubtree
+ */
+function visit<T extends Node = Node>(
+  node: Node,
+  options: Node.Traversal,
+  includeNode: Predicate<Node, T> = () => true,
+  excludeSubtree: Predicate<Node> = () => false,
+  collectSubtree: Predicate<Node> = () => true
+): Iterable<T> {
+  function* doVisit(node: Node, collect: boolean): Iterable<T> {
+    if (test<Node>(excludeSubtree, node)) {
+      return Sequence.empty();
+    }
+
+    if (collect && includeNode(node)) {
+      yield node;
+    }
+
+    collect = collect || collectSubtree(node);
+
+    const children = node.children(options);
+
+    for (const child of children) {
+      yield* doVisit(child, collect);
+    }
+  }
+
+  return doVisit(node, false);
 }

--- a/packages/alfa-rules/src/sia-r68/rule.ts
+++ b/packages/alfa-rules/src/sia-r68/rule.ts
@@ -91,9 +91,11 @@ function isRequiredChild(
 }
 
 /**
- * Collect all descendants of node that:
- * * are non-ignored HTML or SVG elements with a role requiring specific children; and
- * * do not have an aria-busy ancestor
+ * Collect all descendants of the given node where the descendant:
+ *
+ * - is a non-ignored HTML or SVG element with a role requiring specific 
+ *   children; and
+ * - does not have an `aria-busy` ancestor.
  */
 function* visit(node: Node, device: Device): Iterable<Element> {
   if (and(isElement, hasAttribute("aria-busy", equals("true")))(node)) {

--- a/packages/alfa-rules/src/sia-r68/rule.ts
+++ b/packages/alfa-rules/src/sia-r68/rule.ts
@@ -7,6 +7,8 @@ import { Predicate } from "@siteimprove/alfa-predicate";
 import { Ok, Err } from "@siteimprove/alfa-result";
 import { Page } from "@siteimprove/alfa-web";
 
+import * as aria from "@siteimprove/alfa-aria";
+
 import { expectation } from "../common/expectation";
 
 import { hasAttribute } from "../common/predicate/has-attribute";

--- a/packages/alfa-rules/src/sia-r68/rule.ts
+++ b/packages/alfa-rules/src/sia-r68/rule.ts
@@ -97,7 +97,7 @@ function isRequiredChild(
  */
 function* visit(node: Node, device: Device): Iterable<Element> {
   if (and(isElement, hasAttribute("aria-busy", equals("true")))(node)) {
-    return [];
+    return;
   }
 
   if (

--- a/packages/alfa-rules/src/sia-r68/rule.ts
+++ b/packages/alfa-rules/src/sia-r68/rule.ts
@@ -1,5 +1,5 @@
 import { Rule, Diagnostic } from "@siteimprove/alfa-act";
-import { Node as AriaNode, Role } from "@siteimprove/alfa-aria";
+import { Role } from "@siteimprove/alfa-aria";
 import { Device } from "@siteimprove/alfa-device";
 import { Element, Namespace, Node } from "@siteimprove/alfa-dom";
 import { Iterable } from "@siteimprove/alfa-iterable";
@@ -51,7 +51,7 @@ export namespace Outcomes {
 
 function hasRequiredChildren(device: Device): Predicate<Element> {
   return (element) =>
-    AriaNode.from(element, device).every((node) =>
+    aria.Node.from(element, device).every((node) =>
       node.role
         .filter((role) => role.hasRequiredChildren())
         .every((role) =>
@@ -65,13 +65,13 @@ function hasRequiredChildren(device: Device): Predicate<Element> {
 
 function isRequiredChild(
   requiredChildren: Iterable<Iterable<Role.Name>>
-): Predicate<AriaNode> {
+): Predicate<aria.Node> {
   return (node) =>
     [...requiredChildren].some((roles) => isRequiredChild(roles)(node));
 
   function isRequiredChild(
     requiredChildren: Iterable<Role.Name>
-  ): Predicate<AriaNode> {
+  ): Predicate<aria.Node> {
     return (node) => {
       const [role, ...rest] = requiredChildren;
 

--- a/packages/alfa-rules/src/sia-r68/rule.ts
+++ b/packages/alfa-rules/src/sia-r68/rule.ts
@@ -17,7 +17,7 @@ import { hasRole } from "../common/predicate/has-role";
 import { isIgnored } from "../common/predicate/is-ignored";
 
 const { isElement, hasNamespace } = Element;
-const { and, equals, not } = Predicate;
+const { and, equals, not } = Refinement;
 
 export default Rule.Atomic.of<Page, Element>({
   uri: "https://siteimprove.github.io/sanshikan/rules/sia-r68.html",
@@ -101,14 +101,12 @@ function isRequiredChild(
  * - does not have an `aria-busy` ancestor.
  */
 function* visit(node: Node, device: Device): Iterable<Element> {
-  if (
-    Refinement.and(isElement, hasAttribute("aria-busy", equals("true")))(node)
-  ) {
+  if (and(isElement, hasAttribute("aria-busy", equals("true")))(node)) {
     return;
   }
 
   if (
-    Refinement.and(
+    and(
       isElement,
       and(
         hasNamespace(Namespace.HTML, Namespace.SVG),

--- a/packages/alfa-rules/src/sia-r68/rule.ts
+++ b/packages/alfa-rules/src/sia-r68/rule.ts
@@ -1,5 +1,5 @@
 import { Rule, Diagnostic } from "@siteimprove/alfa-act";
-import { Node as AccNode, Role } from "@siteimprove/alfa-aria";
+import { Node as AriaNode, Role } from "@siteimprove/alfa-aria";
 import { Device } from "@siteimprove/alfa-device";
 import { Element, Namespace, Node } from "@siteimprove/alfa-dom";
 import { Iterable } from "@siteimprove/alfa-iterable";
@@ -12,8 +12,6 @@ import { expectation } from "../common/expectation";
 import { hasAttribute } from "../common/predicate/has-attribute";
 import { hasRole } from "../common/predicate/has-role";
 import { isIgnored } from "../common/predicate/is-ignored";
-import { Sequence } from "@siteimprove/alfa-sequence";
-import test = Predicate.test;
 
 const { isElement, hasNamespace } = Element;
 const { and, equals, not } = Predicate;
@@ -53,7 +51,7 @@ export namespace Outcomes {
 
 function hasRequiredChildren(device: Device): Predicate<Element> {
   return (element) =>
-    AccNode.from(element, device).every((node) =>
+    AriaNode.from(element, device).every((node) =>
       node.role
         .filter((role) => role.hasRequiredChildren())
         .every((role) =>
@@ -67,13 +65,13 @@ function hasRequiredChildren(device: Device): Predicate<Element> {
 
 function isRequiredChild(
   requiredChildren: Iterable<Iterable<Role.Name>>
-): Predicate<AccNode> {
+): Predicate<AriaNode> {
   return (node) =>
     [...requiredChildren].some((roles) => isRequiredChild(roles)(node));
 
   function isRequiredChild(
     requiredChildren: Iterable<Role.Name>
-  ): Predicate<AccNode> {
+  ): Predicate<AriaNode> {
     return (node) => {
       const [role, ...rest] = requiredChildren;
 

--- a/packages/alfa-rules/src/sia-r68/rule.ts
+++ b/packages/alfa-rules/src/sia-r68/rule.ts
@@ -4,6 +4,7 @@ import { Device } from "@siteimprove/alfa-device";
 import { Element, Namespace, Node } from "@siteimprove/alfa-dom";
 import { Iterable } from "@siteimprove/alfa-iterable";
 import { Predicate } from "@siteimprove/alfa-predicate";
+import { Refinement } from "@siteimprove/alfa-refinement";
 import { Ok, Err } from "@siteimprove/alfa-result";
 import { Page } from "@siteimprove/alfa-web";
 
@@ -100,12 +101,14 @@ function isRequiredChild(
  * - does not have an `aria-busy` ancestor.
  */
 function* visit(node: Node, device: Device): Iterable<Element> {
-  if (and(isElement, hasAttribute("aria-busy", equals("true")))(node)) {
+  if (
+    Refinement.and(isElement, hasAttribute("aria-busy", equals("true")))(node)
+  ) {
     return;
   }
 
   if (
-    and(
+    Refinement.and(
       isElement,
       and(
         hasNamespace(Namespace.HTML, Namespace.SVG),

--- a/packages/alfa-rules/test/sia-r68/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r68/rule.spec.tsx
@@ -6,7 +6,7 @@ import { Document } from "@siteimprove/alfa-dom";
 import R68, { Outcomes } from "../../src/sia-r68/rule";
 
 import { evaluate } from "../common/evaluate";
-import { passed, failed } from "../common/outcome";
+import { passed, failed, inapplicable } from "../common/outcome";
 
 test("evaluate() passes a list with two list items", async (t) => {
   const list = (
@@ -121,4 +121,15 @@ test("evaluate() fails a list with only a non-list item", async (t) => {
   t.deepEqual(await evaluate(R68, { document }), [
     failed(R68, list, { 1: Outcomes.HasIncorrectOwnedElements }),
   ]);
+});
+
+test("evaluate() is inapplicable to aria-busy elements", async (t) => {
+  const menu = (
+    <ul role="menu" aria-busy="true">
+      Loading
+    </ul>
+  );
+
+  const document = Document.of([menu]);
+  t.deepEqual(await evaluate(R68, { document }), [inapplicable(R68)]);
 });


### PR DESCRIPTION
as per the ACT rule.