### PR TITLE
Unbranch ARIA types

### DIFF
--- a/packages/alfa-aria/src/name.ts
+++ b/packages/alfa-aria/src/name.ts
@@ -1,7 +1,5 @@
 import { Array } from "@siteimprove/alfa-array";
-import { Branched } from "@siteimprove/alfa-branched";
 import { Cache } from "@siteimprove/alfa-cache";
-import { Browser } from "@siteimprove/alfa-compatibility";
 import { Device } from "@siteimprove/alfa-device";
 import { Attribute, Element, Node, Text } from "@siteimprove/alfa-dom";
 import { Equatable } from "@siteimprove/alfa-equatable";
@@ -502,17 +500,11 @@ export namespace Name {
     }
   }
 
-  export function from(
-    node: Element | Text,
-    device: Device
-  ): Branched<Option<Name>, Browser> {
+  export function from(node: Element | Text, device: Device): Option<Name> {
     return fromNode(node, device, State.empty());
   }
 
-  const names = Cache.empty<
-    Device,
-    Cache<Node, Branched<Option<Name>, Browser>>
-  >();
+  const names = Cache.empty<Device, Cache<Node, Option<Name>>>();
 
   /**
    * @internal
@@ -521,7 +513,7 @@ export namespace Name {
     node: Element | Text,
     device: Device,
     state: State
-  ): Branched<Option<Name>, Browser> {
+  ): Option<Name> {
     // Construct a thunk with the computed name of the node. We first need to
     // decide whether or not we can pull the name of the node from the cache and
     // so the actual computation of the name must be delayed.
@@ -590,130 +582,128 @@ export namespace Name {
     element: Element,
     device: Device,
     state: State
-  ): Branched<Option<Name>, Browser> {
-    const empty = Branched.of(None);
-
+  ): Option<Name> {
     if (state.hasVisited(element)) {
       // While self-references are allowed, any other forms of circular
       // references are not. If the referrer therefore isn't the element itself,
       // the result will be an empty name.
       if (!state.referrer.includes(element)) {
-        return empty;
+        return None;
       }
     } else {
       state = state.visit(element);
     }
 
-    return Role.from(element).flatMap((role) => {
-      // The following code handles the _generic_ steps of the accessible name
-      // computation, that is any steps that are shared for all namespaces. All
-      // remaining steps are handled by namespace-specific feature mappings.
+    // The following code handles the _generic_ steps of the accessible name
+    // computation, that is any steps that are shared for all namespaces. All
+    // remaining steps are handled by namespace-specific feature mappings.
 
-      // Step 1: Does the role prohibit naming?
-      // https://w3c.github.io/accname/#step1
-      if (role.some((role) => role.isNameProhibited())) {
-        return empty;
-      }
+    const role = Role.from(element);
 
-      // Step 2A: Is the element hidden and not referenced?
-      // https://w3c.github.io/accname/#step2A
-      if (!state.isReferencing && isHidden(element, device)) {
-        return empty;
-      }
+    // Step 1: Does the role prohibit naming?
+    // https://w3c.github.io/accname/#step1
+    if (role.some((role) => role.isNameProhibited())) {
+      return None;
+    }
 
-      return fromSteps(
-        // Step 2B: Use the `aria-labelledby` attribute, if present and allowed.
-        // https://w3c.github.io/accname/#step2B
-        () => {
-          // Chained `aria-labelledby` references, such `foo` -> `bar` -> `baz`,
-          // are not allowed. If the element is therefore being referenced
-          // already then this step produces an empty name.
-          if (state.isReferencing) {
-            return empty;
-          }
+    // Step 2A: Is the element hidden and not referenced?
+    // https://w3c.github.io/accname/#step2A
+    if (!state.isReferencing && isHidden(element, device)) {
+      return None;
+    }
 
-          const attribute = element.attribute("aria-labelledby");
-
-          if (attribute.isNone()) {
-            return empty;
-          }
-
-          return fromReferences(attribute.get(), element, device, state);
-        },
-
-        // Step 2C: Use the `aria-label` attribute, if present.
-        // https://w3c.github.io/accname/#step2C
-        () => {
-          const attribute = element.attribute("aria-label");
-
-          if (attribute.isNone()) {
-            return empty;
-          }
-
-          return fromLabel(attribute.get());
-        },
-
-        // Step 2D: Use native features, if present and allowed.
-        // https://w3c.github.io/accname/#step2D
-        () => {
-          // Using native features is only allowed if the role, if any, of the
-          // element is not presentational and the element has a namespace with
-          // which to look up its feature mapping, if it exists. If the role of
-          // element therefore is presentational or the element has no namespace
-          // then this step produces an empty name.
-          if (
-            role.some((role) => role.isPresentational()) ||
-            element.namespace.isNone()
-          ) {
-            return empty;
-          }
-
-          const feature = Feature.from(element.namespace.get(), element.name);
-
-          if (feature.isNone()) {
-            return empty;
-          }
-
-          return feature.get().name(element, device, state);
-        },
-
-        // Step 2F: Use the subtree content, if referencing or allowed.
-        // https://w3c.github.io/accname/#step2F
-        () => {
-          // Using the subtree content is only allowed if the element is either
-          // being referenced or the role, if any, of the element allows it to
-          // be named by its content. If the element therefore isn't being
-          // referenced and is not allowed to be named by its content then this
-          // step produces an empty name.
-          if (
-            !state.isReferencing &&
-            !role.every((role) => role.isNamedBy("contents"))
-          ) {
-            return empty;
-          }
-
-          return fromDescendants(element, device, state);
-        },
-
-        // Step 2H: Use the subtree content, if descending.
-        // https://w3c.github.io/accname/#step2H
-        () => {
-          // Unless we're already descending then this step produces an empty
-          // name.
-          if (!state.isDescending) {
-            return empty;
-          }
-
-          return fromDescendants(element, device, state);
+    return fromSteps(
+      // Step 2B: Use the `aria-labelledby` attribute, if present and allowed.
+      // https://w3c.github.io/accname/#step2B
+      () => {
+        // Chained `aria-labelledby` references, such `foo` -> `bar` -> `baz`,
+        // are not allowed. If the element is therefore being referenced
+        // already then this step produces an empty name.
+        if (state.isReferencing) {
+          return None;
         }
-      );
-    });
+
+        const attribute = element.attribute("aria-labelledby");
+
+        if (attribute.isNone()) {
+          return None;
+        }
+
+        return fromReferences(attribute.get(), element, device, state);
+      },
+
+      // Step 2C: Use the `aria-label` attribute, if present.
+      // https://w3c.github.io/accname/#step2C
+      () => {
+        const attribute = element.attribute("aria-label");
+
+        if (attribute.isNone()) {
+          return None;
+        }
+
+        return fromLabel(attribute.get());
+      },
+
+      // Step 2D: Use native features, if present and allowed.
+      // https://w3c.github.io/accname/#step2D
+      () => {
+        // Using native features is only allowed if the role, if any, of the
+        // element is not presentational and the element has a namespace with
+        // which to look up its feature mapping, if it exists. If the role of
+        // element therefore is presentational or the element has no namespace
+        // then this step produces an empty name.
+        if (
+          role.some((role) => role.isPresentational()) ||
+          element.namespace.isNone()
+        ) {
+          return None;
+        }
+
+        const feature = Feature.from(element.namespace.get(), element.name);
+
+        if (feature.isNone()) {
+          return None;
+        }
+
+        return feature.get().name(element, device, state);
+      },
+
+      // Step 2F: Use the subtree content, if referencing or allowed.
+      // https://w3c.github.io/accname/#step2F
+      () => {
+        // Using the subtree content is only allowed if the element is either
+        // being referenced or the role, if any, of the element allows it to
+        // be named by its content. If the element therefore isn't being
+        // referenced and is not allowed to be named by its content then this
+        // step produces an empty name.
+        if (
+          !state.isReferencing &&
+          !role.every((role) => role.isNamedBy("contents"))
+        ) {
+          return None;
+        }
+
+        return fromDescendants(element, device, state);
+      },
+
+      // Step 2H: Use the subtree content, if descending.
+      // https://w3c.github.io/accname/#step2H
+      () => {
+        // Unless we're already descending then this step produces an empty
+        // name.
+        if (!state.isDescending) {
+          return None;
+        }
+
+        return fromDescendants(element, device, state);
+      }
+    );
   }
 
   /**
    * @internal
    */
-  export function fromText(text: Text): Branched<Option<Name>, Browser> {
+  export function fromText(text: Text): Option<Name> {
     // Step 2G: Use the data of the text node.
     // https://w3c.github.io/accname/#step2G
     return fromData(text);
@@ -726,46 +716,43 @@ export namespace Name {
     element: Element,
     device: Device,
     state: State
-  ): Branched<Option<Name>, Browser> {
-    return Branched.traverse(
-      element.children().filter(or(isText, isElement)),
-      (element) =>
+  ): Option<Name> {
+    const names = element
+      .children()
+      .filter(or(isText, isElement))
+      .collect((element) =>
         fromNode(
           element,
           device,
           state.reference(None).recurse(true).descend(true)
         )
-    )
-      .map((names) => Sequence.from(names).collect((name) => name))
-      .map((names) => {
-        const data = flatten(names.map((name) => name.value).join(" "));
+      );
 
-        if (data === "") {
-          return None;
-        }
+    const name = flatten(names.map((name) => name.value).join(" "));
 
-        return Option.of(
-          Name.of(
-            data,
-            names.map((name) => Source.descendant(element, name))
-          )
-        );
-      });
+    if (name === "") {
+      return None;
+    }
+
+    return Option.of(
+      Name.of(
+        name,
+        names.map((name) => Source.descendant(element, name))
+      )
+    );
   }
 
   /**
    * @internal
    */
-  export function fromLabel(
-    attribute: Attribute
-  ): Branched<Option<Name>, Browser> {
-    const data = flatten(attribute.value);
+  export function fromLabel(attribute: Attribute): Option<Name> {
+    const name = flatten(attribute.value);
 
-    if (data === "") {
-      return Branched.of(None);
+    if (name === "") {
+      return None;
     }
 
-    return Branched.of(Option.of(Name.of(data, [Source.label(attribute)])));
+    return Option.of(Name.of(name, [Source.label(attribute)]));
   }
 
   /**
@@ -776,7 +763,7 @@ export namespace Name {
     referrer: Element,
     device: Device,
     state: State
-  ): Branched<Option<Name>, Browser> {
+  ): Option<Name> {
     const root = attribute.owner.get().root();
 
     const references = root
@@ -784,72 +771,53 @@ export namespace Name {
       .filter(isElement)
       .filter(hasId(equals(...attribute.tokens())));
 
-    return Branched.traverse(references, (element) =>
+    const names = references.collect((element) =>
       fromNode(
         element,
         device,
         state.reference(Option.of(referrer)).recurse(true).descend(false)
       )
-    )
-      .map((names) => Sequence.from(names).collect((name) => name))
-      .map((names) => {
-        const name = flatten(names.map((name) => name.value).join(" "));
+    );
 
-        if (name === "") {
-          return None;
-        }
+    const name = flatten(names.map((name) => name.value).join(" "));
 
-        return Option.of(
-          Name.of(name, [
-            Source.reference(
-              attribute,
-              Name.of(
-                name,
-                names.flatMap((name) => Sequence.from(name.source))
-              )
-            ),
-          ])
-        );
-      });
+    if (name === "") {
+      return None;
+    }
+
+    return Option.of(
+      Name.of(name, [
+        Source.reference(
+          attribute,
+          Name.of(
+            name,
+            names.flatMap((name) => Sequence.from(name.source))
+          )
+        ),
+      ])
+    );
   }
 
   /**
    * @internal
    */
-  export function fromData(text: Text): Branched<Option<Name>, Browser> {
-    const data = flatten(text.data);
+  export function fromData(text: Text): Option<Name> {
+    const name = flatten(text.data);
 
-    if (data === "") {
-      return Branched.of(None);
+    if (name === "") {
+      return None;
     }
 
-    return Branched.of(Option.of(Name.of(data, [Source.data(text)])));
+    return Option.of(Name.of(name, [Source.data(text)]));
   }
 
   /**
    * @internal
    */
   export function fromSteps(
-    ...steps: Array<Thunk<Branched<Option<Name>, Browser>>>
-  ): Branched<Option<Name>, Browser> {
-    const step = (
-      name: Branched<Option<Name>, Browser>,
-      i: number = 0
-    ): Branched<Option<Name>, Browser> => {
-      if (i >= steps.length) {
-        return name;
-      }
-
-      return name.flatMap((name) => {
-        if (name.isSome()) {
-          return Branched.of(name);
-        }
-
-        return step(steps[i](), i + 1);
-      });
-    };
-
-    return step(Branched.of(None));
+    ...steps: Array<Thunk<Option<Name>>>
+  ): Option<Name> {
+    return Array.collectFirst(steps, (step) => step());
   }
 
   export const { hasValue } = predicate;

--- a/packages/alfa-aria/src/node.ts
+++ b/packages/alfa-aria/src/node.ts
@@ -1,6 +1,4 @@
-import { Branched } from "@siteimprove/alfa-branched";
 import { Cache } from "@siteimprove/alfa-cache";
-import { Browser } from "@siteimprove/alfa-compatibility";
 import { Device } from "@siteimprove/alfa-device";
 import { Graph } from "@siteimprove/alfa-graph";
 import { Serializable } from "@siteimprove/alfa-json";
@@ -222,12 +220,9 @@ export namespace Node {
     readonly ignored?: boolean;
   }
 
-  const cache = Cache.empty<Device, Cache<dom.Node, Branched<Node, Browser>>>();
+  const cache = Cache.empty<Device, Cache<dom.Node, Node>>();
 
-  export function from(
-    node: dom.Node,
-    device: Device
-  ): Branched<Node, Browser> {
+  export function from(node: dom.Node, device: Device): Node {
     const _cache = cache.get(device, Cache.empty);
 
     // If the cache already holds an entry for the specified node, then the tree
@@ -242,7 +237,7 @@ export namespace Node {
     // then the tree that the node participates in has already been built, but
     // the node itself is not included within the resulting accessibility tree.
     if (_cache.has(root)) {
-      return _cache.get(node, () => Branched.of(Inert.of(node)));
+      return _cache.get(node, () => Inert.of(node));
     }
 
     // Before we start constructing the accessibility tree, we need to resolve
@@ -332,7 +327,7 @@ export namespace Node {
       // If the cache still doesn't hold an entry for the specified node, then
       // the node doesn't even participate in the tree. Store it as an inert
       // node.
-      Branched.of(Inert.of(node))
+      Inert.of(node)
     );
   }
 
@@ -382,7 +377,7 @@ export namespace Node {
     claimed: Set<dom.Node>,
     owned: Map<dom.Element, Sequence<dom.Node>>,
     state: State
-  ): Branched<Node, Browser> {
+  ): Node {
     return cache.get(device, Cache.empty).get(node, () => {
       if (dom.Element.isElement(node)) {
         // Elements that are explicitly excluded from the accessibility tree
@@ -401,7 +396,7 @@ export namespace Node {
               attribute.enumerate("true", "false").some(equals("true"))
             )
         ) {
-          return Branched.of(Inert.of(node));
+          return Inert.of(node);
         }
 
         const style = Style.from(node, device);
@@ -414,16 +409,16 @@ export namespace Node {
         // check the element itself for `display: none` and can safely
         // disregard its ancestors as they will already have been checked.
         if (style.computed("display").value[0].value === "none") {
-          return Branched.of(Inert.of(node));
+          return Inert.of(node);
         }
 
-        let children: (state: State) => Branched<Iterable<Node>, Browser>;
+        let children: (state: State) => Iterable<Node>;
 
         // Children of <iframe> elements act as fallback content in legacy user
         // agents and should therefore never be included in the accessibility
         // tree.
         if (node.name === "iframe") {
-          children = () => Branched.of([]);
+          children = () => [];
         }
 
         // Otherwise, recursively build accessible nodes for the children of the
@@ -439,120 +434,111 @@ export namespace Node {
           // children in the flat tree that are neither claimed already nor
           // explicitly owned by the element.
           const implicit = node
-            .children({ flattened: true })
+            .children({
+              flattened: true,
+            })
             .reject((child) => claimed.has(child) || explicit.includes(child));
 
           // The children implicitly owned by the element come first, then the
           // children explicitly owned by the element.
           children = (state) =>
-            Branched.traverse(implicit.concat(explicit), (child) =>
-              fromNode(child, device, claimed, owned, state)
-            );
+            implicit
+              .concat(explicit)
+              .map((child) => fromNode(child, device, claimed, owned, state));
         }
 
         // Elements that are not visible by means of `visibility: hidden` or
         // `visibility: collapse`, are exposed in the accessibility tree as
         // containers as they may contain visible descendants.
         if (style.computed("visibility").value.value !== "visible") {
-          return children(state.visible(false)).map((children) =>
-            Container.of(node, children)
-          );
+          return Container.of(node, children(state.visible(false)));
         }
 
         state = state.visible(true);
 
-        return Role.fromImplicit(node)
-          .flatMap((implicit) =>
-            Role.fromExplicit(node).map((explicit) => {
-              return { implicit, explicit };
-            })
-          )
-          .flatMap<Node>(({ implicit, explicit }) => {
-            const role = explicit.orElse(() =>
-              // If the element has no explicit role and instead inherits a
-              // presentational role then use that, otherwise fall back to the
-              // implicit role.
-              state.isPresentational
-                ? Option.of(Role.of("presentation"))
-                : implicit
-            );
+        const role = Role.fromExplicit(node).orElse(() =>
+          // If the element has no explicit role and instead inherits a
+          // presentational role then use that, otherwise fall back to the
+          // implicit role.
+          state.isPresentational
+            ? Option.of(Role.of("presentation"))
+            : Role.fromImplicit(node)
+        );
 
-            if (role.some((role) => role.isPresentational())) {
-              return children(
-                state.presentational(
-                  // If the implicit role of the presentational element has
-                  // required children then any owned children must also be
-                  // presentational.
-                  implicit.some((role) => role.hasRequiredChildren())
+        if (role.some((role) => role.isPresentational())) {
+          return Container.of(
+            node,
+            children(
+              state.presentational(
+                // If the implicit role of the presentational element has
+                // required children then any owned children must also be
+                // presentational.
+                Role.fromImplicit(node).some((role) =>
+                  role.hasRequiredChildren()
                 )
-              ).map((children) => Container.of(node, children));
-            }
+              )
+            )
+          );
+        }
 
-            let attributes = Map.empty<Attribute.Name, Attribute>();
+        let attributes = Map.empty<Attribute.Name, Attribute>();
 
-            // First pass: Look up implicit attributes on the role.
-            if (role.isSome()) {
-              for (const attribute of role.get().attributes) {
-                for (const value of role
-                  .get()
-                  .implicitAttributeValue(attribute)) {
-                  attributes = attributes.set(
-                    attribute,
-                    Attribute.of(attribute, value)
-                  );
-                }
-              }
-            }
-
-            // Second pass: Look up implicit attributes on the feature mapping.
-            for (const namespace of node.namespace) {
-              for (const feature of Feature.from(namespace, node.name)) {
-                for (const attribute of feature.attributes(node)) {
-                  attributes = attributes.set(attribute.name, attribute);
-                }
-              }
-            }
-
-            // Third pass: Look up explicit `aria-*` attributes and set the
-            // ones that are either global or supported by the role.
-            for (const { name, value } of node.attributes) {
-              if (Attribute.isName(name)) {
-                const attribute = Attribute.of(name, value);
-
-                if (
-                  attribute.isGlobal() ||
-                  role.some((role) => role.isAttributeSupported(attribute.name))
-                ) {
-                  attributes = attributes.set(name, attribute);
-                }
-              }
-            }
-
-            // If the element has neither attributes, a role, nor a tabindex, it
-            // is not itself interesting for accessibility purposes. It is
-            // therefore exposed as a container.
-            if (
-              attributes.isEmpty() &&
-              role.isNone() &&
-              node.tabIndex().isNone()
-            ) {
-              return children(state).map((children) =>
-                Container.of(node, children)
+        // First pass: Look up implicit attributes on the role.
+        if (role.isSome()) {
+          for (const attribute of role.get().attributes) {
+            for (const value of role.get().implicitAttributeValue(attribute)) {
+              attributes = attributes.set(
+                attribute,
+                Attribute.of(attribute, value)
               );
             }
+          }
+        }
 
-            // If the element has a role that designates its children as
-            // presentational then set the state as presentational.
-            if (role.some((role) => role.hasPresentationalChildren())) {
-              state = state.presentational(true);
+        // Second pass: Look up implicit attributes on the feature mapping.
+        for (const namespace of node.namespace) {
+          for (const feature of Feature.from(namespace, node.name)) {
+            for (const attribute of feature.attributes(node)) {
+              attributes = attributes.set(attribute.name, attribute);
             }
+          }
+        }
 
-            return children(state).flatMap((children) =>
-              Name.from(node, device).map((name) =>
-                Element.of(node, role, name, attributes.values(), children)
-              )
-            );
-          });
+        // Third pass: Look up explicit `aria-*` attributes and set the ones
+        // that are either global or supported by the role.
+        for (const { name, value } of node.attributes) {
+          if (Attribute.isName(name)) {
+            const attribute = Attribute.of(name, value);
+
+            if (
+              attribute.isGlobal() ||
+              role.some((role) => role.isAttributeSupported(attribute.name))
+            ) {
+              attributes = attributes.set(name, attribute);
+            }
+          }
+        }
+
+        // If the element has neither attributes, a role, nor a tabindex, it is
+        // not itself interesting for accessibility purposes. It is therefore
+        // exposed as a container.
+        if (attributes.isEmpty() && role.isNone() && node.tabIndex().isNone()) {
+          return Container.of(node, children(state));
+        }
+
+        // If the element has a role that designates its children as
+        // presentational then set the state as presentational.
+        if (role.some((role) => role.hasPresentationalChildren())) {
+          state = state.presentational(true);
+        }
+
+        return Element.of(
+          node,
+          role,
+          Name.from(node, device),
+          attributes.values(),
+          children(state)
+        );
       }
 
       if (dom.Text.isText(node)) {
@@ -562,20 +548,21 @@ export namespace Node {
         // node. If the parent element isn't visible, the text node instead
         // becomes inert.
         if (!state.isVisible) {
-          return Branched.of(Inert.of(node));
+          return Inert.of(node);
         }
 
-        return Name.from(node, device).map((name) => Text.of(node, name));
+        return Text.of(node, Name.from(node, device));
       }
 
-      const children = Branched.traverse(
+      return Container.of(
+        node,
         node
-          .children({ flattened: true })
-          .reject((child) => claimed.has(child)),
-        (child) => fromNode(child, device, claimed, owned, state)
+          .children({
+            flattened: true,
+          })
+          .reject((child) => claimed.has(child))
+          .map((child) => fromNode(child, device, claimed, owned, state))
       );
-
-      return children.map((children) => Container.of(node, children));
     });
   }
 

--- a/packages/alfa-aria/test/name.spec.tsx
+++ b/packages/alfa-aria/test/name.spec.tsx
@@ -12,86 +12,71 @@ const device = Device.standard();
 test(`.from() determines the name of a text node`, (t) => {
   const text = h.text("Hello world");
 
-  t.deepEqual(Name.from(text, device).toJSON(), [
-    [
-      {
-        type: "some",
-        value: {
-          value: "Hello world",
-          sources: [
-            {
-              type: "data",
-              text: "/text()[1]",
-            },
-          ],
+  t.deepEqual(Name.from(text, device).toJSON(), {
+    type: "some",
+    value: {
+      value: "Hello world",
+      sources: [
+        {
+          type: "data",
+          text: "/text()[1]",
         },
-      },
-      [],
-    ],
-  ]);
+      ],
+    },
+  });
 });
 
 test(`.from() determines the name of a <button> element with child text content`, (t) => {
   const button = <button>Hello world</button>;
 
-  t.deepEqual(Name.from(button, device).toJSON(), [
-    [
-      {
-        type: "some",
-        value: {
-          value: "Hello world",
-          sources: [
-            {
-              type: "descendant",
-              element: "/button[1]",
-              name: {
-                value: "Hello world",
-                sources: [
-                  {
-                    type: "data",
-                    text: "/button[1]/text()[1]",
-                  },
-                ],
+  t.deepEqual(Name.from(button, device).toJSON(), {
+    type: "some",
+    value: {
+      value: "Hello world",
+      sources: [
+        {
+          type: "descendant",
+          element: "/button[1]",
+          name: {
+            value: "Hello world",
+            sources: [
+              {
+                type: "data",
+                text: "/button[1]/text()[1]",
               },
-            },
-          ],
+            ],
+          },
         },
-      },
-      [],
-    ],
-  ]);
+      ],
+    },
+  });
 });
 
 test(`.from() determines the name of a <div> element with a role of button and
       with child text content`, (t) => {
   const button = <div role="button">Hello world</div>;
 
-  t.deepEqual(Name.from(button, device).toJSON(), [
-    [
-      {
-        type: "some",
-        value: {
-          value: "Hello world",
-          sources: [
-            {
-              type: "descendant",
-              element: "/div[1]",
-              name: {
-                value: "Hello world",
-                sources: [
-                  {
-                    type: "data",
-                    text: "/div[1]/text()[1]",
-                  },
-                ],
+  t.deepEqual(Name.from(button, device).toJSON(), {
+    type: "some",
+    value: {
+      value: "Hello world",
+      sources: [
+        {
+          type: "descendant",
+          element: "/div[1]",
+          name: {
+            value: "Hello world",
+            sources: [
+              {
+                type: "data",
+                text: "/div[1]/text()[1]",
               },
-            },
-          ],
+            ],
+          },
         },
-      },
-      [],
-    ],
-  ]);
+      ],
+    },
+  });
 });
 
 test(`.from() determines the name of a <button> element with partially hidden
@@ -103,32 +88,27 @@ test(`.from() determines the name of a <button> element with partially hidden
     </button>
   );
 
-  t.deepEqual(Name.from(button, device).toJSON(), [
-    [
-      {
-        type: "some",
-        value: {
-          value: "Hello world",
-          sources: [
-            {
-              type: "descendant",
-              element: "/button[1]",
-              name: {
-                value: "Hello world",
-                sources: [
-                  {
-                    type: "data",
-                    text: "/button[1]/text()[1]",
-                  },
-                ],
+  t.deepEqual(Name.from(button, device).toJSON(), {
+    type: "some",
+    value: {
+      value: "Hello world",
+      sources: [
+        {
+          type: "descendant",
+          element: "/button[1]",
+          name: {
+            value: "Hello world",
+            sources: [
+              {
+                type: "data",
+                text: "/button[1]/text()[1]",
               },
-            },
-          ],
+            ],
+          },
         },
-      },
-      [],
-    ],
-  ]);
+      ],
+    },
+  });
 });
 
 test(`.from() determines the name of a <button> element with a <span> child
@@ -139,8 +119,7 @@ test(`.from() determines the name of a <button> element with a <span> child
     </button>
   );
 
-  t.deepEqual(Name.from(button, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(button, device).toJSON(),
       {
         type: "some",
         value: {
@@ -170,18 +149,14 @@ test(`.from() determines the name of a <button> element with a <span> child
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of a <button> element with an aria-label
       attribute`, (t) => {
   const button = <button aria-label="Hello world" />;
 
-  t.deepEqual(Name.from(button, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(button, device).toJSON(),
       {
         type: "some",
         value: {
@@ -193,18 +168,14 @@ test(`.from() determines the name of a <button> element with an aria-label
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of a <button> element with an empty aria-label
       attribute and child text content`, (t) => {
   const button = <button aria-label="">Hello world</button>;
 
-  t.deepEqual(Name.from(button, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(button, device).toJSON(),
       {
         type: "some",
         value: {
@@ -225,10 +196,7 @@ test(`.from() determines the name of a <button> element with an empty aria-label
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of a <button> element with an aria-labelledby
@@ -240,8 +208,7 @@ test(`.from() determines the name of a <button> element with an aria-labelledby
     <p id="foo">Hello world</p>
   </div>;
 
-  t.deepEqual(Name.from(button, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(button, device).toJSON(),
       {
         type: "some",
         value: {
@@ -271,10 +238,7 @@ test(`.from() determines the name of a <button> element with an aria-labelledby
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of a <button> element with an aria-labelledby
@@ -287,8 +251,7 @@ test(`.from() determines the name of a <button> element with an aria-labelledby
     <p id="bar">world</p>
   </div>;
 
-  t.deepEqual(Name.from(button, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(button, device).toJSON(),
       {
         type: "some",
         value: {
@@ -331,10 +294,7 @@ test(`.from() determines the name of a <button> element with an aria-labelledby
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of a <button> element with a title attribute
@@ -345,8 +305,7 @@ test(`.from() determines the name of a <button> element with a title attribute
     </button>
   );
 
-  t.deepEqual(Name.from(button, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(button, device).toJSON(),
       {
         type: "some",
         value: {
@@ -358,17 +317,13 @@ test(`.from() determines the name of a <button> element with a title attribute
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of an <img> element with an alt attribute`, (t) => {
   const img = <img alt="Hello world" />;
 
-  t.deepEqual(Name.from(img, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(img, device).toJSON(),
       {
         type: "some",
         value: {
@@ -380,10 +335,7 @@ test(`.from() determines the name of an <img> element with an alt attribute`, (t
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of an <a> element with a <img> child element
@@ -394,8 +346,7 @@ test(`.from() determines the name of an <a> element with a <img> child element
     </a>
   );
 
-  t.deepEqual(Name.from(a, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(a, device).toJSON(),
       {
         type: "some",
         value: {
@@ -416,10 +367,7 @@ test(`.from() determines the name of an <a> element with a <img> child element
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of an <a> element with a <figure> child element
@@ -432,8 +380,7 @@ test(`.from() determines the name of an <a> element with a <figure> child elemen
     </a>
   );
 
-  t.deepEqual(Name.from(a, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(a, device).toJSON(),
       {
         type: "some",
         value: {
@@ -463,10 +410,7 @@ test(`.from() determines the name of an <a> element with a <figure> child elemen
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of an <a> element with text in its subtree`, (t) => {
@@ -476,8 +420,7 @@ test(`.from() determines the name of an <a> element with text in its subtree`, (
     </a>
   );
 
-  t.deepEqual(Name.from(a, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(a, device).toJSON(),
       {
         type: "some",
         value: {
@@ -498,10 +441,7 @@ test(`.from() determines the name of an <a> element with text in its subtree`, (
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of an <a> element with text in its subtree,
@@ -512,8 +452,7 @@ test(`.from() determines the name of an <a> element with text in its subtree,
     </a>
   );
 
-  t.deepEqual(Name.from(a, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(a, device).toJSON(),
       {
         type: "some",
         value: {
@@ -543,10 +482,7 @@ test(`.from() determines the name of an <a> element with text in its subtree,
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of an <a> element with text in its subtree,
@@ -558,8 +494,7 @@ test(`.from() determines the name of an <a> element with text in its subtree,
     </a>
   );
 
-  t.deepEqual(Name.from(a, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(a, device).toJSON(),
       {
         type: "some",
         value: {
@@ -611,17 +546,13 @@ test(`.from() determines the name of an <a> element with text in its subtree,
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of an <area> element with an alt attribute`, (t) => {
   const area = <area alt="Hello world" />;
 
-  t.deepEqual(Name.from(area, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(area, device).toJSON(),
       {
         type: "some",
         value: {
@@ -633,10 +564,7 @@ test(`.from() determines the name of an <area> element with an alt attribute`, (
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of a <fieldset> element with a <legend> child
@@ -648,8 +576,7 @@ test(`.from() determines the name of a <fieldset> element with a <legend> child
     </fieldset>
   );
 
-  t.deepEqual(Name.from(fieldset, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(fieldset, device).toJSON(),
       {
         type: "some",
         value: {
@@ -679,10 +606,7 @@ test(`.from() determines the name of a <fieldset> element with a <legend> child
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of a <figure> element with a <figcaption>
@@ -694,8 +618,7 @@ test(`.from() determines the name of a <figure> element with a <figcaption>
     </figure>
   );
 
-  t.deepEqual(Name.from(figure, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(figure, device).toJSON(),
       {
         type: "some",
         value: {
@@ -725,10 +648,7 @@ test(`.from() determines the name of a <figure> element with a <figcaption>
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of a <table> element with a <caption> child
@@ -742,8 +662,7 @@ test(`.from() determines the name of a <table> element with a <caption> child
     </table>
   );
 
-  t.deepEqual(Name.from(table, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(table, device).toJSON(),
       {
         type: "some",
         value: {
@@ -773,10 +692,7 @@ test(`.from() determines the name of a <table> element with a <caption> child
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of an <input> element with a <label> parent
@@ -790,8 +706,7 @@ test(`.from() determines the name of an <input> element with a <label> parent
     </label>
   </form>;
 
-  t.deepEqual(Name.from(input, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(input, device).toJSON(),
       {
         type: "some",
         value: {
@@ -821,10 +736,7 @@ test(`.from() determines the name of an <input> element with a <label> parent
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of an <input> element with a <label> element
@@ -836,8 +748,7 @@ test(`.from() determines the name of an <input> element with a <label> element
     {input}
   </form>;
 
-  t.deepEqual(Name.from(input, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(input, device).toJSON(),
       {
         type: "some",
         value: {
@@ -867,10 +778,7 @@ test(`.from() determines the name of an <input> element with a <label> element
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of an <input> element with both a <label>
@@ -886,8 +794,7 @@ test(`.from() determines the name of an <input> element with both a <label>
     <label for="foo">!</label>
   </form>;
 
-  t.deepEqual(Name.from(input, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(input, device).toJSON(),
       {
         type: "some",
         value: {
@@ -939,10 +846,7 @@ test(`.from() determines the name of an <input> element with both a <label>
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of a <select> element with a <label> parent
@@ -956,8 +860,7 @@ test(`.from() determines the name of a <select> element with a <label> parent
     </label>
   </form>;
 
-  t.deepEqual(Name.from(select, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(select, device).toJSON(),
       {
         type: "some",
         value: {
@@ -987,18 +890,14 @@ test(`.from() determines the name of a <select> element with a <label> parent
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of an <input> element with a placeholder
       attribute`, (t) => {
   const input = <input placeholder="Hello world" />;
 
-  t.deepEqual(Name.from(input, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(input, device).toJSON(),
       {
         type: "some",
         value: {
@@ -1010,18 +909,14 @@ test(`.from() determines the name of an <input> element with a placeholder
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of an <input> element with a placeholder
       and a title attribute, with the title attribute taking precedence`, (t) => {
   const input = <input title="Hello title" placeholder="Hello placeholder" />;
 
-  t.deepEqual(Name.from(input, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(input, device).toJSON(),
       {
         type: "some",
         value: {
@@ -1033,18 +928,14 @@ test(`.from() determines the name of an <input> element with a placeholder
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of an <input type="button"> element with a
       value attribute`, (t) => {
   const input = <input type="button" value="Hello world" />;
 
-  t.deepEqual(Name.from(input, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(input, device).toJSON(),
       {
         type: "some",
         value: {
@@ -1056,35 +947,27 @@ test(`.from() determines the name of an <input type="button"> element with a
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of an <input type="submit"> element`, (t) => {
   const input = <input type="submit" />;
 
-  t.deepEqual(Name.from(input, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(input, device).toJSON(),
       {
         type: "some",
         value: {
           value: "Submit",
           sources: [],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of an <input type="submit"> element with a
       value attribute`, (t) => {
   const input = <input type="submit" value="Hello world" />;
 
-  t.deepEqual(Name.from(input, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(input, device).toJSON(),
       {
         type: "some",
         value: {
@@ -1096,35 +979,27 @@ test(`.from() determines the name of an <input type="submit"> element with a
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of an <input type="reset"> element`, (t) => {
   const input = <input type="reset" />;
 
-  t.deepEqual(Name.from(input, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(input, device).toJSON(),
       {
         type: "some",
         value: {
           value: "Reset",
           sources: [],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of an <input type="reset"> element with a
       value attribute`, (t) => {
   const input = <input type="reset" value="Hello world" />;
 
-  t.deepEqual(Name.from(input, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(input, device).toJSON(),
       {
         type: "some",
         value: {
@@ -1136,35 +1011,27 @@ test(`.from() determines the name of an <input type="reset"> element with a
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of an <input type="image"> element`, (t) => {
   const input = <input type="image" />;
 
-  t.deepEqual(Name.from(input, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(input, device).toJSON(),
       {
         type: "some",
         value: {
           value: "Submit",
           sources: [],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of an <input type="image"> element with an
       alt attribute`, (t) => {
   const input = <input type="image" alt="Hello world" />;
 
-  t.deepEqual(Name.from(input, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(input, device).toJSON(),
       {
         type: "some",
         value: {
@@ -1176,10 +1043,7 @@ test(`.from() determines the name of an <input type="image"> element with an
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of a <button> element with a role of
@@ -1188,8 +1052,7 @@ test(`.from() determines the name of a <button> element with a role of
   // is ignored to ensure that the button, which is focusable, remains operable.
   const button = <button role="presentation">Hello world</button>;
 
-  t.deepEqual(Name.from(button, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(button, device).toJSON(),
       {
         type: "some",
         value: {
@@ -1210,10 +1073,7 @@ test(`.from() determines the name of a <button> element with a role of
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of a <img> element with a an empty alt
@@ -1223,8 +1083,7 @@ test(`.from() determines the name of a <img> element with a an empty alt
   // `aria-*` attribute, is exposed.
   const img = <img alt="" aria-label="Hello world" />;
 
-  t.deepEqual(Name.from(img, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(img, device).toJSON(),
       {
         type: "some",
         value: {
@@ -1236,10 +1095,7 @@ test(`.from() determines the name of a <img> element with a an empty alt
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of an SVG <svg> element with a <title> child
@@ -1250,8 +1106,7 @@ test(`.from() determines the name of an SVG <svg> element with a <title> child
     </svg>
   );
 
-  t.deepEqual(Name.from(svg, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(svg, device).toJSON(),
       {
         type: "some",
         value: {
@@ -1281,10 +1136,7 @@ test(`.from() determines the name of an SVG <svg> element with a <title> child
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() determines the name of an SVG <a> element with child text content`, (t) => {
@@ -1294,8 +1146,7 @@ test(`.from() determines the name of an SVG <a> element with child text content`
     </a>
   );
 
-  t.deepEqual(Name.from(a, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(a, device).toJSON(),
       {
         type: "some",
         value: {
@@ -1316,10 +1167,7 @@ test(`.from() determines the name of an SVG <a> element with child text content`
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() correctly handles aria-labelledby references to hidden elements
@@ -1333,8 +1181,7 @@ test(`.from() correctly handles aria-labelledby references to hidden elements
     </div>
   </div>;
 
-  t.deepEqual(Name.from(label, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(label, device).toJSON(),
       {
         type: "some",
         value: {
@@ -1373,10 +1220,7 @@ test(`.from() correctly handles aria-labelledby references to hidden elements
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() correctly handles circular aria-labelledby references`, (t) => {
@@ -1397,8 +1241,7 @@ test(`.from() correctly handles circular aria-labelledby references`, (t) => {
     {bar}
   </div>;
 
-  t.deepEqual(Name.from(foo, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(foo, device).toJSON(),
       {
         type: "some",
         value: {
@@ -1428,13 +1271,9 @@ test(`.from() correctly handles circular aria-labelledby references`, (t) => {
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 
-  t.deepEqual(Name.from(bar, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(bar, device).toJSON(),
       {
         type: "some",
         value: {
@@ -1464,10 +1303,7 @@ test(`.from() correctly handles circular aria-labelledby references`, (t) => {
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() correctly handles chained aria-labelledby references`, (t) => {
@@ -1491,8 +1327,7 @@ test(`.from() correctly handles chained aria-labelledby references`, (t) => {
 
   // From the perspective of `foo`, `bar` has a name of "Bar" as the second
   // `aria-labelledby` reference isn't followed.
-  t.deepEqual(Name.from(foo, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(foo, device).toJSON(),
       {
         type: "some",
         value: {
@@ -1522,15 +1357,11 @@ test(`.from() correctly handles chained aria-labelledby references`, (t) => {
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 
   // From the perspective of `bar`, it has a name of "Baz" as `bar` doesn't care
   // about `foo` and therefore only sees a single `aria-labelledby` reference.
-  t.deepEqual(Name.from(bar, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(bar, device).toJSON(),
       {
         type: "some",
         value: {
@@ -1560,10 +1391,7 @@ test(`.from() correctly handles chained aria-labelledby references`, (t) => {
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() correctly handles self-referencing aria-labelledby references`, (t) => {
@@ -1578,8 +1406,7 @@ test(`.from() correctly handles self-referencing aria-labelledby references`, (t
     <div id="bar">world</div>
   </div>;
 
-  t.deepEqual(Name.from(foo, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(foo, device).toJSON(),
       {
         type: "some",
         value: {
@@ -1622,10 +1449,7 @@ test(`.from() correctly handles self-referencing aria-labelledby references`, (t
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(".from() ignores nodes that are not exposed when computing name from content", (t) => {
@@ -1636,8 +1460,7 @@ test(".from() ignores nodes that are not exposed when computing name from conten
     </h1>
   );
 
-  t.deepEqual(Name.from(heading, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(heading, device).toJSON(),
       {
         type: "some",
         value: {
@@ -1667,10 +1490,7 @@ test(".from() ignores nodes that are not exposed when computing name from conten
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });
 
 test(`.from() behaves correctly when encountering a descendant that doesn't
@@ -1681,20 +1501,15 @@ test(`.from() behaves correctly when encountering a descendant that doesn't
 
   // On its own, the <table> element has no name as it's not named by its
   // contents.
-  t.deepEqual(Name.from(table, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(table, device).toJSON(),
       {
         type: "none",
-      },
-      [],
-    ],
-  ]);
+      });
 
   // When part of an <h1> element, which is named by its content, the <table>
   // element also takes its name from its content to ensure that the name
   // propagates to the <h1> element.
-  t.deepEqual(Name.from(heading, device).toJSON(), [
-    [
+  t.deepEqual(Name.from(heading, device).toJSON(),
       {
         type: "some",
         value: {
@@ -1724,8 +1539,5 @@ test(`.from() behaves correctly when encountering a descendant that doesn't
             },
           ],
         },
-      },
-      [],
-    ],
-  ]);
+      });
 });

--- a/packages/alfa-aria/test/node.spec.tsx
+++ b/packages/alfa-aria/test/node.spec.tsx
@@ -10,26 +10,21 @@ const device = Device.standard();
 test(`.from() constructs an accessible node from an element`, (t) => {
   const element = <button>Hello world</button>;
 
-  t.deepEqual(Node.from(element, device).toJSON(), [
-    [
+  t.deepEqual(Node.from(element, device).toJSON(), {
+    type: "element",
+    node: "/button[1]",
+    role: "button",
+    name: "Hello world",
+    attributes: [],
+    children: [
       {
-        type: "element",
-        node: "/button[1]",
-        role: "button",
+        type: "text",
+        node: "/button[1]/text()[1]",
         name: "Hello world",
-        attributes: [],
-        children: [
-          {
-            type: "text",
-            node: "/button[1]/text()[1]",
-            name: "Hello world",
-            children: [],
-          },
-        ],
+        children: [],
       },
-      [],
     ],
-  ]);
+  });
 });
 
 test(`.from() gives precedence to aria-owns references`, (t) => {
@@ -50,60 +45,50 @@ test(`.from() gives precedence to aria-owns references`, (t) => {
     {footer}
   </div>;
 
-  t.deepEqual(Node.from(header, device).toJSON(), [
-    [
+  t.deepEqual(Node.from(header, device).toJSON(), {
+    type: "element",
+    node: "/div[1]/header[1]",
+    role: "banner",
+    name: null,
+    attributes: [
       {
-        type: "element",
-        node: "/div[1]/header[1]",
-        role: "banner",
-        name: null,
-        attributes: [
-          {
-            name: "aria-owns",
-            value: "bar",
-          },
-        ],
-        children: [
-          {
-            type: "element",
-            node: "/div[1]/header[1]/button[1]",
-            role: "button",
-            name: null,
-            attributes: [],
-            children: [],
-          },
-          {
-            type: "element",
-            node: "/div[1]/footer[1]/input[1]",
-            role: "textbox",
-            name: null,
-            attributes: [
-              {
-                name: "aria-checked",
-                value: "false",
-              },
-            ],
-            children: [],
-          },
-        ],
+        name: "aria-owns",
+        value: "bar",
       },
-      [],
     ],
-  ]);
-
-  t.deepEqual(Node.from(footer, device).toJSON(), [
-    [
+    children: [
       {
         type: "element",
-        node: "/div[1]/footer[1]",
-        role: "contentinfo",
+        node: "/div[1]/header[1]/button[1]",
+        role: "button",
         name: null,
         attributes: [],
         children: [],
       },
-      [],
+      {
+        type: "element",
+        node: "/div[1]/footer[1]/input[1]",
+        role: "textbox",
+        name: null,
+        attributes: [
+          {
+            name: "aria-checked",
+            value: "false",
+          },
+        ],
+        children: [],
+      },
     ],
-  ]);
+  });
+
+  t.deepEqual(Node.from(footer, device).toJSON(), {
+    type: "element",
+    node: "/div[1]/footer[1]",
+    role: "contentinfo",
+    name: null,
+    attributes: [],
+    children: [],
+  });
 });
 
 test(`.from() correctly handles conflicting aria-owns claims`, (t) => {
@@ -124,65 +109,55 @@ test(`.from() correctly handles conflicting aria-owns claims`, (t) => {
     {footer}
   </div>;
 
-  t.deepEqual(Node.from(header, device).toJSON(), [
-    [
+  t.deepEqual(Node.from(header, device).toJSON(), {
+    type: "element",
+    node: "/div[1]/header[1]",
+    role: "banner",
+    name: null,
+    attributes: [
       {
-        type: "element",
-        node: "/div[1]/header[1]",
-        role: "banner",
-        name: null,
-        attributes: [
-          {
-            name: "aria-owns",
-            value: "bar",
-          },
-        ],
-        children: [
-          {
-            type: "element",
-            node: "/div[1]/header[1]/button[1]",
-            role: "button",
-            name: null,
-            attributes: [],
-            children: [],
-          },
-          {
-            type: "element",
-            node: "/div[1]/footer[1]/input[1]",
-            role: "textbox",
-            name: null,
-            attributes: [
-              {
-                name: "aria-checked",
-                value: "false",
-              },
-            ],
-            children: [],
-          },
-        ],
+        name: "aria-owns",
+        value: "bar",
       },
-      [],
     ],
-  ]);
-
-  t.deepEqual(Node.from(footer, device).toJSON(), [
-    [
+    children: [
       {
         type: "element",
-        node: "/div[1]/footer[1]",
-        role: "contentinfo",
+        node: "/div[1]/header[1]/button[1]",
+        role: "button",
+        name: null,
+        attributes: [],
+        children: [],
+      },
+      {
+        type: "element",
+        node: "/div[1]/footer[1]/input[1]",
+        role: "textbox",
         name: null,
         attributes: [
           {
-            name: "aria-owns",
-            value: "bar",
+            name: "aria-checked",
+            value: "false",
           },
         ],
         children: [],
       },
-      [],
     ],
-  ]);
+  });
+
+  t.deepEqual(Node.from(footer, device).toJSON(), {
+    type: "element",
+    node: "/div[1]/footer[1]",
+    role: "contentinfo",
+    name: null,
+    attributes: [
+      {
+        name: "aria-owns",
+        value: "bar",
+      },
+    ],
+    children: [],
+  });
 });
 
 test(`.from() correctly handles reordered aria-owns references`, (t) => {
@@ -197,69 +172,59 @@ test(`.from() correctly handles reordered aria-owns references`, (t) => {
     <input id="bar" />
   </div>;
 
-  t.deepEqual(Node.from(header, device).toJSON(), [
-    [
+  t.deepEqual(Node.from(header, device).toJSON(), {
+    type: "element",
+    node: "/div[1]/header[1]",
+    role: "banner",
+    name: null,
+    attributes: [
+      {
+        name: "aria-owns",
+        value: "bar foo",
+      },
+    ],
+    children: [
       {
         type: "element",
-        node: "/div[1]/header[1]",
-        role: "banner",
+        node: "/div[1]/input[1]",
+        role: "textbox",
         name: null,
         attributes: [
           {
-            name: "aria-owns",
-            value: "bar foo",
+            name: "aria-checked",
+            value: "false",
           },
         ],
-        children: [
-          {
-            type: "element",
-            node: "/div[1]/input[1]",
-            role: "textbox",
-            name: null,
-            attributes: [
-              {
-                name: "aria-checked",
-                value: "false",
-              },
-            ],
-            children: [],
-          },
-          {
-            type: "element",
-            node: "/div[1]/header[1]/button[1]",
-            role: "button",
-            name: null,
-            attributes: [],
-            children: [],
-          },
-        ],
+        children: [],
       },
-      [],
+      {
+        type: "element",
+        node: "/div[1]/header[1]/button[1]",
+        role: "button",
+        name: null,
+        attributes: [],
+        children: [],
+      },
     ],
-  ]);
+  });
 });
 
 test(`.from() correctly handles self-referential aria-owns references`, (t) => {
   const div = <div id="foo" aria-owns="foo" />;
 
-  t.deepEqual(Node.from(div, device).toJSON(), [
-    [
+  t.deepEqual(Node.from(div, device).toJSON(), {
+    type: "element",
+    node: "/div[1]",
+    role: null,
+    name: null,
+    attributes: [
       {
-        type: "element",
-        node: "/div[1]",
-        role: null,
-        name: null,
-        attributes: [
-          {
-            name: "aria-owns",
-            value: "foo",
-          },
-        ],
-        children: [],
+        name: "aria-owns",
+        value: "foo",
       },
-      [],
     ],
-  ]);
+    children: [],
+  });
 });
 
 test(`.from() correctly handles circular aria-owns references between siblings`, (t) => {
@@ -272,41 +237,18 @@ test(`.from() correctly handles circular aria-owns references between siblings`,
     {bar}
   </div>;
 
-  t.deepEqual(Node.from(foo, device).toJSON(), [
-    [
+  t.deepEqual(Node.from(foo, device).toJSON(), {
+    type: "element",
+    node: "/div[1]/div[1]",
+    role: null,
+    name: null,
+    attributes: [
       {
-        type: "element",
-        node: "/div[1]/div[1]",
-        role: null,
-        name: null,
-        attributes: [
-          {
-            name: "aria-owns",
-            value: "bar",
-          },
-        ],
-        children: [
-          {
-            type: "element",
-            node: "/div[1]/div[2]",
-            role: null,
-            name: null,
-            attributes: [
-              {
-                name: "aria-owns",
-                value: "foo",
-              },
-            ],
-            children: [],
-          },
-        ],
+        name: "aria-owns",
+        value: "bar",
       },
-      [],
     ],
-  ]);
-
-  t.deepEqual(Node.from(bar, device).toJSON(), [
-    [
+    children: [
       {
         type: "element",
         node: "/div[1]/div[2]",
@@ -320,9 +262,22 @@ test(`.from() correctly handles circular aria-owns references between siblings`,
         ],
         children: [],
       },
-      [],
     ],
-  ]);
+  });
+
+  t.deepEqual(Node.from(bar, device).toJSON(), {
+    type: "element",
+    node: "/div[1]/div[2]",
+    role: null,
+    name: null,
+    attributes: [
+      {
+        name: "aria-owns",
+        value: "foo",
+      },
+    ],
+    children: [],
+  });
 });
 
 test(`.from() correctly handles circular aria-owns references between ancestors
@@ -331,8 +286,24 @@ test(`.from() correctly handles circular aria-owns references between ancestors
 
   const bar = <div id="bar">{foo}</div>;
 
-  t.deepEqual(Node.from(foo, device).toJSON(), [
-    [
+  t.deepEqual(Node.from(foo, device).toJSON(), {
+    type: "element",
+    node: "/div[1]/div[1]",
+    role: null,
+    name: null,
+    attributes: [
+      {
+        name: "aria-owns",
+        value: "bar",
+      },
+    ],
+    children: [],
+  });
+
+  t.deepEqual(Node.from(bar, device).toJSON(), {
+    type: "container",
+    node: "/div[1]",
+    children: [
       {
         type: "element",
         node: "/div[1]/div[1]",
@@ -346,154 +317,98 @@ test(`.from() correctly handles circular aria-owns references between ancestors
         ],
         children: [],
       },
-      [],
     ],
-  ]);
-
-  t.deepEqual(Node.from(bar, device).toJSON(), [
-    [
-      {
-        type: "container",
-        node: "/div[1]",
-        children: [
-          {
-            type: "element",
-            node: "/div[1]/div[1]",
-            role: null,
-            name: null,
-            attributes: [
-              {
-                name: "aria-owns",
-                value: "bar",
-              },
-            ],
-            children: [],
-          },
-        ],
-      },
-      [],
-    ],
-  ]);
+  });
 });
 
 test(".from() exposes elements if they have a role", (t) => {
   const foo = <button />;
 
-  t.deepEqual(Node.from(foo, device).toJSON(), [
-    [
-      {
-        type: "element",
-        node: "/button[1]",
-        role: "button",
-        name: null,
-        attributes: [],
-        children: [],
-      },
-      [],
-    ],
-  ]);
+  t.deepEqual(Node.from(foo, device).toJSON(), {
+    type: "element",
+    node: "/button[1]",
+    role: "button",
+    name: null,
+    attributes: [],
+    children: [],
+  });
 });
 
 test(".from() exposes elements if they have ARIA attributes", (t) => {
   const foo = <div aria-label="foo" />;
 
-  t.deepEqual(Node.from(foo, device).toJSON(), [
-    [
+  t.deepEqual(Node.from(foo, device).toJSON(), {
+    type: "element",
+    node: "/div[1]",
+    role: null,
+    name: "foo",
+    attributes: [
       {
-        type: "element",
-        node: "/div[1]",
-        role: null,
-        name: "foo",
-        attributes: [
-          {
-            name: "aria-label",
-            value: "foo",
-          },
-        ],
-        children: [],
+        name: "aria-label",
+        value: "foo",
       },
-      [],
     ],
-  ]);
+    children: [],
+  });
 });
 
 test(".from() exposes elements if they have a tabindex", (t) => {
   const foo = <div tabindex={0} />;
 
-  t.deepEqual(Node.from(foo, device).toJSON(), [
-    [
-      {
-        type: "element",
-        node: "/div[1]",
-        role: null,
-        name: null,
-        attributes: [],
-        children: [],
-      },
-      [],
-    ],
-  ]);
+  t.deepEqual(Node.from(foo, device).toJSON(), {
+    type: "element",
+    node: "/div[1]",
+    role: null,
+    name: null,
+    attributes: [],
+    children: [],
+  });
 
   const iframe = <iframe />; // Focusable by default, and no role
 
-  t.deepEqual(Node.from(iframe, device).toJSON(), [
-    [
-      {
-        type: "element",
-        node: "/iframe[1]",
-        role: null,
-        name: null,
-        attributes: [],
-        children: [],
-      },
-      [],
-    ],
-  ]);
+  t.deepEqual(Node.from(iframe, device).toJSON(), {
+    type: "element",
+    node: "/iframe[1]",
+    role: null,
+    name: null,
+    attributes: [],
+    children: [],
+  });
 });
 
 test(`.from() does not expose elements that have no role, ARIA attributes, nor
       tabindex`, (t) => {
   const foo = <div>Hello world</div>;
 
-  t.deepEqual(Node.from(foo, device).toJSON(), [
-    [
+  t.deepEqual(Node.from(foo, device).toJSON(), {
+    type: "container",
+    node: "/div[1]",
+    children: [
       {
-        type: "container",
-        node: "/div[1]",
-        children: [
-          {
-            type: "text",
-            node: "/div[1]/text()[1]",
-            name: "Hello world",
-            children: [],
-          },
-        ],
+        type: "text",
+        node: "/div[1]/text()[1]",
+        name: "Hello world",
+        children: [],
       },
-      [],
     ],
-  ]);
+  });
 });
 
 test(`.from() does not expose text nodes of a parent element with
       \`visibility: hidden\``, (t) => {
   const foo = <div style={{ visibility: "hidden" }}>Hello world</div>;
 
-  t.deepEqual(Node.from(foo, device).toJSON(), [
-    [
+  t.deepEqual(Node.from(foo, device).toJSON(), {
+    type: "container",
+    node: "/div[1]",
+    children: [
       {
-        type: "container",
-        node: "/div[1]",
-        children: [
-          {
-            type: "inert",
-            node: "/div[1]/text()[1]",
-            children: [],
-          },
-        ],
+        type: "inert",
+        node: "/div[1]/text()[1]",
+        children: [],
       },
-      [],
     ],
-  ]);
+  });
 });
 
 test(`.from() exposes implicitly required children of a presentational element
@@ -504,22 +419,17 @@ test(`.from() exposes implicitly required children of a presentational element
     </ul>
   );
 
-  t.deepEqual(Node.from(ul, device).toJSON(), [
-    [
+  t.deepEqual(Node.from(ul, device).toJSON(), {
+    type: "container",
+    node: "/ul[1]",
+    children: [
       {
         type: "container",
-        node: "/ul[1]",
-        children: [
-          {
-            type: "container",
-            node: "/ul[1]/li[1]",
-            children: [],
-          },
-        ],
+        node: "/ul[1]/li[1]",
+        children: [],
       },
-      [],
     ],
-  ]);
+  });
 });
 
 test(`.from() doesn't inherit presentational roles into explicitly required
@@ -530,25 +440,20 @@ test(`.from() doesn't inherit presentational roles into explicitly required
     </ul>
   );
 
-  t.deepEqual(Node.from(ul, device).toJSON(), [
-    [
+  t.deepEqual(Node.from(ul, device).toJSON(), {
+    type: "container",
+    node: "/ul[1]",
+    children: [
       {
-        type: "container",
-        node: "/ul[1]",
-        children: [
-          {
-            type: "element",
-            node: "/ul[1]/li[1]",
-            role: "listitem",
-            name: null,
-            attributes: [],
-            children: [],
-          },
-        ],
+        type: "element",
+        node: "/ul[1]/li[1]",
+        role: "listitem",
+        name: null,
+        attributes: [],
+        children: [],
       },
-      [],
     ],
-  ]);
+  });
 });
 
 test(`.from() doesn't inherit presentational roles into children of implicitly
@@ -565,31 +470,26 @@ test(`.from() doesn't inherit presentational roles into children of implicitly
     </ul>
   );
 
-  t.deepEqual(Node.from(ul, device).toJSON(), [
-    [
+  t.deepEqual(Node.from(ul, device).toJSON(), {
+    type: "container",
+    node: "/ul[1]",
+    children: [
       {
         type: "container",
-        node: "/ul[1]",
+        node: "/ul[1]/li[1]",
         children: [
           {
-            type: "container",
-            node: "/ul[1]/li[1]",
-            children: [
-              {
-                type: "element",
-                node: "/ul[1]/li[1]/button[1]",
-                role: "button",
-                name: null,
-                attributes: [],
-                children: [],
-              },
-            ],
+            type: "element",
+            node: "/ul[1]/li[1]/button[1]",
+            role: "button",
+            name: null,
+            attributes: [],
+            children: [],
           },
         ],
       },
-      [],
     ],
-  ]);
+  });
 });
 
 test(`.from() doesn't expose children of elements with roles that designate
@@ -600,23 +500,18 @@ test(`.from() doesn't expose children of elements with roles that designate
     </button>
   );
 
-  t.deepEqual(Node.from(button, device).toJSON(), [
-    [
+  t.deepEqual(Node.from(button, device).toJSON(), {
+    type: "element",
+    node: "/button[1]",
+    role: "button",
+    name: null,
+    attributes: [],
+    children: [
       {
-        type: "element",
-        node: "/button[1]",
-        role: "button",
-        name: null,
-        attributes: [],
-        children: [
-          {
-            type: "container",
-            node: "/button[1]/img[1]",
-            children: [],
-          },
-        ],
+        type: "container",
+        node: "/button[1]/img[1]",
+        children: [],
       },
-      [],
     ],
-  ]);
+  });
 });

--- a/packages/alfa-rules/src/common/predicate/has-accessible-name.ts
+++ b/packages/alfa-rules/src/common/predicate/has-accessible-name.ts
@@ -7,6 +7,5 @@ export function hasAccessibleName<T extends Element | Text>(
   device: Device,
   predicate: Predicate<Name> = () => true
 ): Predicate<T> {
-  return (node) =>
-    Node.from(node, device).some((node) => node.name.some(predicate));
+  return (node) => Node.from(node, device).name.some(predicate);
 }

--- a/packages/alfa-rules/src/common/predicate/has-explicit-role.ts
+++ b/packages/alfa-rules/src/common/predicate/has-explicit-role.ts
@@ -25,6 +25,5 @@ export function hasExplicitRole(
     predicate = property("name", equals(nameOrPredicate, ...names));
   }
 
-  return (element) =>
-    Role.fromExplicit(element).some((role) => role.some(predicate));
+  return (element) => Role.fromExplicit(element).some(predicate);
 }

--- a/packages/alfa-rules/src/common/predicate/has-heading-level.ts
+++ b/packages/alfa-rules/src/common/predicate/has-heading-level.ts
@@ -8,10 +8,8 @@ export function hasHeadingLevel(
   predicate: Predicate<number> = (n) => !isNaN(n)
 ): Predicate<Element> {
   return (element) =>
-    Node.from(element, device).every((node) =>
-      node
-        .attribute("aria-level")
-        .map((level) => Number(level.value))
-        .some(predicate)
-    );
+    Node.from(element, device)
+      .attribute("aria-level")
+      .map((level) => Number(level.value))
+      .some(predicate);
 }

--- a/packages/alfa-rules/src/common/predicate/has-implicit-role.ts
+++ b/packages/alfa-rules/src/common/predicate/has-implicit-role.ts
@@ -25,6 +25,5 @@ export function hasImplicitRole(
     predicate = property("name", equals(nameOrPredicate, ...names));
   }
 
-  return (element) =>
-    Role.fromImplicit(element).some((role) => role.some(predicate));
+  return (element) => Role.fromImplicit(element).some(predicate);
 }

--- a/packages/alfa-rules/src/common/predicate/has-role.ts
+++ b/packages/alfa-rules/src/common/predicate/has-role.ts
@@ -21,5 +21,5 @@ export function hasRole(
     predicate = Role.hasName(nameOrPredicate, ...names);
   }
 
-  return (element) => Role.from(element).some((role) => role.some(predicate));
+  return (element) => Role.from(element).some(predicate);
 }

--- a/packages/alfa-rules/src/common/predicate/is-ignored.ts
+++ b/packages/alfa-rules/src/common/predicate/is-ignored.ts
@@ -12,6 +12,5 @@ import * as aria from "@siteimprove/alfa-aria";
  * still having children that aren't.
  */
 export function isIgnored<T extends Node>(device: Device): Predicate<T> {
-  return (node) =>
-    aria.Node.from(node, device).some((node) => node.isIgnored());
+  return (node) => aria.Node.from(node, device).isIgnored();
 }

--- a/packages/alfa-rules/src/sia-r10/rule.ts
+++ b/packages/alfa-rules/src/sia-r10/rule.ts
@@ -37,11 +37,9 @@ export default Rule.Atomic.of<Page, Attribute>({
               ),
               isPerceivable(device),
               (element) =>
-                Node.from(element, device).some((ariaNode) =>
-                  ariaNode
-                    .attribute("aria-disabled")
-                    .none((ariaDisabled) => ariaDisabled.value === "true")
-                )
+                Node.from(element, device)
+                  .attribute("aria-disabled")
+                  .none((disabled) => disabled.value === "true")
             )
           )
           .map((element) => element.attribute("autocomplete").get());

--- a/packages/alfa-rules/src/sia-r15/rule.ts
+++ b/packages/alfa-rules/src/sia-r15/rule.ts
@@ -39,17 +39,17 @@ export default Rule.Atomic.of<Page, Group<Element>, Question>({
             )
           )
           .reduce((groups, iframe) => {
-            for (const [node] of Node.from(iframe, device)) {
-              const name = node.name.map((name) => name.value);
+            const name = Node.from(iframe, device).name.map((name) =>
+              normalize(name.value)
+            );
 
-              groups = groups.set(
-                name,
-                groups
-                  .get(name)
-                  .getOrElse(() => List.empty<Element>())
-                  .append(iframe)
-              );
-            }
+            groups = groups.set(
+              name,
+              groups
+                .get(name)
+                .getOrElse(() => List.empty<Element>())
+                .append(iframe)
+            );
 
             return groups;
           }, Map.empty<Option<string>, List<Element>>())
@@ -106,4 +106,8 @@ export namespace Outcomes {
       `The \`<iframe>\` elements do not embed the same or equivalent resources`
     )
   );
+}
+
+function normalize(input: string): string {
+  return input.trim().toLowerCase().replace(/\s+/g, " ");
 }

--- a/packages/alfa-rules/src/sia-r16/rule.ts
+++ b/packages/alfa-rules/src/sia-r16/rule.ts
@@ -45,29 +45,30 @@ export default Rule.Atomic.of<Page, Element>({
 });
 
 function hasRequiredValues(device: Device): Predicate<Element> {
-  return (element) =>
-    Node.from(element, device).every((node) => {
-      for (const role of node.role) {
-        // The `separator` role is poorly architected in the sense that its
-        // inheritance and attribute requirements depend on aspects of the
-        // element carrying the role. If the element is not focusable, the
-        // `separator` role has no required attributes.
-        if (role.is("separator") && !isFocusable(device)(element)) {
-          return true;
-        }
+  return (element) => {
+    const node = Node.from(element, device);
 
-        for (const attribute of role.attributes) {
-          if (
-            role.isAttributeRequired(attribute) &&
-            node.attribute(attribute).every(property("value", isEmpty))
-          ) {
-            return false;
-          }
-        }
+    for (const role of node.role) {
+      // The `separator` role is poorly architected in the sense that its
+      // inheritance and attribute requirements depend on aspects of the element
+      // carrying the role. If the element is not focusable, the `separator`
+      // role has no required attributes.
+      if (role.is("separator") && !isFocusable(device)(element)) {
+        return true;
       }
 
-      return true;
-    });
+      for (const attribute of role.attributes) {
+        if (
+          role.isAttributeRequired(attribute) &&
+          node.attribute(attribute).every(property("value", isEmpty))
+        ) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  };
 }
 
 export namespace Outcomes {

--- a/packages/alfa-rules/src/sia-r41/rule.ts
+++ b/packages/alfa-rules/src/sia-r41/rule.ts
@@ -46,17 +46,17 @@ export default Rule.Atomic.of<Page, Group<Element>, Question>({
             .map((elements) =>
               elements
                 .reduce((groups, element) => {
-                  for (const [node] of Node.from(element, device)) {
-                    const name = node.name.map((name) => normalize(name.value));
+                  const name = Node.from(element, device).name.map((name) =>
+                    normalize(name.value)
+                  );
 
-                    groups = groups.set(
-                      name,
-                      groups
-                        .get(name)
-                        .getOrElse(() => List.empty<Element>())
-                        .append(element)
-                    );
-                  }
+                  groups = groups.set(
+                    name,
+                    groups
+                      .get(name)
+                      .getOrElse(() => List.empty<Element>())
+                      .append(element)
+                  );
 
                   return groups;
                 }, Map.empty<Option<string>, List<Element>>())

--- a/packages/alfa-rules/src/sia-r42/rule.ts
+++ b/packages/alfa-rules/src/sia-r42/rule.ts
@@ -65,7 +65,7 @@ export namespace Outcomes {
 
 function hasRequiredParent(device: Device): Predicate<Element> {
   return (element) => {
-    const node = Node.from(element, device);
+    const node = aria.Node.from(element, device);
 
     return node.role
       .filter((role) => role.hasRequiredParent())

--- a/packages/alfa-rules/src/sia-r42/rule.ts
+++ b/packages/alfa-rules/src/sia-r42/rule.ts
@@ -63,14 +63,15 @@ export namespace Outcomes {
 }
 
 function hasRequiredParent(device: Device): Predicate<Element> {
-  return (element) =>
-    Node.from(element, device).some((node) =>
-      node.role
-        .filter((role) => role.hasRequiredParent())
-        .every((role) =>
-          node.parent().some(isRequiredParent(role.requiredParent))
-        )
-    );
+  return (element) => {
+    const node = Node.from(element, device);
+
+    return node.role
+      .filter((role) => role.hasRequiredParent())
+      .every((role) =>
+        node.parent().some(isRequiredParent(role.requiredParent))
+      );
+  };
 }
 
 function isRequiredParent(

--- a/packages/alfa-rules/src/sia-r57/rule.ts
+++ b/packages/alfa-rules/src/sia-r57/rule.ts
@@ -1,11 +1,10 @@
 import { Rule, Diagnostic } from "@siteimprove/alfa-act";
+import { Node } from "@siteimprove/alfa-aria";
 import { Text, Element } from "@siteimprove/alfa-dom";
 import { Iterable } from "@siteimprove/alfa-iterable";
 import { Ok, Err } from "@siteimprove/alfa-result";
 import { Predicate } from "@siteimprove/alfa-predicate";
 import { Page } from "@siteimprove/alfa-web";
-
-import * as aria from "@siteimprove/alfa-aria";
 
 import { expectation } from "../common/expectation";
 
@@ -47,13 +46,11 @@ export default Rule.Atomic.of<Page, Text>({
       expectations(target) {
         return {
           1: expectation(
-            aria.Node.from(target, device).every((node) =>
-              node
-                .ancestors()
-                .some((ancestor) =>
-                  ancestor.role.some((role) => role.isLandmark())
-                )
-            ),
+            Node.from(target, device)
+              .ancestors()
+              .some((ancestor) =>
+                ancestor.role.some((role) => role.isLandmark())
+              ),
             () => Outcomes.IsIncludedInLandmark,
             () => Outcomes.IsNotIncludedInLandmark
           ),

--- a/packages/alfa-rules/src/sia-r67/rule.ts
+++ b/packages/alfa-rules/src/sia-r67/rule.ts
@@ -35,8 +35,8 @@ export default Rule.Atomic.of<Page, Element>({
       expectations(target) {
         return {
           1: expectation(
-            Node.from(target, device).every((node) =>
-              node.role.some(not((role) => role.isPresentational()))
+            Node.from(target, device).role.some(
+              not((role) => role.isPresentational())
             ),
             () => Outcomes.IsExposed,
             () => Outcomes.IsNotExposed

--- a/packages/alfa-rules/src/sia-r68/rule.ts
+++ b/packages/alfa-rules/src/sia-r68/rule.ts
@@ -55,17 +55,18 @@ export namespace Outcomes {
 }
 
 function hasRequiredChildren(device: Device): Predicate<Element> {
-  return (element) =>
-    aria.Node.from(element, device).every((node) =>
-      node.role
-        .filter((role) => role.hasRequiredChildren())
-        .every((role) =>
-          node
-            .children()
-            .filter((node) => isElement(node.node))
-            .some(isRequiredChild(role.requiredChildren))
-        )
-    );
+  return (element) => {
+    const node = aria.Node.from(element, device);
+
+    return node.role
+      .filter((role) => role.hasRequiredChildren())
+      .every((role) =>
+        node
+          .children()
+          .filter((node) => isElement(node.node))
+          .some(isRequiredChild(role.requiredChildren))
+      );
+  };
 }
 
 function isRequiredChild(

--- a/packages/alfa-rules/src/sia-r81/rule.ts
+++ b/packages/alfa-rules/src/sia-r81/rule.ts
@@ -1,4 +1,5 @@
 import { Rule, Diagnostic } from "@siteimprove/alfa-act";
+import { Node } from "@siteimprove/alfa-aria";
 import { Element, Namespace } from "@siteimprove/alfa-dom";
 import { Iterable } from "@siteimprove/alfa-iterable";
 import { List } from "@siteimprove/alfa-list";
@@ -10,7 +11,6 @@ import { Set } from "@siteimprove/alfa-set";
 import { Criterion } from "@siteimprove/alfa-wcag";
 import { Page } from "@siteimprove/alfa-web";
 
-import * as aria from "@siteimprove/alfa-aria";
 import * as dom from "@siteimprove/alfa-dom";
 
 import { expectation } from "../common/expectation";
@@ -49,17 +49,17 @@ export default Rule.Atomic.of<Page, Group<Element>, Question>({
             .map((elements) =>
               elements
                 .reduce((groups, element) => {
-                  for (const [node] of aria.Node.from(element, device)) {
-                    const name = node.name.map((name) => normalize(name.value));
+                  const name = Node.from(element, device).name.map((name) =>
+                    normalize(name.value)
+                  );
 
-                    groups = groups.set(
-                      name,
-                      groups
-                        .get(name)
-                        .getOrElse(() => List.empty<Element>())
-                        .append(element)
-                    );
-                  }
+                  groups = groups.set(
+                    name,
+                    groups
+                      .get(name)
+                      .getOrElse(() => List.empty<Element>())
+                      .append(element)
+                  );
 
                   return groups;
                 }, Map.empty<Option<string>, List<Element>>())


### PR DESCRIPTION
While looking into CPU profiles over the past couple of months, one thing that consistently came out near the top of our cycle spend was handling of branched values during accessibility tree construction. The only thing we currently account for, however, is a bug in Firefox related to case sensitive `role` attributes. 

The plan has for a long time been to expand our coverage of these browser differences, but for lack of actually presenting them in the Siteimprove platform this work has kept getting pushed. As the release of the new Accessibility product has also shown, many customers are already finding it difficult enough to understand some of the more advanced rules that are now available. Adding an additional layer of complexity that is results dependant on possibly branched values will not be an improvement on this front.

For the reasons outlined above, I've therefore decided to pull out what current handling we have in @siteimprove/alfa-aria of branched values, which here and now serves two purposes: Improve performance and simplify the code.

That of course leaves a bit of an open question: What to do about the stuff that branched values were supposed to solve, which is browser differences that could lead to accessibility issues being present in one browser, but not another? My immediate thought is to encode these as separate rules, which will hopefully make it _much_ easier for end users to understand what the issue is. Consider, for example, the following two statements:

> The accessible name of the element is empty in "Browser XYZ".

vs.

> The accessible name of the element is based on its `title` attribute and might therefore not be correctly computed in "Browser XYZ".

The former is what we'd be able to determine with branched values. The latter is what we'd be able to determine with a rule that specifically calls out cases where an accessible name has a source that is based on the `title` attribute, thanks to us already tracking the sources of accessible names.

Resolves #153.
Resolves #154.