### PR TITLE
Make descendents of fully clipped nodes invisible

### DIFF
--- a/packages/alfa-rules/src/common/predicate.ts
+++ b/packages/alfa-rules/src/common/predicate.ts
@@ -4,6 +4,7 @@ export * from "./predicate/has-border";
 export * from "./predicate/has-box-shadow";
 export * from "./predicate/has-cascaded-value-declared-in-inline-style";
 export * from "./predicate/has-child";
+export * from "./predicate/has-computed-style";
 export * from "./predicate/has-descendant";
 export * from "./predicate/has-explicit-role";
 export * from "./predicate/has-heading-level";

--- a/packages/alfa-rules/src/common/predicate/has-computed-style.ts
+++ b/packages/alfa-rules/src/common/predicate/has-computed-style.ts
@@ -1,15 +1,28 @@
 import { Device } from "@siteimprove/alfa-device";
-import { Element } from "@siteimprove/alfa-dom";
+import { Element, Text } from "@siteimprove/alfa-dom";
 import { Predicate } from "@siteimprove/alfa-predicate";
 import { Context } from "@siteimprove/alfa-selector";
 import { Property, Style } from "@siteimprove/alfa-style";
 
+const { isElement } = Element;
+
 export function hasComputedStyle<N extends Property.Name>(
-  name: N,
-  predicate: Predicate<Style.Computed<N>>,
   device: Device,
   context?: Context
-): Predicate<Element> {
-  return (element) =>
-    Style.from(element, device, context).computed(name).some(predicate);
+): (
+  name: N,
+  predicate: Predicate<Style.Computed<N>>
+) => Predicate<Element | Text> {
+  return function hasComputedStyle(
+    name: N,
+    predicate: Predicate<Style.Computed<N>>
+  ): Predicate<Element | Text> {
+    return (node) =>
+      isElement(node)
+        ? Style.from(node, device, context).computed(name).some(predicate)
+        : node
+            .parent({ flattened: true })
+            .filter(isElement)
+            .some(hasComputedStyle(name, predicate));
+  };
 }

--- a/packages/alfa-rules/src/common/predicate/has-computed-style.ts
+++ b/packages/alfa-rules/src/common/predicate/has-computed-style.ts
@@ -1,0 +1,15 @@
+import { Device } from "@siteimprove/alfa-device";
+import { Element } from "@siteimprove/alfa-dom";
+import { Predicate } from "@siteimprove/alfa-predicate";
+import { Context } from "@siteimprove/alfa-selector";
+import { Property, Style } from "@siteimprove/alfa-style";
+
+export function hasComputedStyle<N extends Property.Name>(
+  name: N,
+  predicate: Predicate<Style.Computed<N>>,
+  device: Device,
+  context?: Context
+): Predicate<Element> {
+  return (element) =>
+    Style.from(element, device, context).computed(name).some(predicate);
+}

