### PR TITLE
Add @siteimprove/alfa-performance package

### DIFF
--- a/packages/alfa-performance/package.json
+++ b/packages/alfa-performance/package.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json.schemastore.org/package",
+  "name": "@siteimprove/alfa-performance",
+  "homepage": "https://siteimprove.com",
+  "version": "0.8.0",
+  "license": "MIT",
+  "description": "Functionality for working with performance measurements, inspired by the User Timing specification",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/siteimprove/alfa.git",
+    "directory": "packages/alfa-performance"
+  },
+  "bugs": "https://github.com/siteimprove/alfa/issues",
+  "main": "src/index.js",
+  "types": "src/index.d.ts",
+  "files": [
+    "src/**/*.js",
+    "src/**/*.d.ts"
+  ],
+  "dependencies": {
+    "@siteimprove/alfa-array": "^0.8.0",
+    "@siteimprove/alfa-json": "^0.8.0",
+    "@siteimprove/alfa-option": "^0.8.0",
+    "@siteimprove/alfa-sequence": "^0.8.0",
+    "@siteimprove/alfa-thunk": "^0.8.0"
+  },
+  "devDependencies": {
+    "@siteimprove/alfa-test": "^0.8.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
+  }
+}

--- a/packages/alfa-performance/package.json
+++ b/packages/alfa-performance/package.json
@@ -18,13 +18,9 @@
     "src/**/*.d.ts"
   ],
   "dependencies": {
-    "@siteimprove/alfa-array": "^0.8.0",
     "@siteimprove/alfa-callback": "^0.8.0",
     "@siteimprove/alfa-emitter": "^0.8.0",
-    "@siteimprove/alfa-json": "^0.8.0",
-    "@siteimprove/alfa-option": "^0.8.0",
-    "@siteimprove/alfa-sequence": "^0.8.0",
-    "@siteimprove/alfa-thunk": "^0.8.0"
+    "@siteimprove/alfa-json": "^0.8.0"
   },
   "devDependencies": {
     "@siteimprove/alfa-test": "^0.8.0"

--- a/packages/alfa-performance/package.json
+++ b/packages/alfa-performance/package.json
@@ -19,6 +19,8 @@
   ],
   "dependencies": {
     "@siteimprove/alfa-array": "^0.8.0",
+    "@siteimprove/alfa-callback": "^0.8.0",
+    "@siteimprove/alfa-emitter": "^0.8.0",
     "@siteimprove/alfa-json": "^0.8.0",
     "@siteimprove/alfa-option": "^0.8.0",
     "@siteimprove/alfa-sequence": "^0.8.0",

--- a/packages/alfa-performance/src/index.ts
+++ b/packages/alfa-performance/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./performance";

--- a/packages/alfa-performance/src/now.ts
+++ b/packages/alfa-performance/src/now.ts
@@ -1,0 +1,17 @@
+/// <reference lib="dom" />
+
+import { Thunk } from "@siteimprove/alfa-thunk";
+
+declare const require: (module: string) => any;
+
+export let now: Thunk<number>;
+
+if (typeof performance !== "undefined") {
+  now = performance.now;
+} else {
+  try {
+    now = require("perf_hooks").performance.now;
+  } catch {
+    now = Date.now;
+  }
+}

--- a/packages/alfa-performance/src/performance.ts
+++ b/packages/alfa-performance/src/performance.ts
@@ -31,8 +31,15 @@ export class Performance<T>
     return now ? now - this._epoch : this.now();
   }
 
