### PR TITLE
Implement remaining `display` grammar

### DIFF
--- a/packages/alfa-aria/src/name.ts
+++ b/packages/alfa-aria/src/name.ts
@@ -839,7 +839,9 @@ function isRendered(node: Node, device: Device): boolean {
   if (Element.isElement(node)) {
     const display = Style.from(node, device).computed("display").value;
 
-    const [outside] = display;
+    const {
+      values: [outside],
+    } = display;
 
     if (outside.value === "none") {
       return false;

--- a/packages/alfa-aria/src/node.ts
+++ b/packages/alfa-aria/src/node.ts
@@ -407,7 +407,11 @@ export namespace Node {
         // As we're building the accessibility tree top-down, we only need to
         // check the element itself for `display: none` and can safely
         // disregard its ancestors as they will already have been checked.
-        if (style.computed("display").value[0].value === "none") {
+        if (
+          style
+            .computed("display")
+            .some(({ values: [outside] }) => outside.value === "none")
+        ) {
           return Inert.of(node);
         }
 

--- a/packages/alfa-rules/src/common/predicate/is-rendered.ts
+++ b/packages/alfa-rules/src/common/predicate/is-rendered.ts
@@ -31,7 +31,7 @@ export function isRendered(
           Element.isElement(node) &&
           Style.from(node, device, context)
             .computed("display")
-            .some(([outside]) => outside.value === "none")
+            .some(({ values: [outside] }) => outside.value === "none")
         ) {
           return false;
         }

--- a/packages/alfa-style/src/property/display.ts
+++ b/packages/alfa-style/src/property/display.ts
@@ -86,12 +86,12 @@ export type Computed = Specified;
 /**
  * {@link https://drafts.csswg.org/css-display/#typedef-display-outside}
  */
-const parseDisplayOutside = Keyword.parse("block", "inline", "run-in");
+const parseOutside = Keyword.parse("block", "inline", "run-in");
 
 /**
  * {@link https://drafts.csswg.org/css-display/#typedef-display-inside}
  */
-const parseDisplayInside = Keyword.parse(
+const parseInside = Keyword.parse(
   "flow",
   "flow-root",
   "table",
@@ -103,12 +103,12 @@ const parseDisplayInside = Keyword.parse(
 /**
  * {@link https://drafts.csswg.org/css-display/#typedef-display-listitem}
  */
-const parseDisplayListItem = Keyword.parse("list-item");
+const parseListItem = Keyword.parse("list-item");
 
 /**
  * {@link https://drafts.csswg.org/css-display/#typedef-display-internal}
  */
-const parseDisplayInternal = Keyword.parse(
+const parseInternal = Keyword.parse(
   "table-row-group",
   "table-header-group",
   "table-footer-group",
@@ -126,12 +126,12 @@ const parseDisplayInternal = Keyword.parse(
 /**
  * {@link https://drafts.csswg.org/css-display/#typedef-display-box}
  */
-const parseDisplayBox = Keyword.parse("contents", "none");
+const parseBox = Keyword.parse("contents", "none");
 
 /**
  * {@link https://drafts.csswg.org/css-display/#typedef-display-legacy}
  */
-const parseDisplayLegacy = Keyword.parse(
+const parseLegacy = Keyword.parse(
   "inline-block",
   "inline-table",
   "inline-flex",
@@ -152,7 +152,7 @@ export const parse = either<Slice<Token>, Specified, string>(
       }
 
       if (outside === undefined) {
-        const result = parseDisplayOutside(input);
+        const result = parseOutside(input);
 
         if (result.isOk()) {
           [input, outside] = result.get();
@@ -161,7 +161,7 @@ export const parse = either<Slice<Token>, Specified, string>(
       }
 
       if (inside === undefined) {
-        const result = parseDisplayInside(input);
+        const result = parseInside(input);
 
         if (result.isOk()) {
           [input, inside] = result.get();
@@ -170,7 +170,7 @@ export const parse = either<Slice<Token>, Specified, string>(
       }
 
       if (listItem === undefined) {
-        const result = parseDisplayListItem(input);
+        const result = parseListItem(input);
 
         if (result.isOk()) {
           [input, listItem] = result.get();
@@ -212,7 +212,7 @@ export const parse = either<Slice<Token>, Specified, string>(
 
     return Result.of([input, Tuple.of(outside, inside, listItem)]);
   },
-  map(parseDisplayInternal, (keyword) => {
+  map(parseInternal, (keyword) => {
     switch (keyword.value) {
       case "table-row-group":
       case "table-header-group":
@@ -231,8 +231,8 @@ export const parse = either<Slice<Token>, Specified, string>(
         return Tuple.of(keyword, Keyword.of("flow"));
     }
   }),
-  map(parseDisplayBox, (keyword) => Tuple.of(keyword)),
-  map(parseDisplayLegacy, (keyword) => {
+  map(parseBox, (keyword) => Tuple.of(keyword)),
+  map(parseLegacy, (keyword) => {
     const inline = Keyword.of("inline");
 
     switch (keyword.value) {

--- a/packages/alfa-style/src/property/display.ts
+++ b/packages/alfa-style/src/property/display.ts
@@ -23,7 +23,7 @@ export type Specified = Tuple<
       inside: Specified.Inside,
       listitem?: Specified.ListItem
     ]
-  | [outside: Specified.Internal, inside: Specified.Internal | Specified.Inside]
+  | [outside: Specified.Internal, inside: Specified.Inside]
   | [Specified.Box]
 >;
 
@@ -189,22 +189,25 @@ export const parse = either<Slice<Token>, Specified, string>(
       return Err.of(`Expected an outer or inner display type or a list marker`);
     }
 
-    if (listItem === undefined) {
-      outside =
-        outside ??
-        (inside?.value === "ruby" ? Keyword.of("inline") : Keyword.of("block"));
-      inside = inside ?? Keyword.of("flow");
-    } else {
-      outside = outside ?? Keyword.of("block");
-      inside = inside ?? Keyword.of("flow");
+    if (inside === undefined) {
+      inside = Keyword.of("flow");
+    }
 
-      switch (inside.value) {
-        case "flow":
-        case "flow-root":
-          break;
-        default:
-          return Err.of(`Unexpected inner display type for list marker`);
-      }
+    if (outside === undefined) {
+      outside =
+        inside.value === "ruby" ? Keyword.of("inline") : Keyword.of("block");
+    }
+
+    if (listItem === undefined) {
+      return Result.of([input, Tuple.of(outside, inside)]);
+    }
+
+    switch (inside.value) {
+      case "flow":
+      case "flow-root":
+        break;
+      default:
+        return Err.of(`Unexpected inner display type for list marker`);
     }
 
     return Result.of([input, Tuple.of(outside, inside, listItem)]);

--- a/packages/alfa-style/test/property/display.spec.tsx
+++ b/packages/alfa-style/test/property/display.spec.tsx
@@ -48,7 +48,6 @@ test("#cascaded() parses `display: block`", (t) => {
         type: "keyword",
         value: "flow",
       },
-      null,
     ],
   });
 });
@@ -65,7 +64,6 @@ test("#cascaded() parses `display: inline`", (t) => {
         type: "keyword",
         value: "flow",
       },
-      null,
     ],
   });
 });
@@ -85,6 +83,126 @@ test("#cascaded() parses `display: list-item`", (t) => {
       {
         type: "keyword",
         value: "list-item",
+      },
+    ],
+  });
+});
+
+test("#cascaded() parses `display: inline-block`", (t) => {
+  t.deepEqual(cascaded("inline-block").toJSON(), {
+    type: "tuple",
+    values: [
+      {
+        type: "keyword",
+        value: "inline",
+      },
+      {
+        type: "keyword",
+        value: "flow-root",
+      },
+    ],
+  });
+});
+
+test("#cascaded() parses `display: inline flow`", (t) => {
+  t.deepEqual(cascaded("inline flow").toJSON(), {
+    type: "tuple",
+    values: [
+      {
+        type: "keyword",
+        value: "inline",
+      },
+      {
+        type: "keyword",
+        value: "flow",
+      },
+    ],
+  });
+});
+
+test("#cascaded() parses `display: inline flow list-item`", (t) => {
+  t.deepEqual(cascaded("inline flow list-item").toJSON(), {
+    type: "tuple",
+    values: [
+      {
+        type: "keyword",
+        value: "inline",
+      },
+      {
+        type: "keyword",
+        value: "flow",
+      },
+      {
+        type: "keyword",
+        value: "list-item",
+      },
+    ],
+  });
+});
+
+test("#cascaded() parses `display: block flow`", (t) => {
+  t.deepEqual(cascaded("block flow").toJSON(), {
+    type: "tuple",
+    values: [
+      {
+        type: "keyword",
+        value: "block",
+      },
+      {
+        type: "keyword",
+        value: "flow",
+      },
+    ],
+  });
+});
+
+test("#cascaded() parses `display: block flow list-item`", (t) => {
+  t.deepEqual(cascaded("block flow list-item").toJSON(), {
+    type: "tuple",
+    values: [
+      {
+        type: "keyword",
+        value: "block",
+      },
+      {
+        type: "keyword",
+        value: "flow",
+      },
+      {
+        type: "keyword",
+        value: "list-item",
+      },
+    ],
+  });
+});
+
+test("#cascaded() parses `display: table-row`", (t) => {
+  t.deepEqual(cascaded("table-row").toJSON(), {
+    type: "tuple",
+    values: [
+      {
+        type: "keyword",
+        value: "table-row",
+      },
+      {
+        type: "keyword",
+        value: "flow-root",
+      },
+    ],
+  });
+});
+
+test("#cascaded() parses `display: ruby-text`", (t) => {
+  t.deepEqual(cascaded("ruby-text").toJSON(), {
+    type: "tuple",
+    values: [
+      {
+        type: "keyword",
+        value: "ruby-text",
+      },
+      {
+        type: "keyword",
+        value: "flow",
       },
     ],
   });

--- a/packages/alfa-style/test/property/display.spec.tsx
+++ b/packages/alfa-style/test/property/display.spec.tsx
@@ -1,0 +1,91 @@
+import { test } from "@siteimprove/alfa-test";
+
+import { Device } from "@siteimprove/alfa-device";
+
+import { Style } from "../../src/style";
+
+const device = Device.standard();
+
+function cascaded(display: string) {
+  return Style.from(<div style={{ display }} />, device)
+    .cascaded("display")
+    .get().value;
+}
+
+test("#cascaded() parses `display: none`", (t) => {
+  t.deepEqual(cascaded("none").toJSON(), {
+    type: "tuple",
+    values: [
+      {
+        type: "keyword",
+        value: "none",
+      },
+    ],
+  });
+});
+
+test("#cascaded() parses `display: contents`", (t) => {
+  t.deepEqual(cascaded("contents").toJSON(), {
+    type: "tuple",
+    values: [
+      {
+        type: "keyword",
+        value: "contents",
+      },
+    ],
+  });
+});
+
+test("#cascaded() parses `display: block`", (t) => {
+  t.deepEqual(cascaded("block").toJSON(), {
+    type: "tuple",
+    values: [
+      {
+        type: "keyword",
+        value: "block",
+      },
+      {
+        type: "keyword",
+        value: "flow",
+      },
+      null,
+    ],
+  });
+});
+
+test("#cascaded() parses `display: inline`", (t) => {
+  t.deepEqual(cascaded("inline").toJSON(), {
+    type: "tuple",
+    values: [
+      {
+        type: "keyword",
+        value: "inline",
+      },
+      {
+        type: "keyword",
+        value: "flow",
+      },
+      null,
+    ],
+  });
+});
+
+test("#cascaded() parses `display: list-item`", (t) => {
+  t.deepEqual(cascaded("list-item").toJSON(), {
+    type: "tuple",
+    values: [
+      {
+        type: "keyword",
+        value: "block",
+      },
+      {
+        type: "keyword",
+        value: "flow",
+      },
+      {
+        type: "keyword",
+        value: "list-item",
+      },
+    ],
+  });
+});

--- a/packages/alfa-style/tsconfig.json
+++ b/packages/alfa-style/tsconfig.json
@@ -159,6 +159,7 @@
     "test/property/border-image-width.spec.tsx",
     "test/property/box-shadow.spec.tsx",
     "test/property/clip.spec.tsx",
+    "test/property/display.spec.tsx",
     "test/property/font.spec.tsx",
     "test/property/font-family.spec.tsx",
     "test/property/font-size.spec.tsx",


### PR DESCRIPTION
These changes are breaking as the specified and computed type of the `display` property has changed from a plain tuple type to the `Tuple` class.

Resolves #761.