### PR TITLE
Remove second expectation from R62

### DIFF
--- a/packages/alfa-rules/src/sia-r62/rule.ts
+++ b/packages/alfa-rules/src/sia-r62/rule.ts
@@ -94,27 +94,6 @@ export default Rule.Atomic.of<Page, Element, Question>({
             () => Outcomes.IsDistinguishable,
             () => Outcomes.IsNotDistinguishable
           ),
-
-          2: expectation(
-            test(
-              and(
-                isDistinguishable(container, device, Context.visit(target)),
-                isDistinguishable(
-                  container,
-                  device,
-                  Context.hover(target).visit(target)
-                ),
-                isDistinguishable(
-                  container,
-                  device,
-                  Context.focus(target).visit(target)
-                )
-              ),
-              target
-            ),
-            () => Outcomes.IsDistinguishableWhenVisited,
-            () => Outcomes.IsNotDistinguishableWhenVisited
-          ),
         };
       },
     };
@@ -130,19 +109,6 @@ export namespace Outcomes {
     Diagnostic.of(
       `The link is not distinguishable from the surrounding text, either in its
       default state, or on hover and focus`
-    )
-  );
-
-  export const IsDistinguishableWhenVisited = Ok.of(
-    Diagnostic.of(
-      `When visited, the link is distinguishable from the surrounding text`
-    )
-  );
-
-  export const IsNotDistinguishableWhenVisited = Err.of(
-    Diagnostic.of(
-      `When visited, the link is not distinguishable from the surrounding text,
-      either in its default state, or on hover and focus`
     )
   );
 }

--- a/packages/alfa-rules/test/sia-r62/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r62/rule.spec.tsx
@@ -17,7 +17,6 @@ test(`evaluate() passes an <a> element with a <p> parent element with non-link
   t.deepEqual(await evaluate(R62, { document }), [
     passed(R62, target, {
       1: Outcomes.IsDistinguishable,
-      2: Outcomes.IsDistinguishableWhenVisited,
     }),
   ]);
 });
@@ -35,7 +34,6 @@ test(`evaluate() passes an <a> element with a <p> parent element with non-link
   t.deepEqual(await evaluate(R62, { document }), [
     passed(R62, target, {
       1: Outcomes.IsDistinguishable,
-      2: Outcomes.IsDistinguishableWhenVisited,
     }),
   ]);
 });
@@ -58,7 +56,6 @@ test(`evaluate() fails an <a> element that removes the default text decoration
   t.deepEqual(await evaluate(R62, { document }), [
     failed(R62, target, {
       1: Outcomes.IsNotDistinguishable,
-      2: Outcomes.IsNotDistinguishableWhenVisited,
     }),
   ]);
 });
@@ -81,7 +78,6 @@ test(`evaluate() fails an <a> element that removes the default text decoration
   t.deepEqual(await evaluate(R62, { document }), [
     failed(R62, target, {
       1: Outcomes.IsNotDistinguishable,
-      2: Outcomes.IsNotDistinguishableWhenVisited,
     }),
   ]);
 });
@@ -106,7 +102,6 @@ test(`evaluate() fails an <a> element that removes the default text decoration
   t.deepEqual(await evaluate(R62, { document }), [
     failed(R62, target, {
       1: Outcomes.IsNotDistinguishable,
-      2: Outcomes.IsNotDistinguishableWhenVisited,
     }),
   ]);
 });
@@ -134,7 +129,6 @@ test(`evaluate() fails an <a> element that removes the default text decoration
   t.deepEqual(await evaluate(R62, { document }), [
     failed(R62, target, {
       1: Outcomes.IsNotDistinguishable,
-      2: Outcomes.IsNotDistinguishableWhenVisited,
     }),
   ]);
 });
@@ -161,7 +155,6 @@ test(`evaluate() fails an <a> element that applies a text decoration only on
   t.deepEqual(await evaluate(R62, { document }), [
     failed(R62, target, {
       1: Outcomes.IsNotDistinguishable,
-      2: Outcomes.IsNotDistinguishableWhenVisited,
     }),
   ]);
 });
@@ -188,7 +181,6 @@ test(`evaluate() fails an <a> element that applies a text decoration only on
   t.deepEqual(await evaluate(R62, { document }), [
     failed(R62, target, {
       1: Outcomes.IsNotDistinguishable,
-      2: Outcomes.IsNotDistinguishableWhenVisited,
     }),
   ]);
 });
