### PR TITLE
Make `#toJSON()` parametric for all container types

### DIFF
--- a/packages/alfa-act/src/outcome.ts
+++ b/packages/alfa-act/src/outcome.ts
@@ -144,7 +144,7 @@ export namespace Outcome {
       [key: string]: json.JSON;
       outcome: "passed";
       target: json.JSON;
-      expectations: Array<[string, Result.JSON]>;
+      expectations: Array<[string, Result.JSON<Diagnostic.JSON>]>;
     }
 
     export interface EARL extends Outcome.EARL {
@@ -246,7 +246,7 @@ export namespace Outcome {
       [key: string]: json.JSON;
       outcome: "failed";
       target: json.JSON;
-      expectations: Array<[string, Result.JSON]>;
+      expectations: Array<[string, Result.JSON<Diagnostic.JSON>]>;
     }
 
     export interface EARL extends Outcome.EARL {

--- a/packages/alfa-array/src/array.ts
+++ b/packages/alfa-array/src/array.ts
@@ -2,7 +2,7 @@ import { Clone } from "@siteimprove/alfa-clone";
 import { Comparable, Comparer, Comparison } from "@siteimprove/alfa-comparable";
 import { Equatable } from "@siteimprove/alfa-equatable";
 import { Hash, Hashable } from "@siteimprove/alfa-hash";
-import { JSON, Serializable } from "@siteimprove/alfa-json";
+import { Serializable } from "@siteimprove/alfa-json";
 import { Iterable } from "@siteimprove/alfa-iterable";
 import { None, Option, Some } from "@siteimprove/alfa-option";
 import { Predicate } from "@siteimprove/alfa-predicate";
@@ -201,9 +201,7 @@ export namespace Array {
     Hash.writeUint32(hash, array.length);
   }
 
-  export function toJSON<T extends JSON>(
-    array: Array<Serializable<T>>
-  ): Array<T> {
-    return array.map<T>(Serializable.toJSON);
+  export function toJSON<T>(array: Array<T>): Array<Serializable.ToJSON<T>> {
+    return array.map((value) => Serializable.toJSON(value));
   }
 }

--- a/packages/alfa-branched/src/branched.ts
+++ b/packages/alfa-branched/src/branched.ts
@@ -11,8 +11,6 @@ import { Predicate } from "@siteimprove/alfa-predicate";
 import { Reducer } from "@siteimprove/alfa-reducer";
 import { Refinement } from "@siteimprove/alfa-refinement";
 
-import * as json from "@siteimprove/alfa-json";
-
 const { not } = Predicate;
 
 export class Branched<T, B = never>
@@ -272,7 +270,7 @@ export class Branched<T, B = never>
       ]);
   }
 
