### PR TITLE
Make SIA-R14 assume that non-essential text is imperceivable

### DIFF
--- a/packages/alfa-rules/src/sia-r14/rule.ts
+++ b/packages/alfa-rules/src/sia-r14/rule.ts
@@ -14,15 +14,12 @@ import { hasDescendant } from "../common/predicate/has-descendant";
 import { hasRole } from "../common/predicate/has-role";
 import { isFocusable } from "../common/predicate/is-focusable";
 import { isPerceivable } from "../common/predicate/is-perceivable";
-import { isVisible } from "../common/predicate/is-visible";
-
-import { Question } from "../common/question";
 
 const { isElement, hasNamespace } = Element;
 const { isText } = Text;
 const { and, test } = Predicate;
 
-export default Rule.Atomic.of<Page, Element, Question>({
+export default Rule.Atomic.of<Page, Element>({
   uri: "https://siteimprove.githu.io/sanshikan/rules/sia-r14.html",
   requirements: [Criterion.of("2.5.3"), Technique.of("G208")],
   evaluate({ device, document }) {
@@ -49,7 +46,7 @@ export default Rule.Atomic.of<Page, Element, Question>({
       },
 
       expectations(target) {
-        const textContent = getVisibleTextContent(target, device);
+        const textContent = getPerceivableTextContent(target, device);
 
         const accessibleNameIncludesTextContent = test(
           hasAccessibleName(device, (accessibleName) =>
@@ -62,19 +59,7 @@ export default Rule.Atomic.of<Page, Element, Question>({
           1: expectation(
             accessibleNameIncludesTextContent,
             () => Outcomes.VisibleIsInName,
-            () =>
-              Question.of(
-                "is-human-language",
-                "boolean",
-                target,
-                "Does the accessible name of the element express anything in human language?"
-              ).map((isHumanLanguage) =>
-                expectation(
-                  !isHumanLanguage,
-                  () => Outcomes.NameIsNotLanguage,
-                  () => Outcomes.VisibleIsNotInName
-                )
-              )
+            () => Outcomes.VisibleIsNotInName
           ),
         };
       },
@@ -86,12 +71,12 @@ function normalize(input: string): string {
   return input.trim().toLowerCase().replace(/\s+/g, " ");
 }
 
-function getVisibleTextContent(element: Element, device: Device): string {
+function getPerceivableTextContent(element: Element, device: Device): string {
   return normalize(
     element
       .descendants({ flattened: true })
       .filter(isText)
-      .filter(isVisible(device))
+      .filter(isPerceivable(device))
       .map((text) => text.data)
       .join("")
   );
@@ -101,12 +86,6 @@ export namespace Outcomes {
   export const VisibleIsInName = Ok.of(
     Diagnostic.of(
       `The visible text content of the element is included within its accessible name`
-    )
-  );
-
-  export const NameIsNotLanguage = Ok.of(
-    Diagnostic.of(
-      `The accessible name of the element does not express anything in human language`
     )
   );
 

--- a/packages/alfa-rules/test/sia-r14/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r14/rule.spec.tsx
@@ -1,0 +1,64 @@
+import { jsx } from "@siteimprove/alfa-dom/jsx";
+import { test } from "@siteimprove/alfa-test";
+
+import { Document } from "@siteimprove/alfa-dom";
+
+import R14, { Outcomes } from "../../src/sia-r14/rule";
+
+import { evaluate } from "../common/evaluate";
+import { passed, failed } from "../common/outcome";
+
+test(`evaluate() passes a <button> element whose perceivable text content
+      matches its accessible name set by aria-label`, async (t) => {
+  const target = <button aria-label="Hello world">Hello world</button>;
+
+  const document = Document.of([target]);
+
+  t.deepEqual(await evaluate(R14, { document }), [
+    passed(R14, target, {
+      1: Outcomes.VisibleIsInName,
+    }),
+  ]);
+});
+
+test(`evaluate() passes a <button> element whose perceivable text content
+      is included in its accessible name set by aria-label`, async (t) => {
+  const target = <button aria-label="Hello world">Hello</button>;
+
+  const document = Document.of([target]);
+
+  t.deepEqual(await evaluate(R14, { document }), [
+    passed(R14, target, {
+      1: Outcomes.VisibleIsInName,
+    }),
+  ]);
+});
+
+test(`evaluate() fails a <button> element whose perceivable text content
+      is not included in its accessible name set by aria-label`, async (t) => {
+  const target = <button aria-label="Hello">Hello world</button>;
+
+  const document = Document.of([target]);
+
+  t.deepEqual(await evaluate(R14, { document }), [
+    failed(R14, target, {
+      1: Outcomes.VisibleIsNotInName,
+    }),
+  ]);
+});
+
+test(`evaluate() ignores non-perceivable text content`, async (t) => {
+  const target = (
+    <button aria-label="Hello">
+      Hello <span aria-hidden="true">world</span>
+    </button>
+  );
+
+  const document = Document.of([target]);
+
+  t.deepEqual(await evaluate(R14, { document }), [
+    passed(R14, target, {
+      1: Outcomes.VisibleIsInName,
+    }),
+  ]);
+});

--- a/packages/alfa-rules/tsconfig.json
+++ b/packages/alfa-rules/tsconfig.json
@@ -133,6 +133,7 @@
     "test/sia-r2/rule.spec.tsx",
     "test/sia-r10/rule.spec.tsx",
     "test/sia-r13/rule.spec.tsx",
+    "test/sia-r14/rule.spec.tsx",
     "test/sia-r15/rule.spec.tsx",
     "test/sia-r16/rule.spec.tsx",
     "test/sia-r21/rule.spec.tsx",


### PR DESCRIPTION
This pull request changes the expectation of SIA-R14 to assume that non-essential text, such as purely presentational text, has been made imperceivable. As such, imperceivable text is no longer required to be included in the accessible name of widget elements that receive their name from their contents.