-  public mark(data: T): Performance.Mark<T> {
-    return this._emit(Performance.mark(data, this.now()));
+  public mark(
+    data: T,
+    start: Performance.Entry<T> | number = this.now()
+  ): Performance.Mark<T> {
+    if (typeof start !== "number") {
+      start = start.start;
+    }
+
+    return this._emit(Performance.mark(data, start));
   }
 
   public measure(

--- a/packages/alfa-performance/src/performance.ts
+++ b/packages/alfa-performance/src/performance.ts
@@ -65,6 +65,10 @@ export class Performance
     this._emitter.on(listener);
   }
 
+  public off(listener: Callback<Performance.Entry>): void {
+    this._emitter.off(listener);
+  }
+
   public asyncIterator(): AsyncIterator<Performance.Entry> {
     return this._emitter.asyncIterator();
   }

--- a/packages/alfa-performance/src/performance.ts
+++ b/packages/alfa-performance/src/performance.ts
@@ -10,7 +10,7 @@ export class Performance<T>
   implements
     AsyncIterable<Performance.Entry<T>>,
     Serializable<Performance.JSON> {
-  public static of<T>(): Performance<T> {
+  public static of<T = string>(): Performance<T> {
     return new Performance();
   }
 
@@ -126,6 +126,10 @@ export namespace Performance {
       this._start = start;
     }
 
+    public get type(): "mark" {
+      return "mark";
+    }
+
     public get data(): T {
       return this._data;
     }
@@ -136,6 +140,7 @@ export namespace Performance {
 
     public toJSON(): Mark.JSON<T> {
       return {
+        type: "mark",
         data: Serializable.toJSON(this._data),
         start: this._start,
       };
@@ -145,6 +150,7 @@ export namespace Performance {
   export namespace Mark {
     export interface JSON<T> {
       [key: string]: json.JSON | undefined;
+      type: "mark";
       data: Serializable.ToJSON<T>;
       start: number;
     }
@@ -171,6 +177,10 @@ export namespace Performance {
       this._duration = duration;
     }
 
+    public get type(): "measure" {
+      return "measure";
+    }
+
     public get data(): T {
       return this._data;
     }
@@ -185,6 +195,7 @@ export namespace Performance {
 
     public toJSON(): Measure.JSON<T> {
       return {
+        type: "measure",
         data: Serializable.toJSON(this._data),
         start: this._start,
         duration: this._duration,
@@ -195,6 +206,7 @@ export namespace Performance {
   export namespace Measure {
     export interface JSON<T> {
       [key: string]: json.JSON | undefined;
+      type: "measure";
       data: Serializable.ToJSON<T>;
       start: number;
       duration: number;

--- a/packages/alfa-performance/src/performance.ts
+++ b/packages/alfa-performance/src/performance.ts
@@ -62,6 +62,20 @@ export class Performance<T>
     this._emitter.on(listener);
   }
 
+  public once(): Promise<Performance.Entry<T>>;
+
+  public once(listener: Callback<Performance.Entry<T>>): void;
+
+  public once(
+    listener?: Callback<Performance.Entry<T>>
+  ): void | Promise<Performance.Entry<T>> {
+    if (listener) {
+      return this._emitter.once(listener);
+    } else {
+      return this._emitter.once();
+    }
+  }
+
   public off(listener: Callback<Performance.Entry<T>>): void {
     this._emitter.off(listener);
   }
@@ -87,6 +101,10 @@ export class Performance<T>
 export namespace Performance {
   export interface JSON {
     [key: string]: json.JSON;
+  }
+
+  export function isPerformance<T>(value: unknown): value is Performance<T> {
+    return value instanceof Performance;
   }
 
   export type Entry<T> = Mark<T> | Measure<T>;

--- a/packages/alfa-performance/src/performance.ts
+++ b/packages/alfa-performance/src/performance.ts
@@ -1,0 +1,149 @@
+import { Array } from "@siteimprove/alfa-array";
+import { Serializable } from "@siteimprove/alfa-json";
+import { Option } from "@siteimprove/alfa-option";
+import { Sequence } from "@siteimprove/alfa-sequence";
+
+import * as json from "@siteimprove/alfa-json";
+
+import { now } from "./now";
+
+export class Performance implements Serializable<Performance.JSON> {
+  public static empty(): Performance {
+    return new Performance();
+  }
+
+  private readonly _epoch: number = now();
+  private readonly _entries: Array<Performance.Entry> = [];
+
+  private constructor() {}
+
+  public get epoch(): number {
+    return this._epoch;
+  }
+
+  public get entries(): Sequence<Performance.Entry> {
+    return Sequence.from(this._entries);
+  }
+
+  public now(): number {
+    return now() - this._epoch;
+  }
+
+  public elapsed(now?: number): number {
+    return now ? now - this._epoch : this.now();
+  }
+
+  public mark(id: string): Performance.Entry {
+    const entry = Performance.entry(id, "mark", this.now(), 0);
+
+    this._entries.push(entry);
+
+    return entry;
+  }
+
+  public measure(
+    id: string,
+    start: string | number = this._epoch,
+    end: string | number = this.now()
+  ): Performance.Entry {
+    if (typeof start === "string") {
+      start = this._findLastEntry(start)
+        .map((entry) => entry.start)
+        .getOr(this._epoch);
+    }
+
+    if (typeof end === "string") {
+      end = this._findLastEntry(end)
+        .map((entry) => entry.start)
+        .getOr(this.now());
+    }
+
+    const entry = Performance.entry(id, "measure", start, end - start);
+
+    this._entries.push(entry);
+
+    return entry;
+  }
+
+  public toJSON(): Performance.JSON {
+    return {
+      entries: this._entries.map((entry) => entry.toJSON()),
+    };
+  }
+
+  private _findLastEntry(id: string): Option<Performance.Entry> {
+    return Array.findLast(this._entries, (entry) => entry.id === id);
+  }
+}
+
+export namespace Performance {
+  export interface JSON {
+    [key: string]: json.JSON;
+    entries: Array<Entry.JSON>;
+  }
+
+  export class Entry implements Serializable<Entry.JSON> {
+    public static of(
+      id: string,
+      type: string,
+      start: number,
+      duration: number
+    ): Entry {
+      return new Entry(id, type, start, duration);
+    }
+
+    private readonly _id: string;
+    private readonly _type: string;
+    private readonly _start: number;
+    private readonly _duration: number;
+
+    private constructor(
+      id: string,
+      type: string,
+      start: number,
+      duration: number
+    ) {
+      this._id = id;
+      this._type = type;
+      this._start = start;
+      this._duration = duration;
+    }
+
+    public get id(): string {
+      return this._id;
+    }
+
+    public get type(): string {
+      return this._type;
+    }
+
+    public get start(): number {
+      return this._start;
+    }
+
+    public get duration(): number {
+      return this._duration;
+    }
+
+    public toJSON(): Entry.JSON {
+      return {
+        id: this._id,
+        type: this._type,
+        start: this._start,
+        duration: this._duration,
+      };
+    }
+  }
+
+  export namespace Entry {
+    export interface JSON {
+      [key: string]: json.JSON | undefined;
+      id: string;
+      type: string;
+      start: number;
+      duration: number;
+    }
+  }
+
+  export const { of: entry } = Entry;
+}

--- a/packages/alfa-performance/tsconfig.json
+++ b/packages/alfa-performance/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "extends": "../tsconfig.json",
+  "files": ["src/index.ts", "src/now.ts", "src/performance.ts"],
+  "references": [
+    {
+      "path": "../alfa-array"
+    },
+    {
+      "path": "../alfa-json"
+    },
+    {
+      "path": "../alfa-option"
+    },
+    {
+      "path": "../alfa-sequence"
+    },
+    {
+      "path": "../alfa-test"
+    },
+    {
+      "path": "../alfa-thunk"
+    }
+  ]
+}

--- a/packages/alfa-performance/tsconfig.json
+++ b/packages/alfa-performance/tsconfig.json
@@ -4,9 +4,6 @@
   "files": ["src/index.ts", "src/now.ts", "src/performance.ts"],
   "references": [
     {
-      "path": "../alfa-array"
-    },
-    {
       "path": "../alfa-callback"
     },
     {
@@ -16,16 +13,7 @@
       "path": "../alfa-json"
     },
     {
-      "path": "../alfa-option"
-    },
-    {
-      "path": "../alfa-sequence"
-    },
-    {
       "path": "../alfa-test"
-    },
-    {
-      "path": "../alfa-thunk"
     }
   ]
 }

--- a/packages/alfa-performance/tsconfig.json
+++ b/packages/alfa-performance/tsconfig.json
@@ -7,6 +7,12 @@
       "path": "../alfa-array"
     },
     {
+      "path": "../alfa-callback"
+    },
+    {
+      "path": "../alfa-emitter"
+    },
+    {
       "path": "../alfa-json"
     },
     {

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -64,6 +64,7 @@
     { "path": "alfa-monad" },
     { "path": "alfa-option" },
     { "path": "alfa-parser" },
+    { "path": "alfa-performance" },
     { "path": "alfa-predicate" },
     { "path": "alfa-puppeteer" },
     { "path": "alfa-react" },


### PR DESCRIPTION
This pull request introduces a new package, @siteimprove/alfa-performance, for working with performance measurements. Its design is based on the [User Timing](https://www.w3.org/TR/user-timing/) API, but is implemented independently of runtime environment (browsers vs. Node.js) and aims to solve some of the shortcomings of the User Timing API:

- **Lack of memory bounds**: With the User Timing API, performance entries are added to and kept in an internal buffer whose size can grow without bound. As such, marks and measurements must be cleared out regularly, or disabled entirely, in long running processes to avoid running out of memory.

- **Everything is globally scoped**: With the User Timing API, any code that wishes to track performance measurements do so via a globally scoped `Performance` instance. While this aids discoverability for consumers that sit outside the main code path, such as Real User Measurement (RUM) collectors, it makes it impossible so do things like collecting performance measurements for a particular call tree only, such as a single audit of a given rule set. 

  This problem also relates to the previous point as a singleton `Performance` instance, and its associated performance entries, can never be garbage collected. With locally scoped `Performance` instances, one would be able to simply drop references to these instances when no longer needed and then have the garbage collector do its job.

The implementation of `Performance` introduced in this pull request solves these problems in the following way:

- No global `Performance` instance is available and specific `Performance` instances must be created through `Performance.of()`:

  ```ts
  const performance = Performance.of<string>();
  ```

  Note that keys are not restricted to the `string` type but can be arbitrarily chosen.

- Entries are never buffered, but are instead shipped straight to listeners. To perform measurements between marks, the marks must be passed explicitly:

  ```ts
  const start = performance.mark("start");
  const end = performance.mark("end");
  
  performance.measure("measurement", start, end);
  ```