@@ -215,7 +207,6 @@ test(`evaluate() fails an <a> element that applies a text decoration only on
   t.deepEqual(await evaluate(R62, { document }), [
     failed(R62, target, {
       1: Outcomes.IsNotDistinguishable,
-      2: Outcomes.IsNotDistinguishableWhenVisited,
     }),
   ]);
 });
@@ -239,7 +230,6 @@ test(`evaluate() passes an applicable <a> element that removes the default text
   t.deepEqual(await evaluate(R62, { document }), [
     passed(R62, target, {
       1: Outcomes.IsDistinguishable,
-      2: Outcomes.IsDistinguishableWhenVisited,
     }),
   ]);
 });
@@ -263,7 +253,6 @@ test(`evaluate() passes an applicable <a> element that removes the default text
   t.deepEqual(await evaluate(R62, { document }), [
     passed(R62, target, {
       1: Outcomes.IsDistinguishable,
-      2: Outcomes.IsDistinguishableWhenVisited,
     }),
   ]);
 });
@@ -287,7 +276,6 @@ test(`evaluate() fails an <a> element that has no distinguishing features and
   t.deepEqual(await evaluate(R62, { document }), [
     failed(R62, target, {
       1: Outcomes.IsNotDistinguishable,
-      2: Outcomes.IsNotDistinguishableWhenVisited,
     }),
   ]);
 });
@@ -311,7 +299,6 @@ test(`evaluate() fails an <a> element that has no distinguishing features and
   t.deepEqual(await evaluate(R62, { document }), [
     failed(R62, target, {
       1: Outcomes.IsNotDistinguishable,
-      2: Outcomes.IsNotDistinguishableWhenVisited,
     }),
   ]);
 });
@@ -335,7 +322,6 @@ test(`evaluate() passes an applicable <a> element that removes the default text
   t.deepEqual(await evaluate(R62, { document }), [
     passed(R62, target, {
       1: Outcomes.IsDistinguishable,
-      2: Outcomes.IsDistinguishableWhenVisited,
     }),
   ]);
 });
@@ -362,7 +348,6 @@ test(`evaluate() fails an <a> element that has no distinguishing features but is
   t.deepEqual(await evaluate(R62, { document }), [
     failed(R62, target, {
       1: Outcomes.IsNotDistinguishable,
-      2: Outcomes.IsNotDistinguishableWhenVisited,
     }),
   ]);
 });
@@ -390,7 +375,6 @@ test(`evaluate() fails an <a> element that has no distinguishing features and
   t.deepEqual(await evaluate(R62, { document }), [
     failed(R62, target, {
       1: Outcomes.IsNotDistinguishable,
-      2: Outcomes.IsNotDistinguishableWhenVisited,
     }),
   ]);
 });
@@ -442,7 +426,6 @@ test(`evaluate() passes an <a> element with a <div role="paragraph"> parent elem
   t.deepEqual(await evaluate(R62, { document }), [
     passed(R62, target, {
       1: Outcomes.IsDistinguishable,
-      2: Outcomes.IsDistinguishableWhenVisited,
     }),
   ]);
 });


### PR DESCRIPTION
Due to [Privacy restriction on `:visited`](https://developer.mozilla.org/en-US/docs/Web/CSS/Privacy_and_the_:visited_selector) the only things that can change between a `:link` and a `:visited` is the colour of a few properties, and not even the transparency.

R62 doesn't check colour (except `background-color`), only presence and transparency.

Therefore, in its current state, the only case where
* the second expectation of R62 fails
* BUT the first is passing
* AND this is not a false positive due to #708 
is variations on
```
<style>
p { background-color: white }
:any-link { text-decoration: none }
:link { background-color: red }
:visited { background-color: white }
</style>
```

So, I think it's safe to remove the second expectation as almost everything it catches that isn't a false positive is already caught by the first.
(the fact that there was no test case with different results for each expectation should have warned us…)