### PR TITLE
Fix naming from subtree and implicitly referenced `<label>` elements

### DIFF
--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -124,19 +124,18 @@ const nameFromAttribute = (element: Element, ...attributes: Array<string>) => {
   return None;
 };
 
-const nameFromChild = (predicate: Predicate<Element>) => (
-  element: Element,
-  device: Device,
-  state: Name.State
-) => {
-  for (const child of element.children().filter(isElement).find(predicate)) {
-    return Name.fromDescendants(child, device, state.visit(child)).map((name) =>
-      Name.of(name.value, [Name.Source.descendant(element, name)])
-    );
-  }
-
-  return None;
-};
+const nameFromChild =
+  (predicate: Predicate<Element>) =>
+  (element: Element, device: Device, state: Name.State) =>
+    element
+      .children()
+      .filter(isElement)
+      .find(predicate)
+      .flatMap((child) =>
+        Name.fromDescendants(child, device, state.visit(child)).map((name) =>
+          Name.of(name.value, [Name.Source.descendant(element, name)])
+        )
+      );
 
 const ids = Cache.empty<Node, Map<string, Element>>();
 
@@ -183,7 +182,7 @@ const nameFromLabel = (element: Element, device: Device, state: Name.State) => {
     Name.fromNode(
       element,
       device,
-      state.reference(None).recurse(true).descend(false)
+      state.reference(Option.of(element)).recurse(true).descend(false)
     ).map((name) => [name, element] as const)
   );
 

--- a/packages/alfa-aria/src/name.ts
+++ b/packages/alfa-aria/src/name.ts
@@ -142,7 +142,8 @@ export namespace Name {
     }
 
     export class Descendant
-      implements Equatable, Serializable<Descendant.JSON> {
+      implements Equatable, Serializable<Descendant.JSON>
+    {
       public static of(element: Element, name: Name): Descendant {
         return new Descendant(element, name);
       }
@@ -692,7 +693,7 @@ export namespace Name {
         // step produces an empty name.
         if (
           !state.isReferencing &&
-          !role.every((role) => role.isNamedBy("contents"))
+          !role.some((role) => role.isNamedBy("contents"))
         ) {
           return None;
         }

--- a/packages/alfa-aria/test/node.spec.tsx
+++ b/packages/alfa-aria/test/node.spec.tsx
@@ -543,3 +543,54 @@ test(`.from() correctly sets \`aria-setsize\` and \`aria-posinset\``, (t) => {
     t.deepEqual(node.attribute("aria-posinset").get().value, `${i + 1}`);
   }
 });
+
+test(`.from() behaves when encountering an element with global properties where
+      the element should not be named by its subtree`, (t) => {
+  const div = (
+    <div aria-hidden="false">
+      <label>
+        Foo <input />
+      </label>
+    </div>
+  );
+
+  t.deepEqual(Node.from(div, device).toJSON(), {
+    type: "element",
+    node: "/div[1]",
+    role: null,
+    name: null,
+    attributes: [
+      {
+        name: "aria-hidden",
+        value: "false",
+      },
+    ],
+    children: [
+      {
+        type: "container",
+        node: "/div[1]/label[1]",
+        children: [
+          {
+            type: "text",
+            node: "/div[1]/label[1]/text()[1]",
+            name: "Foo ",
+            children: [],
+          },
+          {
+            type: "element",
+            node: "/div[1]/label[1]/input[1]",
+            role: "textbox",
+            name: "Foo",
+            attributes: [
+              {
+                name: "aria-checked",
+                value: "false",
+              },
+            ],
+            children: [],
+          },
+        ],
+      },
+    ],
+  });
+});


### PR DESCRIPTION
A quantifier was incorrect and a referrer was missing when computing names of implicit `<label>` references.

Resolves #808