--- a/packages/alfa-rules/src/common/predicate/has-computed-style.ts
+++ b/packages/alfa-rules/src/common/predicate/has-computed-style.ts
@@ -7,22 +7,17 @@ import { Property, Style } from "@siteimprove/alfa-style";
 const { isElement } = Element;
 
 export function hasComputedStyle<N extends Property.Name>(
+  name: N,
+  predicate: Predicate<Style.Computed<N>>,
   device: Device,
   context?: Context
-): (
-  name: N,
-  predicate: Predicate<Style.Computed<N>>
-) => Predicate<Element | Text> {
-  return function hasComputedStyle(
-    name: N,
-    predicate: Predicate<Style.Computed<N>>
-  ): Predicate<Element | Text> {
-    return (node) =>
-      isElement(node)
-        ? Style.from(node, device, context).computed(name).some(predicate)
-        : node
-            .parent({ flattened: true })
-            .filter(isElement)
-            .some(hasComputedStyle(name, predicate));
+): Predicate<Element | Text> {
+  return function hasComputedStyle(node): boolean {
+    return isElement(node)
+      ? Style.from(node, device, context).computed(name).some(predicate)
+      : node
+          .parent({ flattened: true })
+          .filter(isElement)
+          .some(hasComputedStyle);
   };
 }

--- a/packages/alfa-rules/src/common/predicate/is-clipped.ts
+++ b/packages/alfa-rules/src/common/predicate/is-clipped.ts
@@ -1,6 +1,6 @@
 import { Cache } from "@siteimprove/alfa-cache";
 import { Device } from "@siteimprove/alfa-device";
-import { Element, Text, Node } from "@siteimprove/alfa-dom";
+import { Element, Node } from "@siteimprove/alfa-dom";
 import { Predicate } from "@siteimprove/alfa-predicate";
 import { Context } from "@siteimprove/alfa-selector";
 import { Style } from "@siteimprove/alfa-style";
@@ -8,7 +8,6 @@ import { Style } from "@siteimprove/alfa-style";
 const { abs } = Math;
 const { isElement } = Element;
 const { or, test } = Predicate;
-const { isText } = Text;
 
 const cache = Cache.empty<Device, Cache<Context, Cache<Node, boolean>>>();
 
@@ -24,13 +23,25 @@ export function isClipped(
         test(
           or(
             isClippedBySize(device, context),
-            isClippedByMasking(device, context)
+            isClippedByIndent(device, context),
+            isClippedByMasking(device, context),
+            (node) =>
+              node
+                .parent({
+                  flattened: true,
+                  nested: true,
+                })
+                .some(isClipped(device, context))
           ),
           node
         )
       );
 }
 
