### PR TITLE
Make `Value.JSON` optionally parametric

### DIFF
--- a/packages/alfa-css/src/value.ts
+++ b/packages/alfa-css/src/value.ts
@@ -14,15 +14,15 @@ export abstract class Value<T extends string = string>
 
   public abstract hash(hash: Hash): void;
 
-  public abstract toJSON(): Value.JSON;
+  public abstract toJSON(): Value.JSON<T>;
 
   public abstract toString(): string;
 }
 
 export namespace Value {
-  export interface JSON {
+  export interface JSON<T extends string = string> {
     [key: string]: json.JSON;
-    type: string;
+    type: T;
   }
 
   export function isValue<T extends string>(

--- a/packages/alfa-css/src/value/angle.ts
+++ b/packages/alfa-css/src/value/angle.ts
@@ -67,8 +67,7 @@ export class Angle<U extends Unit.Angle = Unit.Angle> extends Dimension<
 }
 
 export namespace Angle {
-  export interface JSON extends Dimension.JSON {
-    type: "angle";
+  export interface JSON extends Dimension.JSON<"angle"> {
     unit: Unit.Angle;
   }
 

--- a/packages/alfa-css/src/value/color/hex.ts
+++ b/packages/alfa-css/src/value/color/hex.ts
@@ -72,8 +72,7 @@ export class Hex extends Value<"color"> {
 }
 
 export namespace Hex {
-  export interface JSON extends Value.JSON {
-    type: "color";
+  export interface JSON extends Value.JSON<"color"> {
     format: "hex";
     value: number;
   }

--- a/packages/alfa-css/src/value/color/hsl.ts
+++ b/packages/alfa-css/src/value/color/hsl.ts
@@ -129,8 +129,7 @@ export class HSL<
 }
 
 export namespace HSL {
-  export interface JSON extends Value.JSON {
-    type: "color";
+  export interface JSON extends Value.JSON<"color"> {
     format: "hsl";
     hue: Number.JSON | Angle.JSON;
     saturation: Percentage.JSON;

--- a/packages/alfa-css/src/value/color/named.ts
+++ b/packages/alfa-css/src/value/color/named.ts
@@ -76,8 +76,7 @@ export class Named<C extends Named.Color = Named.Color> extends Value<"color"> {
 }
 
 export namespace Named {
-  export interface JSON extends Value.JSON {
-    type: "color";
+  export interface JSON extends Value.JSON<"color"> {
     format: "named";
     color: string;
   }

--- a/packages/alfa-css/src/value/color/rgb.ts
+++ b/packages/alfa-css/src/value/color/rgb.ts
@@ -93,8 +93,7 @@ export class RGB<
 }
 
 export namespace RGB {
-  export interface JSON extends Value.JSON {
-    type: "color";
+  export interface JSON extends Value.JSON<"color"> {
     format: "rgb";
     red: Number.JSON | Percentage.JSON;
     green: Number.JSON | Percentage.JSON;

--- a/packages/alfa-css/src/value/dimension.ts
+++ b/packages/alfa-css/src/value/dimension.ts
@@ -40,7 +40,7 @@ export abstract class Dimension<
 }
 
 export namespace Dimension {
-  export interface JSON extends Numeric.JSON {
+  export interface JSON<T extends string = string> extends Numeric.JSON<T> {
     unit: Unit;
   }
 

--- a/packages/alfa-css/src/value/gradient/linear.ts
+++ b/packages/alfa-css/src/value/gradient/linear.ts
@@ -97,8 +97,7 @@ export class Linear<
 }
 
 export namespace Linear {
-  export interface JSON extends Value.JSON {
-    type: "gradient";
+  export interface JSON extends Value.JSON<"gradient"> {
     kind: "linear";
     direction: Direction.JSON;
     items: Array<Gradient.Item.JSON>;

--- a/packages/alfa-css/src/value/image.ts
+++ b/packages/alfa-css/src/value/image.ts
@@ -11,9 +11,9 @@ const { map, either } = Parser;
 /**
  * @see https://drafts.csswg.org/css-values/#images
  */
-export class Image<I extends URL | Gradient = URL | Gradient> extends Value<
-  "image"
-> {
+export class Image<
+  I extends URL | Gradient = URL | Gradient
+> extends Value<"image"> {
   public static of<I extends URL | Gradient>(image: I): Image<I> {
     return new Image(image);
   }
@@ -54,8 +54,7 @@ export class Image<I extends URL | Gradient = URL | Gradient> extends Value<
 }
 
 export namespace Image {
-  export interface JSON extends Value.JSON {
-    type: "image";
+  export interface JSON extends Value.JSON<"image"> {
     image: URL.JSON | Gradient.JSON;
   }
 

--- a/packages/alfa-css/src/value/integer.ts
+++ b/packages/alfa-css/src/value/integer.ts
@@ -40,8 +40,8 @@ export class Integer extends Numeric<"integer"> {
 }
 
 export namespace Integer {
-  export interface JSON extends Numeric.JSON {
-    type: "integer";
+  export interface JSON extends Numeric.JSON<"integer"> {
+    value: number;
   }
 
   export function isInteger(value: unknown): value is Integer {

--- a/packages/alfa-css/src/value/keyword.ts
+++ b/packages/alfa-css/src/value/keyword.ts
@@ -52,8 +52,7 @@ export class Keyword<T extends string = string> extends Value<"keyword"> {
 }
 
 export namespace Keyword {
-  export interface JSON extends Value.JSON {
-    type: "keyword";
+  export interface JSON extends Value.JSON<"keyword"> {
     value: string;
   }
 

--- a/packages/alfa-css/src/value/length.ts
+++ b/packages/alfa-css/src/value/length.ts
@@ -74,8 +74,7 @@ export class Length<U extends Unit.Length = Unit.Length>
 }
 
 export namespace Length {
-  export interface JSON extends Dimension.JSON {
-    type: "length";
+  export interface JSON extends Dimension.JSON<"length"> {
     unit: Unit.Length;
   }
 

--- a/packages/alfa-css/src/value/number.ts
+++ b/packages/alfa-css/src/value/number.ts
@@ -34,8 +34,8 @@ export class Number extends Numeric<"number"> {
 }
 
 export namespace Number {
-  export interface JSON extends Numeric.JSON {
-    type: "number";
+  export interface JSON extends Numeric.JSON<"number"> {
+    value: number;
   }
 
   export function isNumber(value: unknown): value is Number {

--- a/packages/alfa-css/src/value/numeric.ts
+++ b/packages/alfa-css/src/value/numeric.ts
@@ -30,7 +30,7 @@ export abstract class Numeric<T extends string = string> extends Value<T> {
     Hash.writeFloat64(hash, this._value);
   }
 
-  public abstract toJSON(): Numeric.JSON;
+  public abstract toJSON(): Numeric.JSON<T>;
 
   public toString(): string {
     return `${this._value}`;
@@ -38,7 +38,7 @@ export abstract class Numeric<T extends string = string> extends Value<T> {
 }
 
 export namespace Numeric {
-  export interface JSON extends Value.JSON {
+  export interface JSON<T extends string = string> extends Value.JSON<T> {
     [key: string]: json.JSON;
     value: number;
   }

--- a/packages/alfa-css/src/value/percentage.ts
+++ b/packages/alfa-css/src/value/percentage.ts
@@ -38,8 +38,8 @@ export class Percentage extends Numeric<"percentage"> {
 }
 
 export namespace Percentage {
-  export interface JSON extends Numeric.JSON {
-    type: "percentage";
+  export interface JSON extends Numeric.JSON<"percentage"> {
+    value: number;
   }
 
   export function isPercentage(value: unknown): value is Percentage {

--- a/packages/alfa-css/src/value/position.ts
+++ b/packages/alfa-css/src/value/position.ts
@@ -77,8 +77,7 @@ export class Position<
 export namespace Position {
   import parseWhitespace = Token.parseWhitespace;
 
-  export interface JSON extends Value.JSON {
-    type: "position";
+  export interface JSON extends Value.JSON<"position"> {
     horizontal: Component.JSON;
     vertical: Component.JSON;
   }
@@ -166,8 +165,7 @@ export namespace Position {
   }
 
   export namespace Side {
-    export interface JSON extends Value.JSON {
-      type: "side";
+    export interface JSON extends Value.JSON<"side"> {
       side: Keyword.JSON;
       offset: Length.JSON | Percentage.JSON | null;
     }

--- a/packages/alfa-css/src/value/shadow.ts
+++ b/packages/alfa-css/src/value/shadow.ts
@@ -122,8 +122,7 @@ export class Shadow<
 }
 
 export namespace Shadow {
-  export interface JSON extends Value.JSON {
-    type: "shadow";
+  export interface JSON extends Value.JSON<"shadow"> {
     vertical: Length.JSON;
     horizontal: Length.JSON;
     blur: Length.JSON;

--- a/packages/alfa-css/src/value/string.ts
+++ b/packages/alfa-css/src/value/string.ts
@@ -51,8 +51,7 @@ export class String extends Value<"string"> {
 }
 
 export namespace String {
-  export interface JSON extends Value.JSON {
-    type: "string";
+  export interface JSON extends Value.JSON<"string"> {
     value: string;
   }
 

--- a/packages/alfa-css/src/value/transform/matrix.ts
+++ b/packages/alfa-css/src/value/transform/matrix.ts
@@ -89,8 +89,7 @@ export class Matrix extends Value<"transform"> {
 }
 
 export namespace Matrix {
-  export interface JSON extends Value.JSON {
-    type: "transform";
+  export interface JSON extends Value.JSON<"transform"> {
     kind: "matrix";
     values: Values<Number.JSON>;
   }

--- a/packages/alfa-css/src/value/transform/perspective.ts
+++ b/packages/alfa-css/src/value/transform/perspective.ts
@@ -54,8 +54,7 @@ export class Perspective<D extends Length = Length> extends Value<"transform"> {
 }
 
 export namespace Perspective {
-  export interface JSON extends Value.JSON {
-    type: "transform";
+  export interface JSON extends Value.JSON<"transform"> {
     kind: "perspective";
     depth: Length.JSON;
   }

--- a/packages/alfa-css/src/value/transform/rotate.ts
+++ b/packages/alfa-css/src/value/transform/rotate.ts
@@ -95,8 +95,7 @@ export class Rotate<A extends Angle = Angle> extends Value<"transform"> {
 }
 
 export namespace Rotate {
-  export interface JSON extends Value.JSON {
-    type: "transform";
+  export interface JSON extends Value.JSON<"transform"> {
     kind: "rotate";
     x: Number.JSON;
     y: Number.JSON;

--- a/packages/alfa-css/src/value/transform/scale.ts
+++ b/packages/alfa-css/src/value/transform/scale.ts
@@ -78,8 +78,7 @@ export class Scale extends Value<"transform"> {
 }
 
 export namespace Scale {
-  export interface JSON extends Value.JSON {
-    type: "transform";
+  export interface JSON extends Value.JSON<"transform"> {
     kind: "scale";
     x: Number.JSON;
     y: Number.JSON;

--- a/packages/alfa-css/src/value/transform/skew.ts
+++ b/packages/alfa-css/src/value/transform/skew.ts
@@ -79,8 +79,7 @@ export class Skew<
 }
 
 export namespace Skew {
-  export interface JSON extends Value.JSON {
-    type: "transform";
+  export interface JSON extends Value.JSON<"transform"> {
     kind: "skew";
     x: Angle.JSON;
     y: Angle.JSON;

--- a/packages/alfa-css/src/value/transform/translate.ts
+++ b/packages/alfa-css/src/value/transform/translate.ts
@@ -90,8 +90,7 @@ export class Translate<
 }
 
 export namespace Translate {
-  export interface JSON extends Value.JSON {
-    type: "transform";
+  export interface JSON extends Value.JSON<"transform"> {
     kind: "translate";
     x: Length.JSON | Percentage.JSON;
     y: Length.JSON | Percentage.JSON;

--- a/packages/alfa-css/src/value/url.ts
+++ b/packages/alfa-css/src/value/url.ts
@@ -50,8 +50,7 @@ export class URL extends Value<"url"> {
 }
 
 export namespace URL {
-  export interface JSON extends Value.JSON {
-    type: "url";
+  export interface JSON extends Value.JSON<"url"> {
     url: string;
   }
 

--- a/packages/alfa-style/src/property/value/list.ts
+++ b/packages/alfa-style/src/property/value/list.ts
@@ -64,8 +64,7 @@ export class List<T> extends Value<"list"> implements Iterable<T> {
 }
 
 export namespace List {
-  export interface JSON extends Value.JSON {
-    type: "list";
+  export interface JSON extends Value.JSON<"list"> {
     values: Array<json.JSON>;
     separator: string;
   }


### PR DESCRIPTION
In the line of #644, I figured `Value.JSON` could as well incorporate the type of value.

Not sure if we should extend further for sub-interfaces with common field (e.g. `format` for colours or `kind` for transforms).