-  public toJSON(): Branched.JSON {
+  public toJSON(): Branched.JSON<T, B> {
     return this._values
       .toArray()
       .map(({ value, branches }) => [
@@ -283,7 +281,9 @@ export class Branched<T, B = never>
 }
 
 export namespace Branched {
-  export type JSON = Array<[json.JSON, List.JSON]>;
+  export type JSON<T, B = never> = Array<
+    [Serializable.ToJSON<T>, Array<Serializable.ToJSON<B>>]
+  >;
 
   export function isBranched<T, B = never>(
     value: unknown
@@ -291,7 +291,7 @@ export namespace Branched {
     return value instanceof Branched;
   }
 
-  export function from<T, B>(
+  export function from<T, B = never>(
     values: Iterable<readonly [T, Iterable<B>]>
   ): Branched<T, B> {
     if (isBranched<T, B>(values)) {

--- a/packages/alfa-collection/src/collection.ts
+++ b/packages/alfa-collection/src/collection.ts
@@ -22,8 +22,7 @@ export interface Collection<T>
     Foldable<T>,
     Applicative<T>,
     Equatable,
-    Hashable,
-    Serializable {
+    Hashable {
   readonly size: number;
   isEmpty(): this is Collection<never>;
   forEach(callback: Callback<T>): void;
@@ -48,7 +47,10 @@ export interface Collection<T>
 }
 
 export namespace Collection {
-  export interface Keyed<K, V> extends Collection<V>, Iterable<[K, V]> {
+  export interface Keyed<K, V>
+    extends Collection<V>,
+      Iterable<[K, V]>,
+      Serializable<Keyed.JSON<K, V>> {
     // Collection<T> methods
 
     isEmpty(): this is Keyed<K, never>;
@@ -83,7 +85,16 @@ export namespace Collection {
     concat(iterable: Iterable<readonly [K, V]>): Keyed<K, V>;
   }
 
-  export interface Unkeyed<T> extends Collection<T>, Iterable<T> {
+  export namespace Keyed {
+    export type JSON<K, V> = Array<
+      [Serializable.ToJSON<K>, Serializable.ToJSON<V>]
+    >;
+  }
+
+  export interface Unkeyed<T>
+    extends Collection<T>,
+      Iterable<T>,
+      Serializable<Unkeyed.JSON<T>> {
     // Collection<T> methods
 
     isEmpty(): this is Unkeyed<never>;
@@ -116,7 +127,14 @@ export namespace Collection {
     concat(iterable: Iterable<T>): Unkeyed<T>;
   }
 
-  export interface Indexed<T> extends Collection<T>, Iterable<T> {
+  export namespace Unkeyed {
+    export type JSON<T> = Array<Serializable.ToJSON<T>>;
+  }
+
+  export interface Indexed<T>
+    extends Collection<T>,
+      Iterable<T>,
+      Serializable<Indexed.JSON<T>> {
     // Collection<T> methods
 
     isEmpty(): this is Indexed<never>;
@@ -167,6 +185,10 @@ export namespace Collection {
     join(separator: string): string;
     sortWith(comparer: Comparer<T>): Indexed<T>;
     compareWith(iterable: Iterable<T>, comparer: Comparer<T>): Comparison;
+  }
+
+  export namespace Indexed {
+    export type JSON<T> = Array<Serializable.ToJSON<T>>;
   }
 
   export function sort<T extends Comparable<T>>(

--- a/packages/alfa-either/src/either.ts
+++ b/packages/alfa-either/src/either.ts
@@ -16,7 +16,7 @@ export interface Either<L, R = L>
     Foldable<L | R>,
     Iterable<L | R>,
     Equatable,
-    Serializable {
+    Serializable<Either.JSON<L, R>> {
   isLeft(): this is Left<L>;
   isRight(): this is Right<R>;
   get(): L | R;
@@ -26,11 +26,11 @@ export interface Either<L, R = L>
   map<T>(mapper: Mapper<L | R, T>): Either<T, T>;
   flatMap<T>(mapper: Mapper<L | R, Either<T, T>>): Either<T, T>;
   reduce<T>(reducer: Reducer<L | R, T>, accumulator: T): T;
-  toJSON(): Either.JSON;
+  toJSON(): Either.JSON<L, R>;
 }
 
 export namespace Either {
-  export type JSON = Left.JSON | Right.JSON;
+  export type JSON<L, R = L> = Left.JSON<L> | Right.JSON<R>;
 
   export function isEither<L, R>(value: unknown): value is Either<L, R> {
     return Left.isLeft(value) || Right.isRight(value);

--- a/packages/alfa-either/src/left.ts
+++ b/packages/alfa-either/src/left.ts
@@ -64,7 +64,7 @@ export class Left<L> implements Either<L, never> {
     yield this._value;
   }
 
-  public toJSON(): Left.JSON {
+  public toJSON(): Left.JSON<L> {
     return {
       type: "left",
       value: Serializable.toJSON(this._value),
@@ -77,10 +77,10 @@ export class Left<L> implements Either<L, never> {
 }
 
 export namespace Left {
-  export interface JSON {
+  export interface JSON<L> {
     [key: string]: json.JSON;
     type: "left";
-    value: json.JSON;
+    value: Serializable.ToJSON<L>;
   }
 
   export function isLeft<L>(value: unknown): value is Left<L> {

--- a/packages/alfa-either/src/right.ts
+++ b/packages/alfa-either/src/right.ts
@@ -66,7 +66,7 @@ export class Right<R> implements Either<never, R> {
     yield this._value;
   }
 
-  public toJSON(): Right.JSON {
+  public toJSON(): Right.JSON<R> {
     return {
       type: "right",
       value: Serializable.toJSON(this._value),
@@ -79,10 +79,10 @@ export class Right<R> implements Either<never, R> {
 }
 
 export namespace Right {
-  export interface JSON {
+  export interface JSON<R> {
     [key: string]: json.JSON;
     type: "right";
-    value: json.JSON;
+    value: Serializable.ToJSON<R>;
   }
 
   export function isRight<R>(value: unknown): value is Right<R> {

--- a/packages/alfa-iterable/src/iterable.ts
+++ b/packages/alfa-iterable/src/iterable.ts
@@ -2,7 +2,7 @@ import { Callback } from "@siteimprove/alfa-callback";
 import { Comparable, Comparer, Comparison } from "@siteimprove/alfa-comparable";
 import { Equatable } from "@siteimprove/alfa-equatable";
 import { Hash, Hashable } from "@siteimprove/alfa-hash";
-import { JSON, Serializable } from "@siteimprove/alfa-json";
+import { Serializable } from "@siteimprove/alfa-json";
 import { Mapper } from "@siteimprove/alfa-mapper";
 import { None, Option, Some } from "@siteimprove/alfa-option";
 import { Predicate } from "@siteimprove/alfa-predicate";
@@ -673,9 +673,9 @@ export namespace Iterable {
     return groups;
   }
 
-  export function toJSON<T extends JSON>(
-    iterable: Iterable<Serializable<T>>
-  ): Array<T> {
-    return [...map<Serializable<T>, T>(iterable, Serializable.toJSON)];
+  export function toJSON<T>(
+    iterable: Iterable<T>
+  ): Array<Serializable.ToJSON<T>> {
+    return [...map(iterable, (value) => Serializable.toJSON(value))];
   }
 }

--- a/packages/alfa-json/src/serializable.ts
+++ b/packages/alfa-json/src/serializable.ts
@@ -20,8 +20,8 @@ export interface Serializable<T extends JSON = JSON> {
 }
 
 export namespace Serializable {
-  export type ToJSON<T> = T extends Serializable<infer T>
-    ? T
+  export type ToJSON<T> = T extends Serializable<infer U>
+    ? U
     : T extends JSON
     ? T
     : JSON;

--- a/packages/alfa-json/src/serializable.ts
+++ b/packages/alfa-json/src/serializable.ts
@@ -20,6 +20,12 @@ export interface Serializable<T extends JSON = JSON> {
 }
 
 export namespace Serializable {
+  export type ToJSON<T> = T extends Serializable<infer T>
+    ? T
+    : T extends JSON
+    ? T
+    : JSON;
+
   export function isSerializable<T extends JSON>(
     value: unknown
   ): value is Serializable<T> {
@@ -28,7 +34,7 @@ export namespace Serializable {
 
   export function toJSON<T extends JSON>(value: Serializable<T>): T;
 
-  export function toJSON(value: unknown): JSON;
+  export function toJSON<T>(value: T): ToJSON<T>;
 
   export function toJSON(value: unknown): JSON {
     if (isSerializable(value)) {

--- a/packages/alfa-lazy/src/lazy.ts
+++ b/packages/alfa-lazy/src/lazy.ts
@@ -6,7 +6,8 @@ import { Monad } from "@siteimprove/alfa-monad";
 import { Thunk } from "@siteimprove/alfa-thunk";
 import { Trampoline } from "@siteimprove/alfa-trampoline";
 
-export class Lazy<T> implements Monad<T>, Functor<T>, Equatable, Serializable {
+export class Lazy<T>
+  implements Monad<T>, Functor<T>, Equatable, Serializable<Lazy.JSON<T>> {
   public static of<T>(thunk: Thunk<T>): Lazy<T> {
     return new Lazy(Trampoline.delay(thunk));
   }
@@ -55,11 +56,15 @@ export class Lazy<T> implements Monad<T>, Functor<T>, Equatable, Serializable {
     return () => this.force();
   }
 
-  public toJSON(): JSON {
+  public toJSON(): Lazy.JSON<T> {
     return Serializable.toJSON(this.force());
   }
 
   public toString(): string {
     return `Lazy { ${this.force()} }`;
   }
+}
+
+export namespace Lazy {
+  export type JSON<T> = Serializable.ToJSON<T>;
 }

--- a/packages/alfa-list/src/list.ts
+++ b/packages/alfa-list/src/list.ts
@@ -12,8 +12,6 @@ import { Reducer } from "@siteimprove/alfa-reducer";
 import { Refinement } from "@siteimprove/alfa-refinement";
 import { Set } from "@siteimprove/alfa-set";
 
-import * as json from "@siteimprove/alfa-json";
-
 import { Branch, Empty, Leaf, Node } from "./node";
 
 const { not } = Predicate;
@@ -368,8 +366,8 @@ export class List<T> implements Collection.Indexed<T> {
     return [...this];
   }
 
-  public toJSON(): List.JSON {
-    return this.toArray().map(Serializable.toJSON);
+  public toJSON(): List.JSON<T> {
+    return this.toArray().map((value) => Serializable.toJSON(value));
   }
 
   public toString(): string {
@@ -561,7 +559,7 @@ export class List<T> implements Collection.Indexed<T> {
 }
 
 export namespace List {
-  export interface JSON extends Array<json.JSON> {}
+  export type JSON<T> = Collection.Indexed.JSON<T>;
 
   export function isList<T>(value: unknown): value is List<T> {
     return value instanceof List;

--- a/packages/alfa-map/src/map.ts
+++ b/packages/alfa-map/src/map.ts
@@ -234,7 +234,7 @@ export class Map<K, V> implements Collection.Keyed<K, V> {
     return [...this];
   }
 
-  public toJSON(): Map.JSON {
+  public toJSON(): Map.JSON<K, V> {
     return this.toArray().map(([key, value]) => [
       Serializable.toJSON(key),
       Serializable.toJSON(value),
@@ -259,7 +259,7 @@ export class Map<K, V> implements Collection.Keyed<K, V> {
 }
 
 export namespace Map {
-  export interface JSON extends Array<[json.JSON, json.JSON]> {}
+  export type JSON<K, V> = Collection.Keyed.JSON<K, V>;
 
   export function isMap<K, V>(value: unknown): value is Map<K, V> {
     return value instanceof Map;

--- a/packages/alfa-option/src/option.ts
+++ b/packages/alfa-option/src/option.ts
@@ -25,7 +25,7 @@ export interface Option<T>
     Iterable<T>,
     Equatable,
     Hashable,
-    Serializable {
+    Serializable<Option.JSON<T>> {
   isSome(): this is Some<T>;
   isNone(): this is None;
   map<U>(mapper: Mapper<T, U>): Option<U>;
@@ -49,13 +49,13 @@ export interface Option<T>
   getOrElse<U>(value: Thunk<U>): T | U;
   compareWith(option: Option<T>, comparer: Comparer<T>): Comparison;
   toArray(): Array<T>;
-  toJSON(): Option.JSON;
+  toJSON(): Option.JSON<T>;
 }
 
 export namespace Option {
   export type Maybe<T> = T | Option<T>;
 
-  export type JSON = Some.JSON | None.JSON;
+  export type JSON<T> = Some.JSON<T> | None.JSON;
 
   export function isOption<T>(value: unknown): value is Option<T> {
     return Some.isSome(value) || value === None;

--- a/packages/alfa-option/src/some.ts
+++ b/packages/alfa-option/src/some.ts
@@ -134,7 +134,7 @@ export class Some<T> implements Option<T> {
     return [this._value];
   }
 
-  public toJSON(): Some.JSON {
+  public toJSON(): Some.JSON<T> {
     return {
       type: "some",
       value: Serializable.toJSON(this._value),
@@ -147,10 +147,10 @@ export class Some<T> implements Option<T> {
 }
 
 export namespace Some {
-  export interface JSON {
+  export interface JSON<T> {
     [key: string]: json.JSON;
     type: "some";
-    value: json.JSON;
+    value: Serializable.ToJSON<T>;
   }
 
   export function isSome<T>(value: unknown): value is Some<T> {

--- a/packages/alfa-record/src/record.ts
+++ b/packages/alfa-record/src/record.ts
@@ -14,7 +14,7 @@ export class Record<T>
     Foldable<Record.Value<T>>,
     Iterable<Record.Entry<T>>,
     Equatable,
-    Serializable {
+    Serializable<Record.JSON<T>> {
   public static of<T>(properties: T): Record<T> {
     const keys = Object.keys(properties).sort() as Array<Record.Key<T>>;
     const values = List.from(keys.map((key) => properties[key]));
@@ -120,14 +120,14 @@ export class Record<T>
     return [...this];
   }
 
-  public toJSON(): Record.JSON {
+  public toJSON(): Record.JSON<T> {
     const json: { [key: string]: json.JSON } = {};
 
     for (const [key, value] of this) {
       json[key] = Serializable.toJSON(value);
     }
 
-    return json;
+    return json as Record.JSON<T>;
   }
 
   public toString(): string {
@@ -146,9 +146,7 @@ export namespace Record {
 
   export type Entry<T> = { [K in Key<T>]: [K, T[K]] }[Key<T>];
 
-  export interface JSON {
-    [key: string]: json.JSON;
-  }
+  export type JSON<T> = { [K in Key<T>]: Serializable.ToJSON<T[K]> };
 
   export function isRecord<T>(value: unknown): value is Record<T> {
     return value instanceof Record;

--- a/packages/alfa-result/src/err.ts
+++ b/packages/alfa-result/src/err.ts
@@ -135,7 +135,7 @@ export class Err<E> implements Result<never, E> {
 
   public *[Symbol.iterator]() {}
 
-  public toJSON(): Err.JSON {
+  public toJSON(): Err.JSON<E> {
     return {
       type: "err",
       error: Serializable.toJSON(this._error),
@@ -152,9 +152,9 @@ export namespace Err {
     return value instanceof Err;
   }
 
-  export interface JSON {
+  export interface JSON<E> {
     [key: string]: json.JSON;
     type: "err";
-    error: json.JSON;
+    error: Serializable.ToJSON<E>;
   }
 }

--- a/packages/alfa-result/src/ok.ts
+++ b/packages/alfa-result/src/ok.ts
@@ -137,7 +137,7 @@ export class Ok<T> implements Result<T, never> {
     yield this._value;
   }
 
-  public toJSON(): Ok.JSON {
+  public toJSON(): Ok.JSON<T> {
     return {
       type: "ok",
       value: Serializable.toJSON(this._value),
@@ -150,10 +150,10 @@ export class Ok<T> implements Result<T, never> {
 }
 
 export namespace Ok {
-  export interface JSON {
+  export interface JSON<T> {
     [key: string]: json.JSON;
     type: "ok";
-    value: json.JSON;
+    value: Serializable.ToJSON<T>;
   }
 
   export function isOk<T>(value: unknown): value is Ok<T> {

--- a/packages/alfa-result/src/result.ts
+++ b/packages/alfa-result/src/result.ts
@@ -46,11 +46,11 @@ export interface Result<T, E = T>
   getOrElse<U>(value: Thunk<U>): T | U;
   ok(): Option<T>;
   err(): Option<E>;
-  toJSON(): Result.JSON;
+  toJSON(): Result.JSON<T, E>;
 }
 
 export namespace Result {
-  export type JSON = Ok.JSON | Err.JSON;
+  export type JSON<T, E> = Ok.JSON<T> | Err.JSON<E>;
 
   export function isResult<T, E>(value: unknown): value is Result<T, E> {
     return Ok.isOk(value) || Err.isErr(value);

--- a/packages/alfa-result/src/result.ts
+++ b/packages/alfa-result/src/result.ts
@@ -20,7 +20,7 @@ export interface Result<T, E = T>
     Iterable<T>,
     Equatable,
     Hashable,
-    Serializable {
+    Serializable<Result.JSON<T, E>> {
   isOk(): this is Ok<T>;
   isErr(): this is Err<E>;
   map<U>(mapper: Mapper<T, U>): Result<U, E>;
@@ -50,7 +50,7 @@ export interface Result<T, E = T>
 }
 
 export namespace Result {
-  export type JSON<T, E> = Ok.JSON<T> | Err.JSON<E>;
+  export type JSON<T, E = T> = Ok.JSON<T> | Err.JSON<E>;
 
   export function isResult<T, E>(value: unknown): value is Result<T, E> {
     return Ok.isOk(value) || Err.isErr(value);

--- a/packages/alfa-sequence/src/cons.ts
+++ b/packages/alfa-sequence/src/cons.ts
@@ -1,4 +1,5 @@
 import { Callback } from "@siteimprove/alfa-callback";
+import { Collection } from "@siteimprove/alfa-collection";
 import { Comparer, Comparison } from "@siteimprove/alfa-comparable";
 import { Equatable } from "@siteimprove/alfa-equatable";
 import { Hash, Hashable } from "@siteimprove/alfa-hash";
@@ -12,8 +13,6 @@ import { Predicate } from "@siteimprove/alfa-predicate";
 import { Reducer } from "@siteimprove/alfa-reducer";
 import { Refinement } from "@siteimprove/alfa-refinement";
 import { Set } from "@siteimprove/alfa-set";
-
-import * as json from "@siteimprove/alfa-json";
 
 import { Nil } from "./nil";
 import { Sequence } from "./sequence";
@@ -616,8 +615,8 @@ export class Cons<T> implements Sequence<T> {
     }
   }
 
-  public toJSON(): Cons.JSON {
-    const json: Cons.JSON = [];
+  public toJSON(): Cons.JSON<T> {
+    const json: Cons.JSON<T> = [];
 
     let next: Cons<T> = this;
 
@@ -640,7 +639,7 @@ export class Cons<T> implements Sequence<T> {
 }
 
 export namespace Cons {
-  export type JSON = Array<json.JSON>;
+  export type JSON<T> = Collection.Indexed.JSON<T>;
 
   export function isCons<T>(value: unknown): value is Cons<T> {
     return value instanceof Cons;

--- a/packages/alfa-sequence/src/nil.ts
+++ b/packages/alfa-sequence/src/nil.ts
@@ -1,3 +1,4 @@
+import { Collection } from "@siteimprove/alfa-collection";
 import { Comparer, Comparison } from "@siteimprove/alfa-comparable";
 import { Hash } from "@siteimprove/alfa-hash";
 import { Iterable } from "@siteimprove/alfa-iterable";
@@ -219,5 +220,5 @@ export const Nil: Nil = new (class Nil {
 })();
 
 export namespace Nil {
-  export type JSON = Array<never>;
+  export type JSON = Collection.Indexed.JSON<never>;
 }

--- a/packages/alfa-sequence/src/sequence.ts
+++ b/packages/alfa-sequence/src/sequence.ts
@@ -75,11 +75,11 @@ export interface Sequence<T> extends Collection.Indexed<T> {
 
   // Serializable methods
 
-  toJSON(): Sequence.JSON;
+  toJSON(): Sequence.JSON<T>;
 }
 
 export namespace Sequence {
-  export type JSON = Cons.JSON | Nil.JSON;
+  export type JSON<T> = Cons.JSON<T> | Nil.JSON;
 
   export function isSequence<T>(value: unknown): value is Sequence<T> {
     return Cons.isCons(value) || value === Nil;

--- a/packages/alfa-set/src/set.ts
+++ b/packages/alfa-set/src/set.ts
@@ -187,8 +187,8 @@ export class Set<T> implements Collection.Unkeyed<T> {
     return [...this];
   }
 
-  public toJSON(): Set.JSON {
-    return this.toArray().map(Serializable.toJSON);
+  public toJSON(): Set.JSON<T> {
+    return this.toArray().map((value) => Serializable.toJSON(value));
   }
 
   public toString(): string {
@@ -199,7 +199,7 @@ export class Set<T> implements Collection.Unkeyed<T> {
 }
 
 export namespace Set {
-  export interface JSON extends Array<json.JSON> {}
+  export type JSON<T> = Collection.Unkeyed.JSON<T>;
 
   export function isSet<T>(value: unknown): value is Set<T> {
     return value instanceof Set;

--- a/packages/alfa-slice/src/slice.ts
+++ b/packages/alfa-slice/src/slice.ts
@@ -2,9 +2,8 @@ import { Equatable } from "@siteimprove/alfa-equatable";
 import { Serializable } from "@siteimprove/alfa-json";
 import { None, Option } from "@siteimprove/alfa-option";
 
-import * as json from "@siteimprove/alfa-json";
-
-export class Slice<T> implements Iterable<T>, Equatable, Serializable {
+export class Slice<T>
+  implements Iterable<T>, Equatable, Serializable<Slice.JSON<T>> {
   public static of<T>(
     array: Readonly<Array<T>>,
     start: number = 0,
@@ -94,8 +93,8 @@ export class Slice<T> implements Iterable<T>, Equatable, Serializable {
     return this._array.slice(this._offset, this._offset + this._length);
   }
 
-  public toJSON(): Slice.JSON {
-    return this.toArray().map(Serializable.toJSON);
+  public toJSON(): Slice.JSON<T> {
+    return this.toArray().map((value) => Serializable.toJSON(value));
   }
 
   public toString(): string {
@@ -106,7 +105,7 @@ export class Slice<T> implements Iterable<T>, Equatable, Serializable {
 }
 
 export namespace Slice {
-  export interface JSON extends Array<json.JSON> {}
+  export type JSON<T> = Array<Serializable.ToJSON<T>>;
 
   export function isSlice<T>(value: unknown): value is Slice<T> {
     return value instanceof Slice;

--- a/packages/alfa-table/src/table.ts
+++ b/packages/alfa-table/src/table.ts
@@ -88,7 +88,7 @@ export class Table implements Equatable, Serializable<Table.JSON> {
     return {
       element: this._element.path(),
       cells: Array.toJSON(this._cells),
-      groups: Array.toJSON<Group.JSON>(this._groups),
+      groups: Array.toJSON(this._groups),
     };
   }
 }


### PR DESCRIPTION
This pull request makes the `#toJSON()` methods parametric for all container types to allow strongly typed JSON serialisation when working with these. The most common use case of this is by far when writing unit tests as these often do deep comparisons of JSON serialised structures. Consider, for example, a list of optional numbers:

```ts
const list: List<Option<number>>
```

Previously, when serialising this structure to JSON, you'd get the following type:

```ts
const json: List.JSON = list.toJSON()
```

Not... terribly helpful. It even becomes harmful when refactoring as TypeScript has no knowledge of the `Option.JSON` types nested within the serialised list structure. Had we typed out the structure by hand, as we often do when doing deep comparisons, TypeScript would not have applied the refactoring. This piece of code would therefore stay the same if had we chosen to rename `Some.JSON#value` to `Some.JSON#whatever`:

```ts
const json: List.JSON = [
  {
    type: "some",
    value: 42
  }
]
```

The result we really want is for TypeScript to intelligently apply to refactor to the above code as well, which this pull request enables by making the `List.JSON` type, and all other container types, parametric:

```ts
const json: List.JSON<Option.JSON<number>> = [
  {
    type: "some",
    value: 42
  }
]
```

If we now choose to rename `Some.JSON#value` to `Some.JSON#whatever`, the refactor will be applied to the above code as well as TypeScript knows that the inner object is of type `Some.JSON<number>`.