### PR TITLE
SIA-R10: ignore disabled elements

### DIFF
--- a/packages/alfa-rules/src/sia-r10/rule.ts
+++ b/packages/alfa-rules/src/sia-r10/rule.ts
@@ -13,7 +13,7 @@ import { isPerceivable } from "../common/predicate/is-perceivable";
 import { isTabbable } from "../common/predicate/is-tabbable";
 
 const { isElement, hasInputType, hasName, hasNamespace } = Element;
-const { and, or, not, equals } = Predicate;
+const { and, or, not } = Predicate;
 
 export default Rule.Atomic.of<Page, Attribute>({
   uri: "https://siteimprove.github.io/sanshikan/rules/sia-r10.html",
@@ -25,26 +25,21 @@ export default Rule.Atomic.of<Page, Attribute>({
           .filter(isElement)
           .filter(
             and(
-              hasAttribute("autocomplete", hasTokens),
               hasNamespace(Namespace.HTML),
               hasName("input", "select", "textarea"),
-              isPerceivable(device),
-              not(
-                and(
-                  hasName("input"),
-                  hasInputType("hidden", "button", "submit", "reset")
-                )
+              not(hasInputType("hidden", "button", "submit", "reset")),
+              hasAttribute("autocomplete", hasTokens),
+              or(
+                isTabbable(device),
+                hasRole((role) => role.isWidget())
               ),
+              isPerceivable(device),
               (element) =>
                 Node.from(element, device).some((ariaNode) =>
                   ariaNode
                     .attribute("aria-disabled")
                     .none((ariaDisabled) => ariaDisabled.value === "true")
-                ),
-              or(
-                isTabbable(device),
-                hasRole((role) => role.isWidget())
-              )
+                )
             )
           )
           .map((element) => element.attribute("autocomplete").get());

--- a/packages/alfa-rules/src/sia-r10/rule.ts
+++ b/packages/alfa-rules/src/sia-r10/rule.ts
@@ -1,4 +1,5 @@
 import { Rule, Diagnostic } from "@siteimprove/alfa-act";
+import { Node } from "@siteimprove/alfa-aria";
 import { Attribute, Element, Namespace } from "@siteimprove/alfa-dom";
 import { Predicate } from "@siteimprove/alfa-predicate";
 import { Err, Ok } from "@siteimprove/alfa-result";
@@ -34,7 +35,12 @@ export default Rule.Atomic.of<Page, Attribute>({
                   hasInputType("hidden", "button", "submit", "reset")
                 )
               ),
-              not(hasAttribute("aria-disabled", equals("true"))),
+              (element) =>
+                Node.from(element, device).some((ariaNode) =>
+                  ariaNode
+                    .attribute("aria-disabled")
+                    .none((ariaDisabled) => ariaDisabled.value === "true")
+                ),
               or(
                 isTabbable(device),
                 hasRole((role) => role.isWidget())

--- a/packages/alfa-rules/test/sia-r10/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r10/rule.spec.tsx
@@ -112,7 +112,7 @@ test("evaluates() is inapplicable on input type who don't support autocomplete",
   t.deepEqual(await evaluate(R10, { document }), [inapplicable(R10)]);
 });
 
-test("evaluates() is inapplicable on invisible element", async (t) => {
+test("evaluates() is inapplicable on invisible elements", async (t) => {
   const element = <input style={{ display: "none" }} autocomplete="email" />;
 
   const document = Document.of([element]);
@@ -120,8 +120,16 @@ test("evaluates() is inapplicable on invisible element", async (t) => {
   t.deepEqual(await evaluate(R10, { document }), [inapplicable(R10)]);
 });
 
-test("evaluates() is inapplicable on aria-disabled element", async (t) => {
+test("evaluates() is inapplicable on aria-disabled elements", async (t) => {
   const element = <input aria-disabled="true" autocomplete="email" />;
+
+  const document = Document.of([element]);
+
+  t.deepEqual(await evaluate(R10, { document }), [inapplicable(R10)]);
+});
+
+test("evaluates() is inapplicable on disabled elements", async (t) => {
+  const element = <input disabled autocomplete="email" />;
 
   const document = Document.of([element]);
 

--- a/packages/alfa-rules/test/sia-r10/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r10/rule.spec.tsx
@@ -1,0 +1,129 @@
+import { jsx } from "@siteimprove/alfa-dom/jsx";
+import { test } from "@siteimprove/alfa-test";
+
+import { Document } from "@siteimprove/alfa-dom";
+
+import R10, { Outcomes } from "../../src/sia-r10/rule";
+
+import { evaluate } from "../common/evaluate";
+import { passed, failed, inapplicable } from "../common/outcome";
+
+test("evaluate() passes a valid simple autocomplete attribute on an <input> element", async (t) => {
+  const element = <input autocomplete="username" />;
+  const target = element.attribute("autocomplete").get()!;
+
+  const document = Document.of([element]);
+
+  t.deepEqual(await evaluate(R10, { document }), [
+    passed(R10, target, {
+      1: Outcomes.HasValidValue,
+    }),
+  ]);
+});
+
+test("evaluate() passes a valid complex autocomplete attribute on an <input> element", async (t) => {
+  const element = (
+    <input type="text" autocomplete="section-primary shipping work email" />
+  );
+  const target = element.attribute("autocomplete").get()!;
+
+  const document = Document.of([element]);
+
+  t.deepEqual(await evaluate(R10, { document }), [
+    passed(R10, target, {
+      1: Outcomes.HasValidValue,
+    }),
+  ]);
+});
+
+test("evaluate() fails an autocomplete attribute with a non-existing term", async (t) => {
+  const element = <input autocomplete="invalid" />;
+  const target = element.attribute("autocomplete").get()!;
+
+  const document = Document.of([element]);
+
+  t.deepEqual(await evaluate(R10, { document }), [
+    failed(R10, target, {
+      1: Outcomes.HasNoValidValue,
+    }),
+  ]);
+});
+
+test("evaluate() fails an autocomplete attribute with terms in wrong order", async (t) => {
+  const element = <input autocomplete="work shipping email" />;
+  const target = element.attribute("autocomplete").get()!;
+
+  const document = Document.of([element]);
+
+  t.deepEqual(await evaluate(R10, { document }), [
+    failed(R10, target, {
+      1: Outcomes.HasNoValidValue,
+    }),
+  ]);
+});
+
+test("evaluate() fails an autocomplete attribute with an inappropriate term", async (t) => {
+  const element = <input type="number" autocomplete="email" />;
+  const target = element.attribute("autocomplete").get()!;
+
+  const document = Document.of([element]);
+
+  t.deepEqual(await evaluate(R10, { document }), [
+    failed(R10, target, {
+      1: Outcomes.HasNoValidValue,
+    }),
+  ]);
+});
+
+test("evaluate() fails an autocomplete attribute with a comma-separated list of terms", async (t) => {
+  const element = <input autocomplete="work,email" />;
+  const target = element.attribute("autocomplete").get()!;
+
+  const document = Document.of([element]);
+
+  t.deepEqual(await evaluate(R10, { document }), [
+    failed(R10, target, {
+      1: Outcomes.HasNoValidValue,
+    }),
+  ]);
+});
+
+test("evaluates() is inapplicable when there is no autocomplete attribute", async (t) => {
+  const element = <input />;
+
+  const document = Document.of([element]);
+
+  t.deepEqual(await evaluate(R10, { document }), [inapplicable(R10)]);
+});
+
+test("evaluates() is inapplicable on empty autocomplete attribute", async (t) => {
+  const element = <input autocomplete=" " />;
+
+  const document = Document.of([element]);
+
+  t.deepEqual(await evaluate(R10, { document }), [inapplicable(R10)]);
+});
+
+test("evaluates() is inapplicable on input type who don't support autocomplete", async (t) => {
+  const element = <input type="button" autocomplete="username" />;
+
+  const document = Document.of([element]);
+
+  t.deepEqual(await evaluate(R10, { document }), [inapplicable(R10)]);
+});
+
+test("evaluates() is inapplicable on invisible element", async (t) => {
+  const element = <input style={{ display: "none" }} autocomplete="email" />;
+
+  const document = Document.of([element]);
+
+  t.deepEqual(await evaluate(R10, { document }), [inapplicable(R10)]);
+});
+
+test("evaluates() is inapplicable on aria-disabled element", async (t) => {
+  const element = <input aria-disabled="true" autocomplete="email" />;
+
+  const document = Document.of([element]);
+
+  t.deepEqual(await evaluate(R10, { document }), [inapplicable(R10)]);
+});

--- a/packages/alfa-rules/tsconfig.json
+++ b/packages/alfa-rules/tsconfig.json
@@ -123,6 +123,7 @@
     "test/common/predicate/is-visible.spec.tsx",
     "test/sia-r1/rule.spec.tsx",
     "test/sia-r2/rule.spec.tsx",
+    "test/sia-r10/rule.spec.tsx",
     "test/sia-r13/rule.spec.tsx",
     "test/sia-r15/rule.spec.tsx",
     "test/sia-r16/rule.spec.tsx",


### PR DESCRIPTION
Ignore elements not on the value of the `aria-disabled` attribute, but on the value of the `aria-disabled` state in the accessibility tree.
And reorder a bit the tests, to put the more generic (namespace), selective (element) and light at the start and only build the accessible node if needed.

Closes #516.