### PR TITLE
Add `archive` option in `Scraper#scrape()`

### DIFF
--- a/packages/alfa-cli/bin/alfa/command/scrape/flags.ts
+++ b/packages/alfa-cli/bin/alfa/command/scrape/flags.ts
@@ -144,14 +144,14 @@ export const Flags = {
 
   screenshot: Flag.string(
     "screenshot",
-    "The path to write a screenshot to. If not provided, no screenshot is taken."
+    "The path to write a screenshot to. If not provided, no screenshot is captured."
   )
     .type("path")
     .optional(),
 
   screenshotType: Flag.string(
     "screenshot-type",
-    "The file type of the screenshot"
+    "The file type of the screenshot."
   )
     .choices("png", "jpeg")
     .default("png"),
@@ -169,4 +169,18 @@ export const Flags = {
     .type("0-100")
     .filter((value) => value >= 0 && value <= 100)
     .default(100),
+
+  archive: Flag.string(
+    "archive",
+    "The path to write an archive to. If not provided, no archive is captured."
+  )
+    .type("path")
+    .optional(),
+
+  archiveFormat: Flag.string(
+    "archive-format",
+    "The format of the captured archive."
+  )
+    .choices("mhtml")
+    .default("mhtml"),
 };

--- a/packages/alfa-cli/bin/alfa/command/scrape/run.ts
+++ b/packages/alfa-cli/bin/alfa/command/scrape/run.ts
@@ -10,6 +10,7 @@ import { Header, Cookie } from "@siteimprove/alfa-http";
 import { Iterable } from "@siteimprove/alfa-iterable";
 import { Ok, Err } from "@siteimprove/alfa-result";
 import {
+  Archive,
   Awaiter,
   Credentials,
   Scraper,
@@ -83,6 +84,15 @@ export const run: Command.Runner<typeof Flags, typeof Arguments> = async ({
     }
   }
 
+  let archive: Archive | undefined;
+
+  for (const path of flags.archive) {
+    switch (flags.archiveFormat) {
+      case "mhtml":
+        archive = Archive.of(path, Archive.Format.MHTML);
+    }
+  }
+
   const headers = [...flags.headers].map((header) => {
     const index = header.indexOf(":");
 
@@ -141,6 +151,7 @@ export const run: Command.Runner<typeof Flags, typeof Arguments> = async ({
       device,
       credentials,
       screenshot,
+      archive,
       headers,
       cookies,
       fit: flags.fit,

--- a/packages/alfa-scraper/src/archive.ts
+++ b/packages/alfa-scraper/src/archive.ts
@@ -1,0 +1,66 @@
+import { Equatable } from "@siteimprove/alfa-equatable";
+import { Serializable } from "@siteimprove/alfa-json";
+
+import * as json from "@siteimprove/alfa-json";
+
+/**
+ * @public
+ */
+export class Archive implements Equatable, Serializable {
+  public static of(
+    path: string,
+    format: Archive.Format = Archive.Format.MHTML
+  ): Archive {
+    return new Archive(path, format);
+  }
+
+  private readonly _path: string;
+  private readonly _format: Archive.Format;
+
+  private constructor(path: string, format: Archive.Format) {
+    this._path = path;
+    this._format = format;
+  }
+
+  public get path(): string {
+    return this._path;
+  }
+
+  public get format(): Archive.Format {
+    return this._format;
+  }
+
+  public equals(value: Archive): boolean;
+
+  public equals(value: unknown): value is this;
+
+  public equals(value: unknown): boolean {
+    return (
+      value instanceof Archive &&
+      value._path === this._path &&
+      value._format === this._format
+    );
+  }
+
+  public toJSON(): Archive.JSON {
+    return {
+      path: this._path,
+      format: this._format,
+    };
+  }
+}
+
+/**
+ * @public
+ */
+export namespace Archive {
+  export interface JSON {
+    [key: string]: json.JSON;
+    path: string;
+    format: `${Format}`;
+  }
+
+  export enum Format {
+    MHTML = "mhtml",
+  }
+}

--- a/packages/alfa-scraper/src/index.ts
+++ b/packages/alfa-scraper/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./archive";
 export * from "./awaiter";
 export * from "./credentials";
 export * from "./scraper";

--- a/packages/alfa-scraper/tsconfig.json
+++ b/packages/alfa-scraper/tsconfig.json
@@ -2,6 +2,7 @@
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "../tsconfig.json",
   "files": [
+    "src/archive.ts",
     "src/awaiter.ts",
     "src/credentials.ts",
     "src/index.ts",


### PR DESCRIPTION
This pull request adds a new option `archive` in the `Scraper#scrape()` method that currently supports capturing an [MHTML](https://en.wikipedia.org/wiki/MHTML) archive of the page being scraped, similar to how screenshots can be captured with the `screenshot` option. It also adds two new flags to the CLI: `--archive` and `--archive-format`.

Archives can be a useful addition to screenshots for verifying the state of the page when scraped. It also provides a useful tool for performing additional manual inspection of the page.