### PR TITLE
Introduce `@siteimprove/alfa-url` package

### DIFF
--- a/docs/examples/custom-testing/crawling/test.ts
+++ b/docs/examples/custom-testing/crawling/test.ts
@@ -25,9 +25,9 @@ Crawler.with(async (crawler) => {
 
       const earl = outcomes.map((outcome) => outcome.toEARL());
 
-      const url = new URL(input.response.url);
+      const { url } = input.response;
 
-      console.group(url.href);
+      console.group(url.toString());
       logStats(outcomes);
       console.groupEnd();
 
@@ -35,8 +35,8 @@ Crawler.with(async (crawler) => {
         path.join(
           __dirname,
           "outcomes",
-          url.host,
-          url.pathname.replace(/\/$/, "")
+          url.host.get(),
+          ...url.path.filter((segment) => segment !== "")
         ) + ".json";
 
       fs.mkdirSync(path.dirname(file), { recursive: true });

--- a/docs/examples/custom-testing/scraping/test.ts
+++ b/docs/examples/custom-testing/scraping/test.ts
@@ -21,9 +21,9 @@ Scraper.with(async (scraper) => {
 
     const earl = outcomes.map((outcome) => outcome.toEARL());
 
-    const url = new URL(input.response.url);
+    const { url } = input.response;
 
-    console.group(url.href);
+    console.group(url.toString());
     logStats(outcomes);
     console.groupEnd();
 
@@ -31,8 +31,8 @@ Scraper.with(async (scraper) => {
       path.join(
         __dirname,
         "outcomes",
-        url.host,
-        url.pathname.replace(/\/$/, "")
+        url.host.get(),
+        ...url.path.filter((segment) => segment !== "")
       ) + ".json";
 
     fs.mkdirSync(path.dirname(file), { recursive: true });

--- a/packages/alfa-cli/bin/alfa/command/scrape/run.ts
+++ b/packages/alfa-cli/bin/alfa/command/scrape/run.ts
@@ -15,6 +15,7 @@ import {
   Screenshot,
 } from "@siteimprove/alfa-scraper";
 import { Timeout } from "@siteimprove/alfa-time";
+import { URL } from "@siteimprove/alfa-url";
 
 import type { Arguments } from "./arguments";
 import type { Flags } from "./flags";
@@ -139,7 +140,7 @@ export const run: Command.Runner<typeof Flags, typeof Arguments> = async ({
   const timeout = Timeout.of(flags.timeout);
 
   const result = await scraper.scrape(
-    new URL(target, url.pathToFileURL(process.cwd() + path.sep)),
+    URL.parse(target, url.pathToFileURL(process.cwd() + path.sep).href).get(),
     {
       timeout,
       awaiter,

--- a/packages/alfa-cli/package.json
+++ b/packages/alfa-cli/package.json
@@ -35,6 +35,7 @@
     "@siteimprove/alfa-rules": "^0.5.0",
     "@siteimprove/alfa-scraper": "^0.5.0",
     "@siteimprove/alfa-time": "^0.5.0",
+    "@siteimprove/alfa-url": "^0.5.0",
     "@siteimprove/alfa-web": "^0.5.0",
     "@siteimprove/alfa-xpath": "^0.5.0",
     "@types/node": "^14.0.12",

--- a/packages/alfa-cli/tsconfig.json
+++ b/packages/alfa-cli/tsconfig.json
@@ -91,6 +91,9 @@
       "path": "../alfa-time"
     },
     {
+      "path": "../alfa-url"
+    },
+    {
       "path": "../alfa-web"
     },
     {

--- a/packages/alfa-crawler/package.json
+++ b/packages/alfa-crawler/package.json
@@ -23,6 +23,7 @@
     "@siteimprove/alfa-mapper": "^0.5.0",
     "@siteimprove/alfa-result": "^0.5.0",
     "@siteimprove/alfa-scraper": "^0.5.0",
+    "@siteimprove/alfa-url": "^0.5.0",
     "@siteimprove/alfa-web": "^0.5.0"
   },
   "devDependencies": {

--- a/packages/alfa-crawler/test/crawler.spec.ts
+++ b/packages/alfa-crawler/test/crawler.spec.ts
@@ -15,7 +15,7 @@ test("#crawl() crawls a frontier", async (t) =>
     for await (const result of crawler.crawl(frontier)) {
       t.equal(result.isOk(), true);
 
-      pages.push(result.get().response.url);
+      pages.push(result.get().response.url.toString());
     }
 
     t.deepEqual(pages, [

--- a/packages/alfa-crawler/tsconfig.json
+++ b/packages/alfa-crawler/tsconfig.json
@@ -22,6 +22,9 @@
       "path": "../alfa-test"
     },
     {
+      "path": "../alfa-url"
+    },
+    {
       "path": "../alfa-web"
     }
   ]

--- a/packages/alfa-frontier/package.json
+++ b/packages/alfa-frontier/package.json
@@ -21,7 +21,8 @@
     "@siteimprove/alfa-equatable": "^0.5.0",
     "@siteimprove/alfa-json": "^0.5.0",
     "@siteimprove/alfa-option": "^0.5.0",
-    "@siteimprove/alfa-predicate": "^0.5.0"
+    "@siteimprove/alfa-predicate": "^0.5.0",
+    "@siteimprove/alfa-url": "^0.5.0"
   },
   "devDependencies": {
     "@siteimprove/alfa-test": "^0.5.0"

--- a/packages/alfa-frontier/test/frontier.spec.ts
+++ b/packages/alfa-frontier/test/frontier.spec.ts
@@ -106,7 +106,7 @@ test("#enqueue() doesn't change the state of an already seen URL", (t) => {
 test("#dequeue() gets the next waiting URL in queue and moves it to in progress", (t) => {
   const frontier = Frontier.of("https://example.com/");
 
-  t.deepEqual(frontier.dequeue().get(), new URL("https://example.com"));
+  t.deepEqual(frontier.dequeue().get().toString(), "https://example.com/");
 
   t.deepEqual(frontier.toJSON(), {
     scope: "https://example.com/",

--- a/packages/alfa-http/package.json
+++ b/packages/alfa-http/package.json
@@ -25,7 +25,8 @@
     "@siteimprove/alfa-json": "^0.5.0",
     "@siteimprove/alfa-map": "^0.5.0",
     "@siteimprove/alfa-option": "^0.5.0",
-    "@siteimprove/alfa-refinement": "^0.5.0"
+    "@siteimprove/alfa-refinement": "^0.5.0",
+    "@siteimprove/alfa-url": "^0.5.0"
   },
   "devDependencies": {
     "@siteimprove/alfa-test": "^0.5.0"

--- a/packages/alfa-http/src/request.ts
+++ b/packages/alfa-http/src/request.ts
@@ -1,4 +1,6 @@
 import { Decoder, Encoder } from "@siteimprove/alfa-encoding";
+import { URL } from "@siteimprove/alfa-url";
+
 import * as earl from "@siteimprove/alfa-earl";
 import * as json from "@siteimprove/alfa-json";
 
@@ -11,25 +13,27 @@ import { Headers } from "./headers";
 export class Request implements Body, json.Serializable, earl.Serializable {
   public static of(
     method: string,
-    url: string,
+    url: URL,
     headers: Headers = Headers.empty(),
     body: ArrayBuffer = new ArrayBuffer(0)
   ): Request {
     return new Request(method, url, headers, body);
   }
 
+  private static _empty = Request.of("GET", URL.parse("about:blank").get());
+
   public static empty(): Request {
-    return Request.of("GET", "about:blank");
+    return this._empty;
   }
 
   private readonly _method: string;
-  private readonly _url: string;
+  private readonly _url: URL;
   private readonly _headers: Headers;
   private readonly _body: ArrayBuffer;
 
   private constructor(
     method: string,
-    url: string,
+    url: URL,
     headers: Headers,
     body: ArrayBuffer
   ) {
@@ -49,7 +53,7 @@ export class Request implements Body, json.Serializable, earl.Serializable {
   /**
    * @see https://fetch.spec.whatwg.org/#dom-request-url
    */
-  public get url(): string {
+  public get url(): URL {
     return this._url;
   }
 
@@ -70,7 +74,7 @@ export class Request implements Body, json.Serializable, earl.Serializable {
   public toJSON(): Request.JSON {
     return {
       method: this._method,
-      url: this._url,
+      url: this._url.toString(),
       headers: this._headers.toJSON(),
       body: Decoder.decode(new Uint8Array(this._body)),
     };
@@ -83,7 +87,7 @@ export class Request implements Body, json.Serializable, earl.Serializable {
       },
       "@type": ["http:Message", "http:Request"],
       "http:methodName": this._method,
-      "http:requestURI": this._url,
+      "http:requestURI": this._url.toString(),
       "http:headers": this._headers.toEARL(),
       "http:body": {
         "@context": {
@@ -130,7 +134,7 @@ export namespace Request {
   export function from(json: JSON): Request {
     return Request.of(
       json.method,
-      json.url,
+      URL.parse(json.url).get(),
       Headers.from(json.headers),
       Encoder.encode(json.body)
     );

--- a/packages/alfa-http/src/response.ts
+++ b/packages/alfa-http/src/response.ts
@@ -1,4 +1,6 @@
 import { Decoder, Encoder } from "@siteimprove/alfa-encoding";
+import { URL } from "@siteimprove/alfa-url";
+
 import * as earl from "@siteimprove/alfa-earl";
 import * as json from "@siteimprove/alfa-json";
 
@@ -10,7 +12,7 @@ import { Headers } from "./headers";
  */
 export class Response implements Body, json.Serializable, earl.Serializable {
   public static of(
-    url: string,
+    url: URL,
     status: number,
     headers: Headers = Headers.empty(),
     body: ArrayBuffer = new ArrayBuffer(0)
@@ -18,17 +20,19 @@ export class Response implements Body, json.Serializable, earl.Serializable {
     return new Response(url, status, headers, body);
   }
 
+  private static _empty = Response.of(URL.parse("about:blank").get(), 200);
+
   public static empty(): Response {
-    return Response.of("about:blank", 200);
+    return this._empty;
   }
 
-  private readonly _url: string;
+  private readonly _url: URL;
   private readonly _status: number;
   private readonly _headers: Headers;
   private readonly _body: ArrayBuffer;
 
   private constructor(
-    url: string,
+    url: URL,
     status: number,
     headers: Headers,
     body: ArrayBuffer
@@ -42,7 +46,7 @@ export class Response implements Body, json.Serializable, earl.Serializable {
   /**
    * @see https://fetch.spec.whatwg.org/#dom-response-url
    */
-  public get url(): string {
+  public get url(): URL {
     return this._url;
   }
 
@@ -69,7 +73,7 @@ export class Response implements Body, json.Serializable, earl.Serializable {
 
   public toJSON(): Response.JSON {
     return {
-      url: this._url,
+      url: this._url.toString(),
       status: this._status,
       headers: this._headers.toJSON(),
       body: Decoder.decode(new Uint8Array(this._body)),
@@ -127,7 +131,7 @@ export namespace Response {
 
   export function from(json: JSON): Response {
     return Response.of(
-      json.url,
+      URL.parse(json.url).get(),
       json.status,
       Headers.from(json.headers),
       Encoder.encode(json.body)

--- a/packages/alfa-http/tsconfig.json
+++ b/packages/alfa-http/tsconfig.json
@@ -38,6 +38,9 @@
     },
     {
       "path": "../alfa-test"
+    },
+    {
+      "path": "../alfa-url"
     }
   ]
 }

--- a/packages/alfa-json-ld/package.json
+++ b/packages/alfa-json-ld/package.json
@@ -19,7 +19,8 @@
   ],
   "dependencies": {
     "@siteimprove/alfa-option": "^0.5.0",
-    "@siteimprove/alfa-result": "^0.5.0"
+    "@siteimprove/alfa-result": "^0.5.0",
+    "@siteimprove/alfa-url": "^0.5.0"
   },
   "devDependencies": {
     "@siteimprove/alfa-test": "^0.5.0"

--- a/packages/alfa-json-ld/src/expand.ts
+++ b/packages/alfa-json-ld/src/expand.ts
@@ -2,6 +2,7 @@
 
 import { None, Option, Some } from "@siteimprove/alfa-option";
 import { Err, Ok, Result } from "@siteimprove/alfa-result";
+import { URL } from "@siteimprove/alfa-url";
 
 import {
   isDictionary,
@@ -871,10 +872,6 @@ function isRelativeIri(url: string): boolean {
   return relativeIri.test(url);
 }
 
-function resolveUrl(target: string, base: string): string {
-  return new URL(target, base).href;
-}
-
 function getMapping(
   context: Context,
   property: string | null,
@@ -957,7 +954,13 @@ function processContext(
         const base = result["@base"];
 
         if (typeof base === "string") {
-          result["@base"] = resolveUrl(value, base);
+          const url = URL.parse(value, base);
+
+          if (url.isErr()) {
+            return url;
+          }
+
+          result["@base"] = url.get().toString();
         }
       }
 

--- a/packages/alfa-json-ld/tsconfig.json
+++ b/packages/alfa-json-ld/tsconfig.json
@@ -18,6 +18,9 @@
     },
     {
       "path": "../alfa-test"
+    },
+    {
+      "path": "../alfa-url"
     }
   ]
 }

--- a/packages/alfa-scraper/test/scraper.spec.ts
+++ b/packages/alfa-scraper/test/scraper.spec.ts
@@ -11,7 +11,7 @@ test("#scrape() scrapes a page with a hash fragment", async (t) =>
 
     const { response } = result.get();
 
-    t.equal(response.url, url);
+    t.equal(response.url.toString(), url);
   }));
 
 test("#scrape() scrapes a page with an immediate meta refresh", async (t) =>
@@ -23,7 +23,7 @@ test("#scrape() scrapes a page with an immediate meta refresh", async (t) =>
 
     const { response } = result.get();
 
-    t.equal(response.url, "https://example.com/");
+    t.equal(response.url.toString(), "https://example.com/");
   }));
 
 test("#scrape() scrapes a page with a delayed meta refresh", async (t) =>
@@ -35,7 +35,7 @@ test("#scrape() scrapes a page with a delayed meta refresh", async (t) =>
 
     const { response } = result.get();
 
-    t.equal(response.url, url);
+    t.equal(response.url.toString(), url);
   }));
 
 test("#scrape() scrapes a page with an immediate location change", async (t) =>
@@ -47,7 +47,7 @@ test("#scrape() scrapes a page with an immediate location change", async (t) =>
 
     const { response } = result.get();
 
-    t.equal(response.url, "https://example.com/");
+    t.equal(response.url.toString(), "https://example.com/");
   }));
 
 test("#scrape() scrapes a page with a delayed location change", async (t) =>
@@ -59,5 +59,5 @@ test("#scrape() scrapes a page with a delayed location change", async (t) =>
 
     const { response } = result.get();
 
-    t.equal(response.url, url);
+    t.equal(response.url.toString(), url);
   }));

--- a/packages/alfa-scraper/tsconfig.json
+++ b/packages/alfa-scraper/tsconfig.json
@@ -38,6 +38,9 @@
       "path": "../alfa-time"
     },
     {
+      "path": "../alfa-url"
+    },
+    {
       "path": "../alfa-web"
     }
   ]

--- a/packages/alfa-url/package.json
+++ b/packages/alfa-url/package.json
@@ -1,14 +1,14 @@
 {
   "$schema": "http://json.schemastore.org/package",
-  "name": "@siteimprove/alfa-scraper",
+  "name": "@siteimprove/alfa-url",
   "homepage": "https://siteimprove.com",
   "version": "0.5.0",
   "license": "MIT",
-  "description": "An implementation of a simple web scraper capable of producing page objects",
+  "description": "Functionality for working with immutable URLs",
   "repository": {
     "type": "git",
     "url": "https://github.com/siteimprove/alfa.git",
-    "directory": "packages/alfa-scraper"
+    "directory": "packages/alfa-url"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "main": "src/index.js",
@@ -18,18 +18,13 @@
     "src/**/*.d.ts"
   ],
   "dependencies": {
-    "@siteimprove/alfa-device": "^0.5.0",
-    "@siteimprove/alfa-dom": "^0.5.0",
     "@siteimprove/alfa-equatable": "^0.5.0",
-    "@siteimprove/alfa-http": "^0.5.0",
+    "@siteimprove/alfa-hash": "^0.5.0",
+    "@siteimprove/alfa-iterable": "^0.5.0",
     "@siteimprove/alfa-json": "^0.5.0",
-    "@siteimprove/alfa-puppeteer": "^0.5.0",
+    "@siteimprove/alfa-option": "^0.5.0",
     "@siteimprove/alfa-result": "^0.5.0",
-    "@siteimprove/alfa-time": "^0.5.0",
-    "@siteimprove/alfa-url": "^0.5.0",
-    "@siteimprove/alfa-web": "^0.5.0",
-    "@types/puppeteer": "^3.0.1",
-    "puppeteer": "^5.2.1"
+    "@siteimprove/alfa-sequence": "^0.5.0"
   },
   "devDependencies": {
     "@siteimprove/alfa-test": "^0.5.0"

--- a/packages/alfa-url/src/index.ts
+++ b/packages/alfa-url/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./url";

--- a/packages/alfa-url/src/url.ts
+++ b/packages/alfa-url/src/url.ts
@@ -1,0 +1,312 @@
+import { Equatable } from "@siteimprove/alfa-equatable";
+import { Hash, Hashable } from "@siteimprove/alfa-hash";
+import { Iterable } from "@siteimprove/alfa-iterable";
+import { Serializable } from "@siteimprove/alfa-json";
+import { Option, None } from "@siteimprove/alfa-option";
+import { Result, Err } from "@siteimprove/alfa-result";
+import { Sequence } from "@siteimprove/alfa-sequence";
+
+import * as json from "@siteimprove/alfa-json";
+
+const { isEmpty } = Iterable;
+
+/**
+ * @see https://url.spec.whatwg.org/
+ */
+export class URL implements Equatable, Hashable, Serializable {
+  public static of(
+    scheme: string,
+    username: Option<string> = None,
+    password: Option<string> = None,
+    host: Option<string> = None,
+    port: Option<number> = None,
+    path: Iterable<string> = [],
+    query: Option<string> = None,
+    fragment: Option<string> = None
+  ): URL {
+    return new URL(
+      scheme,
+      username,
+      password,
+      host,
+      port,
+      Sequence.from(path),
+      query,
+      fragment
+    );
+  }
+  private readonly _scheme: string;
+  private readonly _username: Option<string>;
+  private readonly _password: Option<string>;
+  private readonly _host: Option<string>;
+  private readonly _port: Option<number>;
+  private readonly _path: Sequence<string>;
+  private readonly _query: Option<string>;
+  private readonly _fragment: Option<string>;
+
+  private constructor(
+    scheme: string,
+    username: Option<string>,
+    password: Option<string>,
+    host: Option<string>,
+    port: Option<number>,
+    path: Sequence<string>,
+    query: Option<string>,
+    fragment: Option<string>
+  ) {
+    this._scheme = scheme;
+    this._username = username;
+    this._password = password;
+    this._host = host;
+    this._port = port;
+    this._path = path;
+    this._query = query;
+    this._fragment = fragment;
+  }
+
+  /**
+   * @see https://url.spec.whatwg.org/#concept-url-scheme
+   */
+  public get scheme(): string {
+    return this._scheme;
+  }
+
+  /**
+   * @see https://url.spec.whatwg.org/#concept-url-username
+   */
+  public get username(): Option<string> {
+    return this._username;
+  }
+
+  /**
+   * @see https://url.spec.whatwg.org/#concept-url-password
+   */
+  public get password(): Option<string> {
+    return this._password;
+  }
+
+  /**
+   * @see https://url.spec.whatwg.org/#concept-url-host
+   */
+  public get host(): Option<string> {
+    return this._host;
+  }
+
+  /**
+   * @see https://url.spec.whatwg.org/#concept-url-port
+   */
+  public get port(): Option<number> {
+    return this._port;
+  }
+
+  /**
+   * @see https://url.spec.whatwg.org/#concept-url-path
+   */
+  public get path(): Sequence<string> {
+    return this._path;
+  }
+
+  /**
+   * @see https://url.spec.whatwg.org/#concept-url-query
+   */
+  public get query(): Option<string> {
+    return this._query;
+  }
+
+  /**
+   * @see https://url.spec.whatwg.org/#concept-url-fragment
+   */
+  public get fragment(): Option<string> {
+    return this._fragment;
+  }
+
+  /**
+   * @see https://url.spec.whatwg.org/#include-credentials
+   */
+  public hasCredentials(): boolean {
+    return this._username.isSome() || this._password.isSome();
+  }
+
+  /**
+   * Remove the fragment portion of this URL.
+   *
+   * @remarks
+   * This method is useful for contexts in which the fragment portion of the URL,
+   * which isn't passed from client to server, is of no interest.
+   */
+  public withoutFragment(): URL {
+    if (this._fragment.isNone()) {
+      return this;
+    }
+
+    return new URL(
+      this._scheme,
+      this._username,
+      this._password,
+      this._host,
+      this._port,
+      this._path,
+      this._query,
+      None
+    );
+  }
+
+  /**
+   * @see https://url.spec.whatwg.org/#concept-url-equals
+   */
+  public equals(value: URL): boolean;
+
+  /**
+   * @see https://url.spec.whatwg.org/#concept-url-equals
+   */
+  public equals(value: unknown): value is this;
+
+  public equals(value: unknown): boolean {
+    return (
+      value instanceof URL &&
+      value._scheme === this._scheme &&
+      value._username.equals(this._username) &&
+      value._password.equals(this._password) &&
+      value._host.equals(this._host) &&
+      value._port.equals(this._port) &&
+      value._path.equals(this._path) &&
+      value._query.equals(this._query) &&
+      value._fragment.equals(this._fragment)
+    );
+  }
+
+  public hash(hash: Hash): void {
+    Hash.writeString(hash, this._scheme);
+    this._username.hash(hash);
+    this._password.hash(hash);
+    this._host.hash(hash);
+    this._port.hash(hash);
+    this._path.hash(hash);
+    this._query.hash(hash);
+    this._fragment.hash(hash);
+  }
+
+  public toJSON(): URL.JSON {
+    return {
+      scheme: this._scheme,
+      username: this._username.getOr(null),
+      password: this._password.getOr(null),
+      host: this._host.getOr(null),
+      port: this._port.getOr(null),
+      path: this._path.toArray(),
+      query: this._query.getOr(null),
+      fragment: this._fragment.getOr(null),
+    };
+  }
+
+  /**
+   * @see https://url.spec.whatwg.org/#concept-url-serializer
+   */
+  public toString(): string {
+    let output = this._scheme + ":";
+
+    for (const host of this._host) {
+      output += "//";
+
+      if (this.hasCredentials()) {
+        for (const username of this._username) {
+          output += username;
+        }
+
+        for (const password of this._password) {
+          output += ":" + password;
+        }
+
+        output += "@";
+      }
+
+      output += host;
+
+      for (const port of this._port) {
+        output += ":" + port.toString(10);
+      }
+    }
+
+    if (this._host.isNone() && this._scheme === "file") {
+      output += "//";
+    }
+
+    if (
+      this._host.isNone() &&
+      this._path.size > 1 &&
+      this._path.first().includes("")
+    ) {
+      output += "/.";
+    }
+
+    for (const segment of this._path) {
+      output += "/" + segment;
+    }
+
+    for (const query of this._query) {
+      output += "?" + query;
+    }
+
+    for (const fragment of this._fragment) {
+      output += "#" + fragment;
+    }
+
+    return output;
+  }
+}
+
+export namespace URL {
+  export interface JSON {
+    [key: string]: json.JSON;
+    scheme: string;
+    username: string | null;
+    password: string | null;
+    host: string | null;
+    port: number | null;
+    path: Array<string>;
+    query: string | null;
+    fragment: string | null;
+  }
+
+  export function parse(url: string, base?: string | URL): Result<URL, string> {
+    try {
+      const {
+        // https://url.spec.whatwg.org/#dom-url-protocol
+        protocol,
+        // https://url.spec.whatwg.org/#dom-url-username
+        username,
+        // https://url.spec.whatwg.org/#dom-url-password
+        password,
+        // https://url.spec.whatwg.org/#dom-url-hostname
+        hostname,
+        // https://url.spec.whatwg.org/#dom-url-port
+        port,
+        // https://url.spec.whatwg.org/#dom-url-pathname
+        pathname,
+        // https://url.spec.whatwg.org/#dom-url-search
+        search,
+        // https://url.spec.whatwg.org/#dom-url-hash
+        hash,
+      } = new globalThis.URL(url, base?.toString());
+
+      return Result.of(
+        URL.of(
+          protocol.slice(0, -1),
+          Option.of(username).reject(isEmpty),
+          Option.of(password).reject(isEmpty),
+          Option.of(hostname).reject(isEmpty),
+          Option.of(port).reject(isEmpty).map(Number),
+          pathname.slice(1).split("/"),
+          Option.of(search)
+            .reject(isEmpty)
+            .map((search) => search.slice(1)),
+          Option.of(hash)
+            .reject(isEmpty)
+            .map((hash) => hash.slice(1))
+        )
+      );
+    } catch (err) {
+      return Err.of(err.message);
+    }
+  }
+}

--- a/packages/alfa-url/src/url.ts
+++ b/packages/alfa-url/src/url.ts
@@ -8,6 +8,8 @@ import { Sequence } from "@siteimprove/alfa-sequence";
 
 import * as json from "@siteimprove/alfa-json";
 
+import { Builtin } from "./url/builtin";
+
 const { isEmpty } = Iterable;
 
 /**
@@ -319,7 +321,7 @@ export namespace URL {
         search,
         // https://url.spec.whatwg.org/#dom-url-hash
         hash,
-      } = new globalThis.URL(url, base?.toString());
+      } = new Builtin(url, base?.toString());
 
       return Result.of(
         URL.of(

--- a/packages/alfa-url/src/url.ts
+++ b/packages/alfa-url/src/url.ts
@@ -324,7 +324,7 @@ export namespace URL {
       return Result.of(
         URL.of(
           // `URL#protocol` appends a ":" to the scheme which we need to remove.
-          protocol.slice(0, -1),
+          protocol.replace(/:$/, ""),
 
           // `URL#username`, `URL#password`, and `URL#hostname` expose the
           // username, password, and host as-is and so the only thing we need to
@@ -340,19 +340,19 @@ export namespace URL {
           // `URL#pathname` exposes the path segments with a leading "/" and
           // joins the segments with "/". We therefore remove the leading "/"
           // and split the segments by "/" into an array.
-          pathname.slice(1).split("/"),
+          pathname.replace(/^\//, "").split("/"),
 
           // `URL#search` exposes the query portion of the URL with a leading
           // "?" which we need to remove.
           Option.of(search)
             .reject(isEmpty)
-            .map((search) => search.slice(1)),
+            .map((search) => search.replace(/^\?/, "")),
 
           // `URL#hash` exposes the fragment portion of the URL with a leading
           // "#" which we need to remove.
           Option.of(hash)
             .reject(isEmpty)
-            .map((hash) => hash.slice(1))
+            .map((hash) => hash.replace(/^#/, ""))
         )
       );
     } catch (err) {

--- a/packages/alfa-url/src/url/builtin.ts
+++ b/packages/alfa-url/src/url/builtin.ts
@@ -1,0 +1,4 @@
+/**
+ * @internal
+ */
+export const Builtin = URL;

--- a/packages/alfa-url/test/url.spec.ts
+++ b/packages/alfa-url/test/url.spec.ts
@@ -28,6 +28,19 @@ test(".parse() parses a relative URL against a base URL", (t) => {
   });
 });
 
+test(".parse() parses the special about:blank URL", (t) => {
+  t.deepEqual(URL.parse("about:blank").get().toJSON(), {
+    scheme: "about",
+    username: null,
+    password: null,
+    host: null,
+    port: null,
+    path: ["blank"],
+    query: null,
+    fragment: null,
+  });
+});
+
 test("#equals() checks if two URLs are equal", (t) => {
   const a = URL.parse("foo", "file:").get();
   const b = URL.parse("foo", "file:").get();

--- a/packages/alfa-url/test/url.spec.ts
+++ b/packages/alfa-url/test/url.spec.ts
@@ -1,3 +1,37 @@
 import { test } from "@siteimprove/alfa-test";
 
+import { None, Option } from "@siteimprove/alfa-option";
+
 import { URL } from "../src/url";
+
+test(".parse() parses an absolute URL", (t) => {
+  t.deepEqual(
+    URL.parse("https://example.com/page.html").get().toJSON(),
+    URL.of(
+      "https",
+      None,
+      None,
+      Option.of("example.com"),
+      None,
+      ["page.html"],
+      None,
+      None
+    ).toJSON()
+  );
+});
+
+test(".parse() parses a relative URL against a base URL", (t) => {
+  t.deepEqual(
+    URL.parse("/page.html", "https://example.com/").get().toJSON(),
+    URL.of(
+      "https",
+      None,
+      None,
+      Option.of("example.com"),
+      None,
+      ["page.html"],
+      None,
+      None
+    ).toJSON()
+  );
+});

--- a/packages/alfa-url/test/url.spec.ts
+++ b/packages/alfa-url/test/url.spec.ts
@@ -1,37 +1,29 @@
 import { test } from "@siteimprove/alfa-test";
 
-import { None, Option } from "@siteimprove/alfa-option";
-
 import { URL } from "../src/url";
 
 test(".parse() parses an absolute URL", (t) => {
-  t.deepEqual(
-    URL.parse("https://example.com/page.html").get().toJSON(),
-    URL.of(
-      "https",
-      None,
-      None,
-      Option.of("example.com"),
-      None,
-      ["page.html"],
-      None,
-      None
-    ).toJSON()
-  );
+  t.deepEqual(URL.parse("https://example.com/page.html").get().toJSON(), {
+    scheme: "https",
+    username: null,
+    password: null,
+    host: "example.com",
+    port: null,
+    path: ["page.html"],
+    query: null,
+    fragment: null,
+  });
 });
 
 test(".parse() parses a relative URL against a base URL", (t) => {
-  t.deepEqual(
-    URL.parse("/page.html", "https://example.com/").get().toJSON(),
-    URL.of(
-      "https",
-      None,
-      None,
-      Option.of("example.com"),
-      None,
-      ["page.html"],
-      None,
-      None
-    ).toJSON()
-  );
+  t.deepEqual(URL.parse("/page.html", "https://example.com/").get().toJSON(), {
+    scheme: "https",
+    username: null,
+    password: null,
+    host: "example.com",
+    port: null,
+    path: ["page.html"],
+    query: null,
+    fragment: null,
+  });
 });

--- a/packages/alfa-url/test/url.spec.ts
+++ b/packages/alfa-url/test/url.spec.ts
@@ -1,0 +1,3 @@
+import { test } from "@siteimprove/alfa-test";
+
+import { URL } from "../src/url";

--- a/packages/alfa-url/test/url.spec.ts
+++ b/packages/alfa-url/test/url.spec.ts
@@ -27,3 +27,13 @@ test(".parse() parses a relative URL against a base URL", (t) => {
     fragment: null,
   });
 });
+
+test("#equals() checks if two URLs are equal", (t) => {
+  const a = URL.parse("foo", "file:").get();
+  const b = URL.parse("foo", "file:").get();
+  const c = URL.parse("bar", "file:").get();
+
+  t.equal(a.equals(a), true);
+  t.equal(a.equals(b), true);
+  t.equal(a.equals(c), false);
+});

--- a/packages/alfa-url/tsconfig.json
+++ b/packages/alfa-url/tsconfig.json
@@ -1,10 +1,16 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "../tsconfig.json",
-  "files": ["src/frontier.ts", "src/index.ts", "test/frontier.spec.ts"],
+  "files": ["src/index.ts", "src/url.ts", "test/url.spec.ts"],
   "references": [
     {
       "path": "../alfa-equatable"
+    },
+    {
+      "path": "../alfa-hash"
+    },
+    {
+      "path": "../alfa-iterable"
     },
     {
       "path": "../alfa-json"
@@ -13,13 +19,13 @@
       "path": "../alfa-option"
     },
     {
-      "path": "../alfa-predicate"
+      "path": "../alfa-result"
+    },
+    {
+      "path": "../alfa-sequence"
     },
     {
       "path": "../alfa-test"
-    },
-    {
-      "path": "../alfa-url"
     }
   ]
 }

--- a/packages/alfa-url/tsconfig.json
+++ b/packages/alfa-url/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "../tsconfig.json",
-  "files": ["src/index.ts", "src/url.ts", "test/url.spec.ts"],
+  "files": [
+    "src/index.ts",
+    "src/url.ts",
+    "src/url/builtin.ts",
+    "test/url.spec.ts"
+  ],
   "references": [
     {
       "path": "../alfa-equatable"

--- a/packages/alfa-web/src/page.ts
+++ b/packages/alfa-web/src/page.ts
@@ -69,8 +69,8 @@ export class Page implements Resource, json.Serializable, earl.Serializable {
         dct: "http://purl.org/dc/terms/",
       },
       "@type": ["earl:TestSubject"],
-      "@id": this.response.url,
-      "dct:source": this.response.url,
+      "@id": this.response.url.toString(),
+      "dct:source": this.response.url.toString(),
       "dct:hasPart": [this._request.toEARL(), this._response.toEARL()],
     };
   }

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -84,6 +84,7 @@
     { "path": "alfa-trampoline" },
     { "path": "alfa-trilean" },
     { "path": "alfa-unexpected" },
+    { "path": "alfa-url" },
     { "path": "alfa-vue" },
     { "path": "alfa-web" },
     { "path": "alfa-webdriver" },


### PR DESCRIPTION
This pull request introduces a new `@siteimprove/alfa-url` package with an implementation of an immutable URL class modelled on the WHATWG URL specification. An obvious question might be "why not just use the WHATWG URL DOM API?" to which the obvious answer is "well, it kinda does". That is, `URL.parse()` relies on the WHATWG URL DOM API for parsing URL strings and extracting URL records. From there, the `URL` class also adds some convenience like implementations of `Equatable`, `Hashable`, and `Serializable`, making it easy to use `URL` instances in the various data structures Alfa provides.

The caveat to this approach is of course that we now rely on the WHATWG URL specification being implemented by whatever runtime Alfa is used in, which shouldn't really be a problem. It's of course readily available in browsers and is also supported in Node.js 10+ as well as Deno.