### PR TITLE
Implement traversal API for `Graph`

### DIFF
--- a/packages/alfa-graph/package.json
+++ b/packages/alfa-graph/package.json
@@ -22,7 +22,7 @@
     "@siteimprove/alfa-iterable": "^0.5.0",
     "@siteimprove/alfa-json": "^0.5.0",
     "@siteimprove/alfa-map": "^0.5.0",
-    "@siteimprove/alfa-option": "^0.5.0",
+    "@siteimprove/alfa-sequence": "^0.5.0",
     "@siteimprove/alfa-set": "^0.5.0"
   },
   "devDependencies": {

--- a/packages/alfa-graph/src/graph.ts
+++ b/packages/alfa-graph/src/graph.ts
@@ -180,12 +180,12 @@ export namespace Graph {
    * @see https://en.wikipedia.org/wiki/Depth-first_search
    */
   export const DepthFirst: Traversal = function* <T>(graph: Graph<T>, root: T) {
-    const queue = [root];
+    const stack = [root];
 
     let seen = Set.empty<T>();
 
-    while (queue.length > 0) {
-      const next = queue.pop()!;
+    while (stack.length > 0) {
+      const next = stack.pop()!;
 
       if (seen.has(next)) {
         continue;
@@ -196,7 +196,7 @@ export namespace Graph {
       seen = seen.add(next);
 
       for (const neighbor of graph.neighbors(next)) {
-        queue.push(neighbor);
+        stack.push(neighbor);
       }
     }
   };

--- a/packages/alfa-graph/test/graph.spec.ts
+++ b/packages/alfa-graph/test/graph.spec.ts
@@ -113,9 +113,6 @@ test("#traverse() traverses the subgraph rooted at a node breadth-first", (t) =>
 });
 
 test("#hasPath() checks if there's a path from one node to another", (t) => {
-  // foo always has a path to itself
-  t.equal(graph.hasPath("foo", "foo"), true);
-
   // foo -> bar
   t.equal(graph.hasPath("foo", "bar"), true);
 
@@ -124,4 +121,9 @@ test("#hasPath() checks if there's a path from one node to another", (t) => {
 
   // bar has no neighbors
   t.equal(graph.hasPath("bar", "baz"), false);
+
+  // A node always has a path to itself
+  for (const node of ["foo", "bar", "baz"]) {
+    t.equal(graph.hasPath(node, node), true);
+  }
 });

--- a/packages/alfa-graph/test/graph.spec.ts
+++ b/packages/alfa-graph/test/graph.spec.ts
@@ -73,20 +73,13 @@ test("#traverse() traverses the subgraph rooted at a node depth-first", (t) => {
   t.deepEqual(
     [...graph.traverse(1, Graph.DepthFirst)],
     [
-      // 1
-      1,
-      // |- 5
-      5,
-      //    |- 7
-      7,
-      //    |- 6
-      6,
-      // |- 2
-      2,
-      //    |- 3
-      3,
-      //    |- 4
-      4,
+      1, // 1
+      5, // |- 5
+      7, //    |- 7
+      6, //    |- 6
+      2, // |- 2
+      3, //    |- 3
+      4, //    |- 4
     ]
   );
 });
@@ -108,20 +101,13 @@ test("#traverse() traverses the subgraph rooted at a node breadth-first", (t) =>
   t.deepEqual(
     [...graph.traverse(1, Graph.BreadthFirst)],
     [
-      // 1
-      1,
-      // |- 2
-      2,
-      // |- 5
-      5,
-      //    |- 4
-      4,
-      //    |- 3
-      3,
-      //    |- 6
-      6,
-      //    |- 7
-      7,
+      1, // 1
+      2, // |- 2
+      5, // |- 5
+      4, //    |- 4
+      3, //    |- 3
+      6, //    |- 6
+      7, //    |- 7
     ]
   );
 });

--- a/packages/alfa-graph/test/graph.spec.ts
+++ b/packages/alfa-graph/test/graph.spec.ts
@@ -30,3 +30,18 @@ test("#delete() removes a node from a graph", (t) => {
     ["foo", ["baz"]],
   ]);
 });
+
+test("#traverse() traverses the subgraph rooted at a node", (t) => {
+  t.deepEqual([...graph.traverse("baz")], ["baz", "foo", "bar"]);
+});
+
+test("#hasPath() checks if there's a path from one node to another", (t) => {
+  // foo -> bar
+  t.equal(graph.hasPath("foo", "bar"), true);
+
+  // baz -> foo -> bar
+  t.equal(graph.hasPath("baz", "bar"), true);
+
+  // bar ->
+  t.equal(graph.hasPath("bar", "baz"), false);
+});

--- a/packages/alfa-graph/test/graph.spec.ts
+++ b/packages/alfa-graph/test/graph.spec.ts
@@ -2,6 +2,11 @@ import { test } from "@siteimprove/alfa-test";
 
 import { Graph } from "../src/graph";
 
+// foo
+// |- bar
+// |- baz
+//    |- foo
+//       |- ...
 const graph = Graph.from([
   ["foo", ["bar", "baz"]],
   ["bar", []],
@@ -9,6 +14,13 @@ const graph = Graph.from([
 ]);
 
 test("#connect() connects two nodes in a graph", (t) => {
+  // foo
+  // |- bar
+  //    |- baz
+  //       |- ...
+  // |- baz
+  //    |- foo
+  //       |- ...
   t.deepEqual(graph.connect("bar", "baz").toArray(), [
     ["baz", ["foo"]],
     ["foo", ["baz", "bar"]],
@@ -17,6 +29,11 @@ test("#connect() connects two nodes in a graph", (t) => {
 });
 
 test("#disconnect() disconnects two nodes in a graph", (t) => {
+  // foo
+  // |- baz
+  //    |- foo
+  //       |- ...
+  // bar
   t.deepEqual(graph.disconnect("foo", "bar").toArray(), [
     ["baz", ["foo"]],
     ["foo", ["baz"]],
@@ -25,6 +42,10 @@ test("#disconnect() disconnects two nodes in a graph", (t) => {
 });
 
 test("#delete() removes a node from a graph", (t) => {
+  // foo
+  // |- baz
+  //    |- foo
+  //       |- ...
   t.deepEqual(graph.delete("bar").toArray(), [
     ["baz", ["foo"]],
     ["foo", ["baz"]],
@@ -32,16 +53,89 @@ test("#delete() removes a node from a graph", (t) => {
 });
 
 test("#traverse() traverses the subgraph rooted at a node", (t) => {
-  t.deepEqual([...graph.traverse("baz")], ["baz", "foo", "bar"]);
+  t.deepEqual([...graph.traverse("baz")].sort(), ["baz", "foo", "bar"].sort());
+});
+
+test("#traverse() traverses the subgraph rooted at a node depth-first", (t) => {
+  // 1
+  // |- 2
+  //    |- 3
+  //    |- 4
+  // |- 5
+  //    |- 6
+  //    |- 7
+  const graph = Graph.from([
+    [1, [2, 5]],
+    [2, [3, 4]],
+    [5, [6, 7]],
+  ]);
+
+  t.deepEqual(
+    [...graph.traverse(1, Graph.DepthFirst)],
+    [
+      // 1
+      1,
+      // |- 5
+      5,
+      //    |- 7
+      7,
+      //    |- 6
+      6,
+      // |- 2
+      2,
+      //    |- 3
+      3,
+      //    |- 4
+      4,
+    ]
+  );
+});
+
+test("#traverse() traverses the subgraph rooted at a node breadth-first", (t) => {
+  // 1
+  // |- 2
+  //    |- 3
+  //    |- 4
+  // |- 5
+  //    |- 6
+  //    |- 7
+  const graph = Graph.from([
+    [1, [2, 5]],
+    [2, [3, 4]],
+    [5, [6, 7]],
+  ]);
+
+  t.deepEqual(
+    [...graph.traverse(1, Graph.BreadthFirst)],
+    [
+      // 1
+      1,
+      // |- 2
+      2,
+      // |- 5
+      5,
+      //    |- 4
+      4,
+      //    |- 3
+      3,
+      //    |- 6
+      6,
+      //    |- 7
+      7,
+    ]
+  );
 });
 
 test("#hasPath() checks if there's a path from one node to another", (t) => {
+  // foo always has a path to itself
+  t.equal(graph.hasPath("foo", "foo"), true);
+
   // foo -> bar
   t.equal(graph.hasPath("foo", "bar"), true);
 
   // baz -> foo -> bar
   t.equal(graph.hasPath("baz", "bar"), true);
 
-  // bar ->
+  // bar has no neighbors
   t.equal(graph.hasPath("bar", "baz"), false);
 });

--- a/packages/alfa-graph/tsconfig.json
+++ b/packages/alfa-graph/tsconfig.json
@@ -16,9 +16,6 @@
       "path": "../alfa-map"
     },
     {
-      "path": "../alfa-option"
-    },
-    {
       "path": "../alfa-set"
     },
     {

--- a/packages/alfa-graph/tsconfig.json
+++ b/packages/alfa-graph/tsconfig.json
@@ -16,6 +16,9 @@
       "path": "../alfa-map"
     },
     {
+      "path": "../alfa-sequence"
+    },
+    {
       "path": "../alfa-set"
     },
     {


### PR DESCRIPTION
This pull request implements a traversal API for the `Graph` class, which is needed for correctly dealing with cyclic `aria-owns` references:

https://github.com/Siteimprove/alfa/blob/2db1ec794a867b858a8f971e48229332d5a8dd46/packages/alfa-aria/test/node.spec.tsx#L182-L188

The changes are breaking as `Graph#neighbors()` now returns `Iterable<T>` rather than `Option<Set<T>>`, which seemed like a strong promise.