### PR TITLE
Aria attributes depending on element

### DIFF
--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -13,10 +13,10 @@ import { Cell, Table } from "@siteimprove/alfa-table";
 import { Attribute } from "./attribute";
 import { Name } from "./name";
 import { Role } from "./role";
-import and = Refinement.and;
 
 const { hasInputType, hasName, isElement } = Element;
 const { or, test } = Predicate;
+const { and } = Refinement;
 
 /**
  * @internal
@@ -247,6 +247,7 @@ const Features: Features = {
       }
     ),
 
+    // https://w3c.github.io/html-aam/#el-datalist
     // <datalist> only has a role if it is correctly mapped to an <input>
     // via the list attribute. We should probably check that.
     // Additionally, it seems to never be rendered, hence always ignored.
@@ -402,6 +403,11 @@ const Features: Features = {
         return None;
       },
       function* (element) {
+        // https://w3c.github.io/html-aam/#el-input-checkbox
+        // aria-checked should be "mixed" if the indeterminate IDL attribute is
+        // true
+        // aria-checked should otherwise mimic the checkedness, i.e. the
+        // checked *IDL* attribute, not the DOM one.
         // https://w3c.github.io/html-aam/#att-checked
         yield Attribute.of(
           "aria-checked",
@@ -500,18 +506,19 @@ const Features: Features = {
 
             return None;
           }),
-      function* (element) {
+      (element) => {
         // https://w3c.github.io/html-aam/#el-li
         const siblings = element
           .inclusiveSiblings()
           .filter(and(Element.isElement, Element.hasName("li")));
 
-        yield Attribute.of("aria-setsize", `${siblings.size}`);
-
-        yield Attribute.of(
-          "aria-posinset",
-          `${siblings.takeUntil((sibling) => sibling.equals(element)).size}`
-        );
+        return [
+          Attribute.of("aria-setsize", `${siblings.size}`),
+          Attribute.of(
+            "aria-posinset",
+            `${siblings.takeUntil((sibling) => sibling.equals(element)).size}`
+          ),
+        ];
       }
     ),
 

--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -245,6 +245,9 @@ const Features: Features = {
       }
     ),
 
+    // <datalist> only has a role if it is correctly mapped to an <input>
+    // via the list attribute. We should probably check that.
+    // Additionally, it seems to never be rendered, hence always ignored.
     datalist: html(() => Option.of(Role.of("listbox"))),
 
     dd: html(() => Option.of(Role.of("definition"))),
@@ -614,6 +617,9 @@ const Features: Features = {
     textarea: html(
       () => Option.of(Role.of("textbox")),
       function* (element) {
+        // https://w3c.github.io/html-aam/#el-textarea
+        yield Attribute.of("aria-multiline", "true");
+
         // https://w3c.github.io/html-aam/#att-disabled
         for (const _ of element.attribute("disabled")) {
           yield Attribute.of("aria-disabled", "true");

--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -516,7 +516,9 @@ const Features: Features = {
           Attribute.of("aria-setsize", `${siblings.size}`),
           Attribute.of(
             "aria-posinset",
-            `${siblings.takeUntil((sibling) => sibling.equals(element)).size}`
+            `${
+              siblings.takeUntil((sibling) => sibling.equals(element)).size + 1
+            }`
           ),
         ];
       }

--- a/packages/alfa-aria/test/node.spec.tsx
+++ b/packages/alfa-aria/test/node.spec.tsx
@@ -448,7 +448,10 @@ test(`.from() doesn't inherit presentational roles into explicitly required
         node: "/ul[1]/li[1]",
         role: "listitem",
         name: null,
-        attributes: [],
+        attributes: [
+          { name: "aria-setsize", value: "1" },
+          { name: "aria-posinset", value: "0" },
+        ],
         children: [],
       },
     ],
@@ -513,4 +516,30 @@ test(`.from() doesn't expose children of elements with roles that designate
       },
     ],
   });
+});
+
+test(`.from() correctly sets \`aria-setsize\` and \`aria-posinset\``, (t) => {
+  const first = <li>First</li>;
+  const second = <li>Second</li>;
+  const third = <li>Third</li>;
+  const fourth = <li>Fourth</li>;
+
+  const _ = (
+    <ul>
+      {first}
+      {second}
+      {third}
+      {fourth}
+    </ul>
+  );
+
+  const items = [first, second, third, fourth];
+
+  for (let i = 0; i < items.length; i++) {
+    const node = Node.from(items[i], device);
+
+    t.deepEqual(node.attribute("aria-setsize").get().value, `${items.length}`);
+
+    t.deepEqual(node.attribute("aria-posinset").get().value, `${i}`);
+  }
 });

--- a/packages/alfa-aria/test/node.spec.tsx
+++ b/packages/alfa-aria/test/node.spec.tsx
@@ -450,7 +450,7 @@ test(`.from() doesn't inherit presentational roles into explicitly required
         name: null,
         attributes: [
           { name: "aria-setsize", value: "1" },
-          { name: "aria-posinset", value: "0" },
+          { name: "aria-posinset", value: "1" },
         ],
         children: [],
       },
@@ -540,6 +540,6 @@ test(`.from() correctly sets \`aria-setsize\` and \`aria-posinset\``, (t) => {
 
     t.deepEqual(node.attribute("aria-setsize").get().value, `${items.length}`);
 
-    t.deepEqual(node.attribute("aria-posinset").get().value, `${i}`);
+    t.deepEqual(node.attribute("aria-posinset").get().value, `${i + 1}`);
   }
 });


### PR DESCRIPTION
Resolves #799 

* Ignoring `<datalist>` because 
    1. it's hard and costly to find if there is a correct `<input list="id">`
    2. it's never rendered (I think), so always ignored 🤔 
    3. let's keep it simple until it proves problematic…
* Ignoring checkboxes and radio buttons because:
    1. the bit around the `checkedness` is mostly covered by the `checked` attribute (https://html.spec.whatwg.org/multipage/input.html#dom-input-checked) not fully, since it is the IDL attribute, but should be good enough.
    2. the bit around the `indeterminate` IDL attribute looks like something we just can't handle currently…


