### PR TITLE
Handle arrays in Equatable.equals

### DIFF
--- a/packages/alfa-equatable/src/equatable.ts
+++ b/packages/alfa-equatable/src/equatable.ts
@@ -35,6 +35,12 @@ export namespace Equatable {
       return b.equals(a);
     }
 
+    if (Array.isArray(a) && Array.isArray(b)) {
+      return (
+        a.length === b.length && a.every((value, i) => equals(value, b[i]))
+      );
+    }
+
     return false;
   }
 }


### PR DESCRIPTION
`Equatable.equals([1, 2], [1,2])` is currently `false` while `Equatable.equals(List.of([1, 2]), List.of([1,2]))` is `true` (same for other iterables AFAICT), which is a bit confusing given that `List` is mostly a wrapper for arrays.

This handle arrays in `Equatable.equals`
