### PR TITLE
Implement style resolution for stateful pseudo classes

### DIFF
--- a/packages/alfa-cascade/package.json
+++ b/packages/alfa-cascade/package.json
@@ -23,6 +23,7 @@
     "@siteimprove/alfa-device": "^0.5.0",
     "@siteimprove/alfa-dom": "^0.5.0",
     "@siteimprove/alfa-iterable": "^0.5.0",
+    "@siteimprove/alfa-json": "^0.5.0",
     "@siteimprove/alfa-media": "^0.5.0",
     "@siteimprove/alfa-option": "^0.5.0",
     "@siteimprove/alfa-predicate": "^0.5.0",

--- a/packages/alfa-cascade/tsconfig.json
+++ b/packages/alfa-cascade/tsconfig.json
@@ -26,6 +26,9 @@
       "path": "../alfa-iterable"
     },
     {
+      "path": "../alfa-json"
+    },
+    {
       "path": "../alfa-media"
     },
     {

--- a/packages/alfa-selector/package.json
+++ b/packages/alfa-selector/package.json
@@ -23,6 +23,7 @@
     "@siteimprove/alfa-equatable": "^0.5.0",
     "@siteimprove/alfa-iterable": "^0.5.0",
     "@siteimprove/alfa-json": "^0.5.0",
+    "@siteimprove/alfa-map": "^0.5.0",
     "@siteimprove/alfa-option": "^0.5.0",
     "@siteimprove/alfa-parser": "^0.5.0",
     "@siteimprove/alfa-predicate": "^0.5.0",

--- a/packages/alfa-selector/src/context.ts
+++ b/packages/alfa-selector/src/context.ts
@@ -1,0 +1,96 @@
+import { Element } from "@siteimprove/alfa-dom";
+import { Map } from "@siteimprove/alfa-map";
+
+export class Context {
+  public static of(state: Iterable<[Element, Context.State]>): Context {
+    return new Context(Map.from(state));
+  }
+
+  private static _empty = new Context(Map.empty());
+
+  public static empty(): Context {
+    return this._empty;
+  }
+
+  private readonly _state: Map<Element, Context.State>;
+
+  private constructor(state: Map<Element, Context.State>) {
+    this._state = state;
+  }
+
+  public hasState(element: Element, state: Context.State): boolean {
+    return this._state.get(element).some((found) => (found & state) !== 0);
+  }
+
+  public getState(element: Element): Context.State {
+    return this._state.get(element).getOr(Context.State.None);
+  }
+
+  public setState(element: Element, state: Context.State): Context {
+    return new Context(this._state.set(element, state));
+  }
+
+  public hover(element: Element): Context {
+    return this.setState(element, this.getState(element) | Context.State.Hover);
+  }
+
+  public static hover(element: Element): Context {
+    return this.empty().hover(element);
+  }
+
+  public isHovered(element: Element): boolean {
+    return this.hasState(element, Context.State.Hover);
+  }
+
+  public active(element: Element): Context {
+    return this.setState(
+      element,
+      this.getState(element) | Context.State.Active
+    );
+  }
+
+  public static active(element: Element): Context {
+    return this.empty().active(element);
+  }
+
+  public isActive(element: Element): boolean {
+    return this.hasState(element, Context.State.Active);
+  }
+
+  public focus(element: Element): Context {
+    return this.setState(element, this.getState(element) | Context.State.Focus);
+  }
+
+  public static focus(element: Element): Context {
+    return this.empty().focus(element);
+  }
+
+  public isFocused(element: Element): boolean {
+    return this.hasState(element, Context.State.Focus);
+  }
+
+  public visit(element: Element): Context {
+    return this.setState(
+      element,
+      this.getState(element) | Context.State.Visited
+    );
+  }
+
+  public static visit(element: Element): Context {
+    return this.empty().visit(element);
+  }
+
+  public isVisited(element: Element): boolean {
+    return this.hasState(element, Context.State.Visited);
+  }
+}
+
+export namespace Context {
+  export enum State {
+    None = 0,
+    Hover = 1,
+    Active = 1 << 1,
+    Focus = 1 << 2,
+    Visited = 1 << 3,
+  }
+}

--- a/packages/alfa-selector/src/context.ts
+++ b/packages/alfa-selector/src/context.ts
@@ -30,8 +30,12 @@ export class Context {
     return new Context(this._state.set(element, state));
   }
 
+  public addState(element: Element, state: Context.State): Context {
+    return this.setState(element, this.getState(element) | state);
+  }
+
   public hover(element: Element): Context {
-    return this.setState(element, this.getState(element) | Context.State.Hover);
+    return this.addState(element, Context.State.Hover);
   }
 
   public static hover(element: Element): Context {
@@ -43,10 +47,7 @@ export class Context {
   }
 
   public active(element: Element): Context {
-    return this.setState(
-      element,
-      this.getState(element) | Context.State.Active
-    );
+    return this.addState(element, Context.State.Active);
   }
 
   public static active(element: Element): Context {
@@ -58,7 +59,7 @@ export class Context {
   }
 
   public focus(element: Element): Context {
-    return this.setState(element, this.getState(element) | Context.State.Focus);
+    return this.addState(element, Context.State.Focus);
   }
 
   public static focus(element: Element): Context {
@@ -70,10 +71,7 @@ export class Context {
   }
 
   public visit(element: Element): Context {
-    return this.setState(
-      element,
-      this.getState(element) | Context.State.Visited
-    );
+    return this.addState(element, Context.State.Visited);
   }
 
   public static visit(element: Element): Context {

--- a/packages/alfa-selector/src/index.ts
+++ b/packages/alfa-selector/src/index.ts
@@ -1,1 +1,2 @@
+export * from "./context";
 export * from "./selector";

--- a/packages/alfa-selector/src/selector.ts
+++ b/packages/alfa-selector/src/selector.ts
@@ -785,6 +785,10 @@ export namespace Selector {
             return Result.of([input, Active.of()]);
           case "focus":
             return Result.of([input, Focus.of()]);
+          case "focus-within":
+            return Result.of([input, FocusWithin.of()]);
+          case "focus-visible":
+            return Result.of([input, FocusVisible.of()]);
           case "link":
             return Result.of([input, Link.of()]);
           case "visited":
@@ -1090,6 +1094,49 @@ export namespace Selector {
 
     public matches(element: Element, context: Context): boolean {
       return context.isFocused(element);
+    }
+  }
+
+  /**
+   * @see https://drafts.csswg.org/selectors/#focus-within-pseudo
+   */
+  export class FocusWithin extends Pseudo.Class {
+    public static of(): FocusWithin {
+      return new FocusWithin();
+    }
+
+    private constructor() {
+      super("focus-within");
+    }
+
+    public matches(element: Element, context: Context): boolean {
+      return (
+        context.isFocused(element) ||
+        element
+          .descendants({ flattened: true })
+          .filter(isElement)
+          .some((element) => context.isFocused(element))
+      );
+    }
+  }
+
+  /**
+   * @see https://drafts.csswg.org/selectors/#focus-visible-pseudo
+   */
+  export class FocusVisible extends Pseudo.Class {
+    public static of(): FocusVisible {
+      return new FocusVisible();
+    }
+
+    private constructor() {
+      super("focus-visible");
+    }
+
+    public matches(): boolean {
+      // For the purposes of accessibility testing, we currently assume that
+      // focus related styling can safely be "hidden" behind the :focus-visible
+      // pseudo-class and it will therefore always match.
+      return true;
     }
   }
 

--- a/packages/alfa-selector/src/selector.ts
+++ b/packages/alfa-selector/src/selector.ts
@@ -1110,13 +1110,10 @@ export namespace Selector {
     }
 
     public matches(element: Element, context: Context): boolean {
-      return (
-        context.isFocused(element) ||
-        element
-          .descendants({ flattened: true })
-          .filter(isElement)
-          .some((element) => context.isFocused(element))
-      );
+      return element
+        .inclusiveDescendants({ flattened: true })
+        .filter(isElement)
+        .some((element) => context.isFocused(element));
     }
   }
 

--- a/packages/alfa-selector/test/selector.spec.tsx
+++ b/packages/alfa-selector/test/selector.spec.tsx
@@ -2,6 +2,9 @@ import { jsx } from "@siteimprove/alfa-dom/jsx";
 import { test } from "@siteimprove/alfa-test";
 
 import { Selector } from "../src/selector";
+import { Context } from "../src/context";
+
+const context = Context.empty();
 
 test(".parse() parses a type selector", (t) => {
   t.deepEqual(Selector.parse("div").get().toJSON(), {
@@ -818,10 +821,10 @@ test("#matches() checks if an element matches an :nth-child selector", (t) => {
     {d}
   </div>;
 
-  t.equal(selector.matches(a), true);
-  t.equal(selector.matches(b), false);
-  t.equal(selector.matches(c), true);
-  t.equal(selector.matches(d), false);
+  t.equal(selector.matches(a, context), true);
+  t.equal(selector.matches(b, context), false);
+  t.equal(selector.matches(c, context), true);
+  t.equal(selector.matches(d, context), false);
 });
 
 test("#matches() checks if an element matches an :nth-last-child selector", (t) => {
@@ -840,10 +843,10 @@ test("#matches() checks if an element matches an :nth-last-child selector", (t) 
     {d}
   </div>;
 
-  t.equal(selector.matches(a), false);
-  t.equal(selector.matches(b), true);
-  t.equal(selector.matches(c), false);
-  t.equal(selector.matches(d), true);
+  t.equal(selector.matches(a, context), false);
+  t.equal(selector.matches(b, context), true);
+  t.equal(selector.matches(c, context), false);
+  t.equal(selector.matches(d, context), true);
 });
 
 test("#matches() checks if an element matches a :first-child selector", (t) => {
@@ -858,8 +861,8 @@ test("#matches() checks if an element matches a :first-child selector", (t) => {
     {b}
   </div>;
 
-  t.equal(selector.matches(a), true);
-  t.equal(selector.matches(b), false);
+  t.equal(selector.matches(a, context), true);
+  t.equal(selector.matches(b, context), false);
 });
 
 test("#matches() checks if an element matches a :last-child selector", (t) => {
@@ -874,8 +877,8 @@ test("#matches() checks if an element matches a :last-child selector", (t) => {
     Hello
   </div>;
 
-  t.equal(selector.matches(a), false);
-  t.equal(selector.matches(b), true);
+  t.equal(selector.matches(a, context), false);
+  t.equal(selector.matches(b, context), true);
 });
 
 test("#matches() checks if an element matches an :only-child selector", (t) => {
@@ -895,8 +898,8 @@ test("#matches() checks if an element matches an :only-child selector", (t) => {
     Hello
   </div>;
 
-  t.equal(selector.matches(a), true);
-  t.equal(selector.matches(b), false);
+  t.equal(selector.matches(a, context), true);
+  t.equal(selector.matches(b, context), false);
 });
 
 test("#matches() checks if an element matches an :nth-of-type selector", (t) => {
@@ -917,10 +920,10 @@ test("#matches() checks if an element matches an :nth-of-type selector", (t) => 
     {d}
   </div>;
 
-  t.equal(selector.matches(a), true);
-  t.equal(selector.matches(b), false);
-  t.equal(selector.matches(c), true);
-  t.equal(selector.matches(d), false);
+  t.equal(selector.matches(a, context), true);
+  t.equal(selector.matches(b, context), false);
+  t.equal(selector.matches(c, context), true);
+  t.equal(selector.matches(d, context), false);
 });
 
 test("#matches() checks if an element matches an :nth-last-of-type selector", (t) => {
@@ -941,10 +944,10 @@ test("#matches() checks if an element matches an :nth-last-of-type selector", (t
     <span />
   </div>;
 
-  t.equal(selector.matches(a), false);
-  t.equal(selector.matches(b), true);
-  t.equal(selector.matches(c), false);
-  t.equal(selector.matches(d), true);
+  t.equal(selector.matches(a, context), false);
+  t.equal(selector.matches(b, context), true);
+  t.equal(selector.matches(c, context), false);
+  t.equal(selector.matches(d, context), true);
 });
 
 test("#matches() checks if an element matches a :first-of-type selector", (t) => {
@@ -960,8 +963,8 @@ test("#matches() checks if an element matches a :first-of-type selector", (t) =>
     {b}
   </div>;
 
-  t.equal(selector.matches(a), true);
-  t.equal(selector.matches(b), false);
+  t.equal(selector.matches(a, context), true);
+  t.equal(selector.matches(b, context), false);
 });
 
 test("#matches() checks if an element matches a :last-of-type selector", (t) => {
@@ -977,8 +980,8 @@ test("#matches() checks if an element matches a :last-of-type selector", (t) => 
     <div />
   </div>;
 
-  t.equal(selector.matches(a), false);
-  t.equal(selector.matches(b), true);
+  t.equal(selector.matches(a, context), false);
+  t.equal(selector.matches(b, context), true);
 });
 
 test("#matches() checks if an element matches a :only-of-type selector", (t) => {
@@ -1000,6 +1003,6 @@ test("#matches() checks if an element matches a :only-of-type selector", (t) => 
     <div />
   </div>;
 
-  t.equal(selector.matches(a), true);
-  t.equal(selector.matches(b), false);
+  t.equal(selector.matches(a, context), true);
+  t.equal(selector.matches(b, context), false);
 });

--- a/packages/alfa-selector/test/selector.spec.tsx
+++ b/packages/alfa-selector/test/selector.spec.tsx
@@ -1006,3 +1006,80 @@ test("#matches() checks if an element matches a :only-of-type selector", (t) => 
   t.equal(selector.matches(a, context), true);
   t.equal(selector.matches(b, context), false);
 });
+
+test("#matches() checks if an element matches a :hover selector", (t) => {
+  const selector = Selector.parse(":hover").get();
+
+  const p = <p />;
+
+  t.equal(selector.matches(p, context), false);
+  t.equal(selector.matches(p, context.hover(p)), true);
+});
+
+test("#matches() checks if an element matches an :active selector", (t) => {
+  const selector = Selector.parse(":active").get();
+
+  const p = <p />;
+
+  t.equal(selector.matches(p, context), false);
+  t.equal(selector.matches(p, context.active(p)), true);
+});
+
+test("#matches() checks if an element matches a :focus selector", (t) => {
+  const selector = Selector.parse(":focus").get();
+
+  const p = <p />;
+
+  t.equal(selector.matches(p, context), false);
+  t.equal(selector.matches(p, context.focus(p)), true);
+});
+
+test("#matches() checks if an element matches a :link selector", (t) => {
+  const selector = Selector.parse(":link").get();
+
+  // These elements are links
+  for (const element of [
+    <a href="#" />,
+    <area href="#" />,
+    <link href="#" />,
+  ]) {
+    t.equal(selector.matches(element, context), true, element.toString());
+
+    // Only non-visited links match :link
+    t.equal(
+      selector.matches(element, context.visit(element)),
+      false,
+      element.toString()
+    );
+  }
+
+  // These elements aren't links
+  for (const element of [<a />, <p />]) {
+    t.equal(selector.matches(element, context), false, element.toString());
+  }
+});
+
+test("#matches() checks if an element matches a :visited selector", (t) => {
+  const selector = Selector.parse(":visited").get();
+
+  // These elements are links
+  for (const element of [
+    <a href="#" />,
+    <area href="#" />,
+    <link href="#" />,
+  ]) {
+    t.equal(
+      selector.matches(element, context.visit(element)),
+      true,
+      element.toString()
+    );
+
+    // Only visited links match :link
+    t.equal(selector.matches(element, context), false, element.toString());
+  }
+
+  // These elements aren't links
+  for (const element of [<a />, <p />]) {
+    t.equal(selector.matches(element, context), false, element.toString());
+  }
+});

--- a/packages/alfa-selector/test/selector.spec.tsx
+++ b/packages/alfa-selector/test/selector.spec.tsx
@@ -1034,6 +1034,17 @@ test("#matches() checks if an element matches a :focus selector", (t) => {
   t.equal(selector.matches(p, context.focus(p)), true);
 });
 
+test("#matches() checks if an element matches a :focus-within selector", (t) => {
+  const selector = Selector.parse(":focus-within").get();
+
+  const button = <button />;
+  const p = <p>{button}</p>;
+
+  t.equal(selector.matches(p, context), false);
+  t.equal(selector.matches(p, context.focus(p)), true);
+  t.equal(selector.matches(p, context.focus(button)), true);
+});
+
 test("#matches() checks if an element matches a :link selector", (t) => {
   const selector = Selector.parse(":link").get();
 

--- a/packages/alfa-selector/tsconfig.json
+++ b/packages/alfa-selector/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "../tsconfig.json",
-  "files": ["src/index.ts", "src/selector.ts", "test/selector.spec.tsx"],
+  "files": [
+    "src/context.ts",
+    "src/index.ts",
+    "src/selector.ts",
+    "test/selector.spec.tsx"
+  ],
   "references": [
     {
       "path": "../alfa-css"
@@ -17,6 +22,9 @@
     },
     {
       "path": "../alfa-json"
+    },
+    {
+      "path": "../alfa-map"
     },
     {
       "path": "../alfa-option"

--- a/packages/alfa-style/package.json
+++ b/packages/alfa-style/package.json
@@ -35,6 +35,7 @@
     "@siteimprove/alfa-option": "^0.5.0",
     "@siteimprove/alfa-parser": "^0.5.0",
     "@siteimprove/alfa-record": "^0.5.0",
+    "@siteimprove/alfa-selector": "^0.5.0",
     "@siteimprove/alfa-set": "^0.5.0",
     "@siteimprove/alfa-slice": "^0.5.0"
   },

--- a/packages/alfa-style/test/style.spec.tsx
+++ b/packages/alfa-style/test/style.spec.tsx
@@ -3,13 +3,16 @@ import { h } from "@siteimprove/alfa-dom/h";
 import { jsx } from "@siteimprove/alfa-dom/jsx";
 
 import { Device } from "@siteimprove/alfa-device";
+import { Context } from "@siteimprove/alfa-selector";
 
 import { Style } from "../src/style";
+
+const device = Device.standard();
 
 test("#cascaded() returns the cascaded value of a property", (t) => {
   const element = <div style={{ color: "red" }}></div>;
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("color").get().toJSON(), {
     value: {
@@ -36,7 +39,7 @@ test("#cascaded() correctly handles duplicate properties", (t) => {
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("color").get().toJSON(), {
     value: {
@@ -61,7 +64,7 @@ test("#cascaded() returns the most specific property value", (t) => {
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("color").get().toJSON(), {
     value: {
@@ -78,7 +81,7 @@ test("#cascaded() correctly handles inline styles overriding the sheet", (t) => 
 
   h.document([element], [h.sheet([h.rule.style("div", { color: "red" })])]);
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("color").get().toJSON(), {
     value: {
@@ -99,7 +102,7 @@ test(`#cascaded() correctly handles an important declaration overriding inline
     [h.sheet([h.rule.style("div", { color: "red !important" })])]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("color").get().toJSON(), {
     value: {
@@ -120,7 +123,7 @@ test(`#cascaded() correctly handles important inline styles overriding an
     [h.sheet([h.rule.style("div", { color: "red !important" })])]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("color").get().toJSON(), {
     value: {
@@ -148,7 +151,7 @@ test(`#cascaded() correctly handles a shorthand declaration overriding a
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
     value: {
@@ -175,7 +178,7 @@ test(`#cascaded() correctly handles a longhand declaration overriding a
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
     value: {
@@ -201,7 +204,7 @@ test(`#cascaded() expands a var() function`, (t) => {
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
     value: {
@@ -226,7 +229,7 @@ test(`#cascaded() expands a var() function with a fallback`, (t) => {
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
     value: {
@@ -255,7 +258,7 @@ test(`#cascaded() expands a var() function with an inherited value`, (t) => {
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
     value: {
@@ -286,7 +289,7 @@ test(`#cascaded() expands a var() function with an overridden value`, (t) => {
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
     value: {
@@ -315,7 +318,7 @@ test(`#cascaded() expands a var() function with a value that contains another
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
     value: {
@@ -343,7 +346,7 @@ test(`#cascaded() expands multiple var() functions in the same declaration`, (t)
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
     value: {
@@ -378,7 +381,7 @@ test(`#cascaded() expands several var() function references to the same variable
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
     value: {
@@ -412,7 +415,7 @@ test(`#cascaded() expands a var() function with a fallback with a var() function
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
     value: {
@@ -439,7 +442,7 @@ test(`#cascaded() returns "unset" when a var() function variable isn't defined`,
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
     value: {
@@ -464,7 +467,7 @@ test(`#cascaded() returns "unset" when a var() function fallback is empty`, (t) 
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
     value: {
@@ -492,7 +495,7 @@ test(`#cascaded() returns "unset" when declaration with a var() function is
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
     value: {
@@ -519,7 +522,7 @@ test(`#cascaded() returns "unset" when a var() function is invalid`, (t) => {
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
     value: {
@@ -547,7 +550,7 @@ test(`#cascaded() returns "unset" when var() functions contain cyclic references
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
     value: {
@@ -575,7 +578,7 @@ test(`#cascaded() returns "unset" when a custom property referenced by a var()
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
     value: {
@@ -631,7 +634,7 @@ test(`#cascaded() returns "unset" when confronted with a billion laughs`, (t) =>
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
     value: {
@@ -668,7 +671,7 @@ test(`#cascaded() correctly resolves var() function references within context
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
     value: {
@@ -700,7 +703,7 @@ test(`#cascaded() gives precedence to !important custom properties used in var()
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
     value: {
@@ -732,7 +735,7 @@ test(`#cascaded() does not fall back on the inherited value of a custom property
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
     value: {
@@ -765,7 +768,7 @@ test(`#cascaded() does not fall back on the inherited value of a custom property
     ]
   );
 
-  const style = Style.from(element, Device.standard());
+  const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("overflow-x").get().toJSON(), {
     value: {
@@ -773,5 +776,35 @@ test(`#cascaded() does not fall back on the inherited value of a custom property
       value: "unset",
     },
     source: h.declaration("overflow-x", "var(--hidden, foo)").toJSON(),
+  });
+});
+
+test(`#cascaded() resolves a contextual :hover style for an element`, (t) => {
+  const element = <div />;
+
+  h.document(
+    [element],
+    [
+      h.sheet([
+        h.rule.style("div", {
+          color: "red",
+        }),
+
+        h.rule.style("div:hover", {
+          color: "blue",
+        }),
+      ]),
+    ]
+  );
+
+  const style = Style.from(element, device, Context.hover(element));
+
+  t.deepEqual(style.cascaded("color").get().toJSON(), {
+    value: {
+      type: "color",
+      format: "named",
+      color: "blue",
+    },
+    source: h.declaration("color", "blue").toJSON(),
   });
 });

--- a/packages/alfa-style/test/style.spec.tsx
+++ b/packages/alfa-style/test/style.spec.tsx
@@ -779,7 +779,7 @@ test(`#cascaded() does not fall back on the inherited value of a custom property
   });
 });
 
-test(`#cascaded() resolves a contextual :hover style for an element`, (t) => {
+test(`#cascaded() resolves :hover style for an element`, (t) => {
   const element = <div />;
 
   h.document(
@@ -797,7 +797,7 @@ test(`#cascaded() resolves a contextual :hover style for an element`, (t) => {
     ]
   );
 
-  const style = Style.from(element, device, Context.hover(element));
+  let style = Style.from(element, device, Context.hover(element));
 
   t.deepEqual(style.cascaded("color").get().toJSON(), {
     value: {
@@ -806,5 +806,57 @@ test(`#cascaded() resolves a contextual :hover style for an element`, (t) => {
       color: "blue",
     },
     source: h.declaration("color", "blue").toJSON(),
+  });
+
+  style = Style.from(element, device);
+
+  t.deepEqual(style.cascaded("color").get().toJSON(), {
+    value: {
+      type: "color",
+      format: "named",
+      color: "red",
+    },
+    source: h.declaration("color", "red").toJSON(),
+  });
+});
+
+test(`#cascaded() resolves :focus style for an element`, (t) => {
+  const element = <div />;
+
+  h.document(
+    [element],
+    [
+      h.sheet([
+        h.rule.style("div", {
+          color: "red",
+        }),
+
+        h.rule.style("div:focus", {
+          color: "blue",
+        }),
+      ]),
+    ]
+  );
+
+  let style = Style.from(element, device, Context.focus(element));
+
+  t.deepEqual(style.cascaded("color").get().toJSON(), {
+    value: {
+      type: "color",
+      format: "named",
+      color: "blue",
+    },
+    source: h.declaration("color", "blue").toJSON(),
+  });
+
+  style = Style.from(element, device);
+
+  t.deepEqual(style.cascaded("color").get().toJSON(), {
+    value: {
+      type: "color",
+      format: "named",
+      color: "red",
+    },
+    source: h.declaration("color", "red").toJSON(),
   });
 });

--- a/packages/alfa-style/tsconfig.json
+++ b/packages/alfa-style/tsconfig.json
@@ -80,6 +80,9 @@
       "path": "../alfa-record"
     },
     {
+      "path": "../alfa-selector"
+    },
+    {
       "path": "../alfa-set"
     },
     {


### PR DESCRIPTION
This pull request implements style resolution for the following stateful pseudo classes:

- `:hover`
- `:active`
- `:focus`
- `:focus-within`
- `:focus-visible`
- `:link`
- `:visited`

A new class, `Context`, has been introduced to model context-dependant information during selector matching, such as which element is currently in focus, which elements have been visited, and so on. This class is heavily inspired by Servo ([`components/selectors/context.rs`][components/selectors/context.rs]) and works by modelling state as bit flags associated with elements. As an example, this means that it's up to the caller, not `Selector#matches()`, to decide if a given element links to a resource that has been visited; `Selector#matches()` simply checks the associated state, not the actual URL of the element being matched against.

This pull request also introduces changes to the way cascade is managed to allow efficiently re-computing cascade for elements when context changes. The `Cascade` class is now no longer immutable, but instead incrementally builds up a rule tree and caches entries for elements keyed on context. A "baseline" cascade is performed at construction time and computes cascade for all elements in a document with an empty context to benefit from ancestor filtering during selector matching. From then, matching declarations for individual elements can be queried with an optional context that defaults to an empty context. Whenever a non-yet-seen context is passed for an element, the rule tree is extended with matching declarations for the element and associated context.

Closes #447.

[components/selectors/context.rs]: https://github.com/servo/servo/blob/4886788a8ed975cbc1ae4f05cd8ce0ab41cd30e2/components/selectors/context.rs