### PR TITLE
Keep source of explicit `initial` properties

### DIFF
--- a/packages/alfa-style/src/style.ts
+++ b/packages/alfa-style/src/style.ts
@@ -7,7 +7,7 @@ import { Either } from "@siteimprove/alfa-either";
 import { Iterable } from "@siteimprove/alfa-iterable";
 import { Serializable } from "@siteimprove/alfa-json";
 import { Map } from "@siteimprove/alfa-map";
-import { None, Option, Some } from "@siteimprove/alfa-option";
+import { None, Option } from "@siteimprove/alfa-option";
 import { Parser } from "@siteimprove/alfa-parser";
 import { Context } from "@siteimprove/alfa-selector";
 import { Set } from "@siteimprove/alfa-set";
@@ -194,7 +194,8 @@ export class Style implements Serializable {
 
     return this.cascaded(name)
       .map((cascaded) => {
-        // If we have a cascade value, act upon it
+        // If we have a cascade value, act upon it.
+        // In these cases, `initial`/`unset` have been explicitly set and their source is needed.
         const { value, source } = cascaded;
 
         if (Keyword.isKeyword(value)) {
@@ -219,7 +220,8 @@ export class Style implements Serializable {
       })
       .getOrElse(() => {
         // If we don't have a cascade value, take the initial or parent value depending whether
-        // this is an inherited property
+        // this is an inherited property.
+        // In these case, `initial` is a fallback value and has no source per se.
         if (inherits === false) {
           return this.initial(name);
         }

--- a/packages/alfa-style/test/style.spec.tsx
+++ b/packages/alfa-style/test/style.spec.tsx
@@ -861,7 +861,7 @@ test(`#cascaded() resolves :focus style for an element`, (t) => {
   });
 });
 
-test(`#specified() keeps the !important flag of propertiesset to initial`, (t) => {
+test(`#specified() keeps the !important flag of properties set to initial`, (t) => {
   const element = <div style={{ backgroundColor: "initial !important" }}></div>;
 
   const style = Style.from(element, device);

--- a/packages/alfa-style/test/style.spec.tsx
+++ b/packages/alfa-style/test/style.spec.tsx
@@ -860,3 +860,21 @@ test(`#cascaded() resolves :focus style for an element`, (t) => {
     source: h.declaration("color", "red").toJSON(),
   });
 });
+
+test(`#specified() keeps the !important flag of propertiesset to initial`, (t) => {
+  const element = <div style={{ backgroundColor: "initial !important" }}></div>;
+
+  const style = Style.from(element, device);
+
+  t.deepEqual(style.specified("background-color").toJSON(), {
+    value: {
+      type: "color",
+      format: "rgb",
+      red: { type: "percentage", value: 0 },
+      green: { type: "percentage", value: 0 },
+      blue: { type: "percentage", value: 0 },
+      alpha: { type: "percentage", value: 0 },
+    },
+    source: { name: "background-color", value: "initial", important: true },
+  });
+});


### PR DESCRIPTION
Properties that are explicitly declared as `initial` were still recorded with no source. Among other, this causes Alfa to loose the `!important` flag in declarations like `<div style="foo: initial !important">` and therefore to incorrectly pass https://act-rules.github.io/rules/78fd32#failed-example-6

Testing on 
```html
<html lang="en">
	<style>
		p { background-color: initial !important;}
	</style>
<body>
	<p>White</p>
	<p style="background-color: blue;">Still white</p>
</body>
</html>
```
shows that the important flag on an explicit `initial` property is indeed respected.