### PR TITLE
Accept arbitrarily deeply nested children in `jsx()`

### DIFF
--- a/docs/review/api/alfa-dom.api.md
+++ b/docs/review/api/alfa-dom.api.md
@@ -555,7 +555,7 @@ export namespace jsx {
     // (undocumented)
     export type Child = Node | string;
     // (undocumented)
-    export type Children = Array<Child | Children>;
+    export type Children = (Child | Children)[];
     // (undocumented)
     export namespace JSX {
         // Warning: (ae-forgotten-export) The symbol "dom" needs to be exported by the entry point index.d.ts

--- a/docs/review/api/alfa-dom.api.md
+++ b/docs/review/api/alfa-dom.api.md
@@ -50,7 +50,7 @@ export class Attribute extends Node {
     toString(): string;
     // (undocumented)
     get value(): string;
-    }
+}
 
 // @public (undocumented)
 export namespace Attribute {
@@ -184,7 +184,7 @@ export class Declaration implements Equatable, Serializable {
     toString(): string;
     // (undocumented)
     get value(): string;
-    }
+}
 
 // @public (undocumented)
 export namespace Declaration {
@@ -548,12 +548,14 @@ function isEditingHost(element: Element): boolean;
 function isSuggestedFocusable(element: Element): boolean;
 
 // @public (undocumented)
-export function jsx(name: string, properties?: jsx.Properties | null, ...children: Array<jsx.Child>): Element;
+export function jsx(name: string, properties?: jsx.Properties | null, ...children: jsx.Children): Element;
 
 // @public (undocumented)
 export namespace jsx {
     // (undocumented)
     export type Child = Node | string;
+    // (undocumented)
+    export type Children = Array<Child | Children>;
     // (undocumented)
     export namespace JSX {
         // Warning: (ae-forgotten-export) The symbol "dom" needs to be exported by the entry point index.d.ts
@@ -785,10 +787,10 @@ export namespace Node {
         };
         // (undocumented)
         "@type": [
-            "ptr:Pointer",
-            "ptr:SinglePointer",
-            "ptr:ExpressionPointer",
-            "ptr:XPathPointer"
+        "ptr:Pointer",
+        "ptr:SinglePointer",
+        "ptr:ExpressionPointer",
+        "ptr:XPathPointer"
         ];
         // (undocumented)
         "ptr:expression": string;
@@ -1175,7 +1177,6 @@ export namespace Type {
         type: "type";
     }
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "execa": "^5.1.1",
     "minimist": "^1.2.5",
     "prettier": "^2.3.1",
-    "typescript": "^4.3.2"
+    "typescript": "^4.3.5"
   },
   "resolutions": {
     "@microsoft/api-documenter": "patch:@microsoft/api-documenter@7.12.7#.yarn/patches/api-documenter.patch"

--- a/packages/alfa-aria/test/node.spec.tsx
+++ b/packages/alfa-aria/test/node.spec.tsx
@@ -519,27 +519,20 @@ test(`.from() doesn't expose children of elements with roles that designate
 });
 
 test(`.from() correctly sets \`aria-setsize\` and \`aria-posinset\``, (t) => {
-  const first = <li>First</li>;
-  const second = <li>Second</li>;
-  const third = <li>Third</li>;
-  const fourth = <li>Fourth</li>;
+  const items = [
+    <li>First</li>,
+    <li>Second</li>,
+    <li>Third</li>,
+    <li>Fourth</li>,
+  ];
 
-  const _ = (
-    <ul>
-      {first}
-      {second}
-      {third}
-      {fourth}
-    </ul>
-  );
-
-  const items = [first, second, third, fourth];
+  <ul>{items}</ul>;
 
   for (let i = 0; i < items.length; i++) {
     const node = Node.from(items[i], device);
 
-    t.deepEqual(node.attribute("aria-setsize").get().value, `${items.length}`);
+    t.equal(node.attribute("aria-setsize").get().value, `${items.length}`);
 
-    t.deepEqual(node.attribute("aria-posinset").get().value, `${i + 1}`);
+    t.equal(node.attribute("aria-posinset").get().value, `${i + 1}`);
   }
 });

--- a/packages/alfa-dom/src/jsx-runtime.ts
+++ b/packages/alfa-dom/src/jsx-runtime.ts
@@ -25,7 +25,7 @@ export function jsx(
  */
 export function jsxs(
   name: string,
-  properties: _jsx.Properties & { children?: Array<_jsx.Child> }
+  properties: _jsx.Properties & { children?: _jsx.Children }
 ): Element {
   const { children, ...rest } = properties;
 
@@ -41,7 +41,7 @@ export function jsxs(
  */
 export function jsxDEV(
   name: string,
-  properties: _jsx.Properties & { children?: _jsx.Child | Array<_jsx.Child> }
+  properties: _jsx.Properties & { children?: _jsx.Child | _jsx.Children }
 ): Element {
   const { children, ...rest } = properties;
 

--- a/packages/alfa-dom/src/jsx.ts
+++ b/packages/alfa-dom/src/jsx.ts
@@ -12,7 +12,7 @@ const { entries } = Object;
 export function jsx(
   name: string,
   properties: jsx.Properties | null = null,
-  ...children: Array<jsx.Child>
+  ...children: jsx.Children
 ): Element {
   const attributes: Record<string, string | boolean> = {};
   const style: Record<string, string> = {};
@@ -37,7 +37,7 @@ export function jsx(
     }
   }
 
-  return h(name, attributes, children, style);
+  return h(name, attributes, children.flat(undefined), style);
 }
 
 /**
@@ -45,6 +45,8 @@ export function jsx(
  */
 export namespace jsx {
   export type Child = Node | string;
+
+  export type Children = Array<Child | Children>;
 
   export interface Properties {
     [name: string]: unknown;

--- a/packages/alfa-dom/src/jsx.ts
+++ b/packages/alfa-dom/src/jsx.ts
@@ -37,7 +37,7 @@ export function jsx(
     }
   }
 
-  return h(name, attributes, children.flat(undefined), style);
+  return h(name, attributes, children.flat(Infinity), style);
 }
 
 /**

--- a/packages/alfa-dom/src/jsx.ts
+++ b/packages/alfa-dom/src/jsx.ts
@@ -37,7 +37,12 @@ export function jsx(
     }
   }
 
-  return h(name, attributes, children.flat(Infinity), style);
+  return h(
+    name,
+    attributes,
+    (children as Array<jsx.Child>).flat(Infinity),
+    style
+  );
 }
 
 /**
@@ -46,7 +51,12 @@ export function jsx(
 export namespace jsx {
   export type Child = Node | string;
 
-  export type Children = Array<Child | Children>;
+  /**
+   * @remarks
+   * This type is declared using the short array syntax (`[]`) to avoid issues
+   * with circular generic references.
+   */
+  export type Children = (Child | Children)[];
 
   export interface Properties {
     [name: string]: unknown;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9039,7 +9039,7 @@ resolve@~1.19.0:
   languageName: node
   linkType: hard
 
-typescript@^4.3.5:
+"typescript@^4.3.5, typescript@~4.3.2":
   version: 4.3.5
   resolution: "typescript@npm:4.3.5"
   bin:
@@ -9049,33 +9049,13 @@ typescript@^4.3.5:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.3.5#~builtin<compat/typescript>":
+"typescript@patch:typescript@^4.3.5#~builtin<compat/typescript>, typescript@patch:typescript@~4.3.2#~builtin<compat/typescript>":
   version: 4.3.5
   resolution: "typescript@patch:typescript@npm%3A4.3.5#~builtin<compat/typescript>::version=4.3.5&hash=34ad7d"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 94acb9409712c7073eaecb328cf9be872e4882c62d991cc3d9b53d59f4844d72afbf75818471e086bfb26c444e3a411667a9517f2be2518f8be95bab9fa50ae9
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@~4.3.2#~builtin<compat/typescript>":
-  version: 4.3.4
-  resolution: "typescript@patch:typescript@npm%3A4.3.4#~builtin<compat/typescript>::version=4.3.4&hash=34ad7d"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 3b9d89d6d34162316668a4c1eff51451d5387447d33e9608d526fbd3eb1b8bcf370a134a3546a6e4b429e76855cbf61374d17245612643dd74e7ae0cf29ca299
-  languageName: node
-  linkType: hard
-
-typescript@~4.3.2:
-  version: 4.3.4
-  resolution: "typescript@npm:4.3.4"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 75e1f2769c7ff38c718523d05eaf1c2611dbf92c0ab0f85f603ead9bb23416af2009a5dac46e76ef6a207a8508fa53f51b43a41f2a91b1241b53cd744c16128c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2405,7 +2405,7 @@ __metadata:
     execa: ^5.1.1
     minimist: ^1.2.5
     prettier: ^2.3.1
-    typescript: ^4.3.2
+    typescript: ^4.3.5
   languageName: unknown
   linkType: soft
 
@@ -9039,23 +9039,43 @@ resolve@~1.19.0:
   languageName: node
   linkType: hard
 
-"typescript@^4.3.2, typescript@~4.3.2":
-  version: 4.3.4
-  resolution: "typescript@npm:4.3.4"
+typescript@^4.3.5:
+  version: 4.3.5
+  resolution: "typescript@npm:4.3.5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 75e1f2769c7ff38c718523d05eaf1c2611dbf92c0ab0f85f603ead9bb23416af2009a5dac46e76ef6a207a8508fa53f51b43a41f2a91b1241b53cd744c16128c
+  checksum: bab033b5e2b0790dd35b77fd005df976ef80b8d84fd2c6e63cc31808151875beae9216e5a315fe7068e8499905c3c354248fe83272cdfc13b7705635f0c66c97
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.3.2#~builtin<compat/typescript>, typescript@patch:typescript@~4.3.2#~builtin<compat/typescript>":
+"typescript@patch:typescript@^4.3.5#~builtin<compat/typescript>":
+  version: 4.3.5
+  resolution: "typescript@patch:typescript@npm%3A4.3.5#~builtin<compat/typescript>::version=4.3.5&hash=34ad7d"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 94acb9409712c7073eaecb328cf9be872e4882c62d991cc3d9b53d59f4844d72afbf75818471e086bfb26c444e3a411667a9517f2be2518f8be95bab9fa50ae9
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@~4.3.2#~builtin<compat/typescript>":
   version: 4.3.4
   resolution: "typescript@patch:typescript@npm%3A4.3.4#~builtin<compat/typescript>::version=4.3.4&hash=34ad7d"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 3b9d89d6d34162316668a4c1eff51451d5387447d33e9608d526fbd3eb1b8bcf370a134a3546a6e4b429e76855cbf61374d17245612643dd74e7ae0cf29ca299
+  languageName: node
+  linkType: hard
+
+typescript@~4.3.2:
+  version: 4.3.4
+  resolution: "typescript@npm:4.3.4"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 75e1f2769c7ff38c718523d05eaf1c2611dbf92c0ab0f85f603ead9bb23416af2009a5dac46e76ef6a207a8508fa53f51b43a41f2a91b1241b53cd744c16128c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This was actually already accepted, but the types weren't accounting for it and so neither was the code 🙈 