### PR TITLE
SIA R62: accept different font weight

### DIFF
--- a/packages/alfa-rules/src/sia-r62/rule.ts
+++ b/packages/alfa-rules/src/sia-r62/rule.ts
@@ -142,6 +142,8 @@ function isDistinguishable(
     hasDistinguishableTextDecoration(container, device, context),
     hasDistinguishableBackground(container, device, context),
 
+    hasDistinguishableFontWeight(container, device, context),
+
     // We consider the mere presence of borders or outlines on the element as
     // distinguishable features. There's of course a risk of these blending with
     // other features of the container element, such as its background, but this
@@ -187,5 +189,27 @@ function hasDistinguishableBackground(
     return Style.from(element, device, context)
       .computed("background-color")
       .none((color) => Color.isTransparent(color) || color.equals(reference));
+  };
+}
+
+/**
+ * Check if an element has a different font weight than its container.
+ *
+ * This is brittle and imperfect but removes a strong pain point until we find
+ * a better solution…
+ */
+function hasDistinguishableFontWeight(
+  container: Element,
+  device: Device,
+  context?: Context
+): Predicate<Element> {
+  const reference = Style.from(container, device, context).computed(
+    "font-weight"
+  ).value;
+
+  return (element) => {
+    return Style.from(element, device, context)
+      .computed("font-weight")
+      .none((weight) => weight.equals(reference));
   };
 }

--- a/packages/alfa-rules/test/sia-r62/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r62/rule.spec.tsx
@@ -442,3 +442,27 @@ test(`evaluate() is inapplicable to an <a> element with a <p> parent element
 
   t.deepEqual(await evaluate(R62, { document }), [inapplicable(R62)]);
 });
+
+test(`evaluate() passes a link whose bolder than surrounding text`, async (t) => {
+  const target = <a href="#">Link</a>;
+
+  const document = Document.of(
+    [
+      <p>
+        <span>Hello</span> {target}
+      </p>,
+    ],
+    [
+      h.sheet([
+        h.rule.style("a", {
+          textDecoration: "none",
+          fontWeight: "bold",
+        }),
+      ]),
+    ]
+  );
+
+  t.deepEqual(await evaluate(R62, { document }), [
+    passed(R62, target, { 1: Outcomes.IsDistinguishable }),
+  ]);
+});


### PR DESCRIPTION
Let SIA R62 accept a difference in `font-weight` with the container as a distinguishable feature for links.
This is a brittle and imperfect patch, and we need to consider this more cautiously as part of #775. This removes a large pain point for customers until we take further decision, and aligns with the text in the platform.
This is still hit by #777.

This creates false negatives in cases like
```html
<p>Lorem <span style="font-weight: bold">Text</span> ipsum <a style="text-decoration: none; font-weight: bold">Link</a></p>
```
where the link is not distinguishable from the span.
