### PR TITLE
SIA R53: ignore headings that are not in the accessibility tree

### DIFF
--- a/packages/alfa-rules/src/sia-r53/rule.ts
+++ b/packages/alfa-rules/src/sia-r53/rule.ts
@@ -10,7 +10,7 @@ import { hasHeadingLevel } from "../common/predicate/has-heading-level";
 import { hasRole } from "../common/predicate/has-role";
 import { isIgnored } from "../common/predicate/is-ignored";
 
-const { equals, not } = Predicate;
+const { equals } = Predicate;
 const { isElement } = Element;
 
 export default Rule.Atomic.of<Page, Element>({
@@ -20,7 +20,7 @@ export default Rule.Atomic.of<Page, Element>({
       .descendants({ flattened: true })
       .filter(isElement)
       .filter(hasRole("heading"))
-      .filter(not(isIgnored(device)));
+      .reject(isIgnored(device));
 
     return {
       applicability() {

--- a/packages/alfa-rules/src/sia-r53/rule.ts
+++ b/packages/alfa-rules/src/sia-r53/rule.ts
@@ -8,8 +8,9 @@ import { expectation } from "../common/expectation";
 
 import { hasHeadingLevel } from "../common/predicate/has-heading-level";
 import { hasRole } from "../common/predicate/has-role";
+import { isIgnored } from "../common/predicate/is-ignored";
 
-const { and, equals } = Predicate;
+const { equals, not } = Predicate;
 const { isElement } = Element;
 
 export default Rule.Atomic.of<Page, Element>({
@@ -18,7 +19,8 @@ export default Rule.Atomic.of<Page, Element>({
     const headings = document
       .descendants({ flattened: true })
       .filter(isElement)
-      .filter(hasRole("heading"));
+      .filter(hasRole("heading"))
+      .filter(not(isIgnored(device)));
 
     return {
       applicability() {

--- a/packages/alfa-rules/test/sia-r53/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r53/rule.spec.tsx
@@ -69,8 +69,8 @@ test("evaluate() is inapplicable when the document has only one heading", async 
 });
 
 test("evaluate() ignore headings that are not exposed", async (t) => {
-  const target1 = <h2>Part one</h2>;
-  const target2 = <h2>Part two</h2>;
+  const target1 = <h2>Chapter one</h2>;
+  const target2 = <h2>Chapter two</h2>;
 
   const document = Document.of([
     <html>

--- a/packages/alfa-rules/test/sia-r53/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r53/rule.spec.tsx
@@ -7,6 +7,7 @@ import R53, { Outcomes } from "../../src/sia-r53/rule";
 
 import { evaluate } from "../common/evaluate";
 import { passed, failed, inapplicable } from "../common/outcome";
+import { Device } from "@siteimprove/alfa-device";
 
 test("evaluate() passes when the document headings are structured", async (t) => {
   const target1 = <h2>Chapter one</h2>;
@@ -65,4 +66,27 @@ test("evaluate() is inapplicable when the document has only one heading", async 
   ]);
 
   t.deepEqual(await evaluate(R53, { document }), [inapplicable(R53)]);
+});
+
+test("evaluate() ignore headings that are not exposed", async (t) => {
+  const target1 = <h2>Part one</h2>;
+  const target2 = <h2>Part two</h2>;
+
+  const document = Document.of([
+    <html>
+      <h1>Part one</h1>
+      <h3 hidden>I'm not here</h3>
+      {target1}
+      {target2}
+    </html>,
+  ]);
+
+  t.deepEqual(await evaluate(R53, { document, device: Device.standard() }), [
+    passed(R53, target1, {
+      1: Outcomes.IsStructured,
+    }),
+    passed(R53, target2, {
+      1: Outcomes.IsStructured,
+    }),
+  ]);
 });

--- a/packages/alfa-rules/test/sia-r53/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r53/rule.spec.tsx
@@ -1,13 +1,13 @@
 import { jsx } from "@siteimprove/alfa-dom/jsx";
 import { test } from "@siteimprove/alfa-test";
 
+import { Device } from "@siteimprove/alfa-device";
 import { Document } from "@siteimprove/alfa-dom";
 
 import R53, { Outcomes } from "../../src/sia-r53/rule";
 
 import { evaluate } from "../common/evaluate";
 import { passed, failed, inapplicable } from "../common/outcome";
-import { Device } from "@siteimprove/alfa-device";
 
 test("evaluate() passes when the document headings are structured", async (t) => {
   const target1 = <h2>Chapter one</h2>;


### PR DESCRIPTION
Closes #576.