+/**
+ * Checks if an element's size is reduced to 0 or 1 pixel, and overflow is
+ * somehow hidden.
+ */
 function isClippedBySize(
   device: Device,
   context: Context = Context.empty()
@@ -39,13 +50,19 @@ function isClippedBySize(
     if (isElement(node)) {
       const style = Style.from(node, device, context);
 
-      const { value: x } = style.computed("overflow-x");
-      const { value: y } = style.computed("overflow-y");
+      const {
+        value: { value: x },
+      } = style.computed("overflow-x");
+      const {
+        value: { value: y },
+      } = style.computed("overflow-y");
 
       const { value: height } = style.computed("height");
       const { value: width } = style.computed("width");
 
-      if (x.value === "hidden" || y.value === "hidden") {
+      const hasNoScrollBar = x === "hidden" || y === "hidden";
+
+      if (x !== "visible" || y !== "visible") {
         for (const dimension of [height, width]) {
           switch (dimension.type) {
             case "percentage":
@@ -55,8 +72,12 @@ function isClippedBySize(
                 break;
               }
 
+            // technically, 1×1 elements are (possibly) visible since they
+            // show one pixel of background. We assume this is used to hide
+            // elements and that the background is the same as the surrounding
+            // one.
             case "length":
-              if (dimension.value <= 1) {
+              if (dimension.value <= (hasNoScrollBar ? 1 : 0)) {
                 return true;
               } else {
                 break;
@@ -64,66 +85,53 @@ function isClippedBySize(
           }
         }
       }
-
-      if (
-        x.value === "auto" ||
-        x.value === "scroll" ||
-        y.value === "auto" ||
-        y.value === "scroll"
-      ) {
-        for (const dimension of [height, width]) {
-          switch (dimension.type) {
-            case "percentage":
-              if (dimension.value <= 0) {
-                return true;
-              } else {
-                break;
-              }
-
-            case "length":
-              if (dimension.value <= 0) {
-                return true;
-              } else {
-                break;
-              }
-          }
-        }
-      }
-    }
-
-    for (const parent of node.parent({ flattened: true })) {
-      if (isText(node) && isElement(parent)) {
-        const style = Style.from(parent, device, context);
-
-        const { value: x } = style.computed("overflow-x");
-
-        if (x.value === "hidden") {
-          const { value: indent } = style.computed("text-indent");
-          const { value: whitespace } = style.computed("white-space");
-
-          if (indent.value < 0 || whitespace.value === "nowrap") {
-            switch (indent.type) {
-              case "percentage":
-                if (abs(indent.value) >= 1) {
-                  return true;
-                }
-
-              case "length":
-                if (abs(indent.value) >= 999) {
-                  return true;
-                }
-            }
-          }
-        }
-      }
-
-      return isClipped(parent);
     }
 
     return false;
   };
 }
 
+/**
+ * Checks if an element is fully indented out of screen.
+ */
+function isClippedByIndent(device: Device, context: Context): Predicate<Node> {
+  return function isClipped(node: Node): boolean {
+    if (isElement(node)) {
+      const style = Style.from(node, device, context);
+
+      const { value: x } = style.computed("overflow-x");
+
+      if (x.value === "hidden") {
+        const { value: indent } = style.computed("text-indent");
+        const { value: whitespace } = style.computed("white-space");
+
+        if (indent.value < 0 || whitespace.value === "nowrap") {
+          switch (indent.type) {
+            case "percentage":
+              if (abs(indent.value) >= 1) {
+                return true;
+              } else {
+                break;
+              }
+
+            case "length":
+              if (abs(indent.value) >= 999) {
+                return true;
+              } else {
+                break;
+              }
+          }
+        }
+      }
+    }
+
+    return false;
+  };
+}
+
+/**
+ * Checks if an element is fully masked by a clipping shape.
+ */
 function isClippedByMasking(device: Device, context: Context): Predicate<Node> {
   return function isClipped(node: Node): boolean {
     if (isElement(node)) {
@@ -144,11 +152,6 @@ function isClippedByMasking(device: Device, context: Context): Predicate<Node> {
       }
     }
 
-    return node
-      .parent({
-        flattened: true,
-        nested: true,
-      })
-      .some(isClipped);
+    return false;
   };
 }

--- a/packages/alfa-rules/src/common/predicate/is-clipped.ts
+++ b/packages/alfa-rules/src/common/predicate/is-clipped.ts
@@ -13,6 +13,9 @@ const { and } = Refinement;
 
 const cache = Cache.empty<Device, Cache<Context, Cache<Node, boolean>>>();
 
+/**
+ * Checks if a node (or one of its ancestor) is fully clipped
+ */
 export function isClipped(
   device: Device,
   context: Context = Context.empty()
@@ -24,6 +27,7 @@ export function isClipped(
       .get(node, () =>
         test(
           or(
+            // Either it a clipped element
             and(
               isElement,
               or(
@@ -32,6 +36,7 @@ export function isClipped(
                 isClippedByMasking(device, context)
               )
             ),
+            // Or its parent is clipped
             (node: Node) =>
               node
                 .parent({
@@ -46,6 +51,7 @@ export function isClipped(
 }
 
 /**
+ * @internal
  * Checks if an element's size is reduced to 0 or 1 pixel, and overflow is
  * somehow hidden.
  */
@@ -97,7 +103,8 @@ function isClippedBySize(
 }
 
 /**
- * Checks if an element is fully indented out of screen.
+ * @internal
+ * Checks if an element is fully indented out of its box.
  */
 function isClippedByIndent(
   device: Device,

--- a/packages/alfa-rules/src/common/predicate/is-clipped.ts
+++ b/packages/alfa-rules/src/common/predicate/is-clipped.ts
@@ -51,7 +51,6 @@ export function isClipped(
 }
 
 /**
- * @internal
  * Checks if an element's size is reduced to 0 or 1 pixel, and overflow is
  * somehow hidden.
  */
@@ -84,7 +83,7 @@ function isClippedBySize(
               break;
             }
 
-          // technically, 1×1 elements are (possibly) visible since they
+          // Technically, 1×1 elements are (possibly) visible since they
           // show one pixel of background. We assume this is used to hide
           // elements and that the background is the same as the surrounding
           // one.
@@ -103,7 +102,6 @@ function isClippedBySize(
 }
 
 /**
- * @internal
  * Checks if an element is fully indented out of its box.
  */
 function isClippedByIndent(

--- a/packages/alfa-rules/src/common/predicate/is-visible.ts
+++ b/packages/alfa-rules/src/common/predicate/is-visible.ts
@@ -26,9 +26,6 @@ export function isVisible(device: Device, context?: Context): Predicate<Node> {
   return not(isInvisible(device, context));
 }
 
-/**
- * @internal
- */
 function isInvisible(device: Device, context?: Context): Predicate<Node> {
   const hasStyle = <N extends Property.Name>(
     name: N,
@@ -47,7 +44,7 @@ function isInvisible(device: Device, context?: Context): Predicate<Node> {
       isText,
       hasStyle("font-size", (size) => size.value === 0)
     ),
-    // Element with visibility ≠ "visible"
+    // Element with visibility != "visible"
     and(
       isElement,
       hasStyle("visibility", (visibility) => visibility.value !== "visible")

--- a/packages/alfa-rules/src/common/predicate/is-visible.ts
+++ b/packages/alfa-rules/src/common/predicate/is-visible.ts
@@ -27,11 +27,6 @@ export function isVisible(device: Device, context?: Context): Predicate<Node> {
 }
 
 function isInvisible(device: Device, context?: Context): Predicate<Node> {
-  const hasStyle = <N extends Property.Name>(
-    name: N,
-    predicate: Predicate<Style.Computed<N>>
-  ) => hasComputedStyle(device, context)(name, predicate);
-
   return or(
     not(isRendered(device, context)),
     isTransparent(device, context),
@@ -42,12 +37,17 @@ function isInvisible(device: Device, context?: Context): Predicate<Node> {
     // Text of size 0
     and(
       isText,
-      hasStyle("font-size", (size) => size.value === 0)
+      hasComputedStyle("font-size", (size) => size.value === 0, device, context)
     ),
     // Element with visibility != "visible"
     and(
       isElement,
-      hasStyle("visibility", (visibility) => visibility.value !== "visible")
+      hasComputedStyle(
+        "visibility",
+        (visibility) => visibility.value !== "visible",
+        device,
+        context
+      )
     ),
     // Most non-replaced elements with no visible children are not visible while
     // replaced elements are assumed to be replaced by something visible. Some

--- a/packages/alfa-rules/src/common/predicate/is-visible.ts
+++ b/packages/alfa-rules/src/common/predicate/is-visible.ts
@@ -1,12 +1,11 @@
 import { Device } from "@siteimprove/alfa-device";
 import { Element, Text, Node } from "@siteimprove/alfa-dom";
-import { Iterable } from "@siteimprove/alfa-iterable";
 import { Predicate } from "@siteimprove/alfa-predicate";
 import { Refinement } from "@siteimprove/alfa-refinement";
 import { Context } from "@siteimprove/alfa-selector";
-import { Style } from "@siteimprove/alfa-style";
 
 import {
+  hasComputedStyle,
   isClipped,
   isOffscreen,
   isRendered,
@@ -14,70 +13,59 @@ import {
   isTransparent,
 } from "../predicate";
 
-const { every } = Iterable;
-const { not } = Predicate;
-const { and, or } = Refinement;
+const { nor, not, or } = Predicate;
+const { and } = Refinement;
 const { hasName, isElement } = Element;
 const { isText } = Text;
 
+/**
+ * Checks if a node is visible
+ */
 export function isVisible(device: Device, context?: Context): Predicate<Node> {
-  return and(
-    isRendered(device, context),
-    not(isTransparent(device, context)),
-    not(
-      and(
-        or(isElement, isText),
-        or(isClipped(device, context), isOffscreen(device, context))
+  return not(isInvisible(device, context));
+}
+
+function isInvisible(device: Device, context?: Context): Predicate<Node> {
+  return or(
+    not(isRendered(device, context)),
+    isTransparent(device, context),
+    isClipped(device, context),
+    isOffscreen(device, context),
+    and(isText, (text) => text.data.trim() === ""),
+    and(isText, (text) =>
+      text
+        .parent({ flattened: true })
+        .filter(isElement)
+        .some(
+          hasComputedStyle(
+            "font-size",
+            (size) => size.value === 0,
+            device,
+            context
+          )
+        )
+    ),
+    and(
+      isElement,
+      hasComputedStyle(
+        "visibility",
+        (visibility) => visibility.value !== "visible",
+        device,
+        context
       )
     ),
-    (node) => {
-      if (
-        isElement(node) &&
-        Style.from(node, device, context)
-          .computed("visibility")
-          .some((visibility) => visibility.value !== "visible")
-      ) {
-        return false;
-      }
-
-      if (isText(node)) {
-        if (node.data.trim() === "") {
-          return false;
-        }
-
-        if (
-          node
-            .parent({
-              flattened: true,
-            })
-            .filter(isElement)
-            .some((element) =>
-              Style.from(element, device, context)
-                .computed("font-size")
-                .some((size) => size.value === 0)
-            )
-        ) {
-          return false;
-        }
-      }
-
-      return true;
-    },
     // Most non-replaced elements with no visible children are not visible while
     // replaced elements are assumed to be replaced by something visible. Some
     // non-replaced elements are, however, visible even when empty.
-    not(
-      and(
-        isElement,
-        and(not(or(isReplaced, isVisibleWhenEmpty)), (element) =>
-          every(
-            element.children({
-              nested: true,
-              flattened: true,
-            }),
-            not(isVisible(device, context))
-          )
-        )
+    and(
+      isElement,
+      and(nor(isReplaced, isVisibleWhenEmpty), (element) =>
+        element
+          .children({
+            nested: true,
+            flattened: true,
+          })
+          .every(isInvisible(device, context))
       )
     )
   );

--- a/packages/alfa-rules/test/common/predicate/is-visible.spec.tsx
+++ b/packages/alfa-rules/test/common/predicate/is-visible.spec.tsx
@@ -418,3 +418,27 @@ test(`isVisible() returns false for a text node with a parent element with
   t.equal(isVisible(text), false);
   t.equal(isVisible(element), false);
 });
+
+test(`isVisible() returns false for an element with a fully clipped ancestor`, (t) => {
+  const spanSize = <span>Hello World</span>;
+  const spanIndent = <span>Hello World</span>;
+  const spanMask = <span>Hello World</span>;
+
+  h.document([
+    <div style={{ height: "0px", width: "0px", overflow: "hidden" }}>
+      {spanSize}
+    </div>,
+    <div
+      style={{ textIndent: "100%", whiteSpace: "nowrap", overflow: "hidden" }}
+    >
+      {spanIndent}
+    </div>,
+    <div style={{ clip: "rect(1px, 1px, 1px, 1px)", position: "absolute" }}>
+      {spanMask}
+    </div>,
+  ]);
+
+  for (const target of [spanSize, spanIndent, spanMask]) {
+    t.equal(isVisible(target), false);
+  }
+});

--- a/packages/alfa-rules/tsconfig.json
+++ b/packages/alfa-rules/tsconfig.json
@@ -28,6 +28,7 @@
     "src/common/predicate/has-box-shadow.ts",
     "src/common/predicate/has-cascaded-value-declared-in-inline-style.ts",
     "src/common/predicate/has-child.ts",
+    "src/common/predicate/has-computed-style.ts",
     "src/common/predicate/has-descendant.ts",
     "src/common/predicate/has-explicit-role.ts",
     "src/common/predicate/has-heading-level.ts",


### PR DESCRIPTION
Resolves #731 

Plus a bit a refactor/streamlining of `isVisible` and `isClipped`.