### PR TITLE
Make content document of non-rendered elements also not rendered

### DIFF
--- a/packages/alfa-rules/src/common/predicate/is-rendered.ts
+++ b/packages/alfa-rules/src/common/predicate/is-rendered.ts
@@ -43,6 +43,7 @@ export function isRendered(
         return node
           .parent({
             flattened: true,
+            nested: true,
           })
           .every(isRendered);
       });


### PR DESCRIPTION
`<iframe srcdoc="<p>Foo</p>" hidden />` was considering the `<p>` element as rendered because all its non-nested parents are…