### PR TITLE
SIA R66 and R69: return `cantTell` when encountering a text shadow

### DIFF
--- a/docs/review/api/alfa-css.api.md
+++ b/docs/review/api/alfa-css.api.md
@@ -72,7 +72,7 @@ export class Block implements Iterable<Token>, Equatable, Serializable {
     toString(): string;
     // (undocumented)
     get value(): Array<Token>;
-    }
+}
 
 // @public (undocumented)
 export namespace Block {
@@ -333,7 +333,7 @@ export namespace Calculation {
         get type(): "value";
         // (undocumented)
         get value(): Numeric;
-        }
+    }
     // (undocumented)
     export namespace Value {
         // (undocumented)
@@ -428,7 +428,7 @@ export class Component implements Iterable<Token>, Equatable, Serializable {
     toString(): string;
     // (undocumented)
     get value(): Array<Token>;
-    }
+}
 
 // @public (undocumented)
 export namespace Component {
@@ -488,7 +488,7 @@ export class Declaration implements Iterable<Token>, Equatable, Serializable {
     toString(): string;
     // (undocumented)
     get value(): Array<Token>;
-    }
+}
 
 // @public (undocumented)
 export namespace Declaration {
@@ -604,7 +604,7 @@ class Function_2 implements Iterable<Token>, Equatable, Serializable {
     toString(): string;
     // (undocumented)
     get value(): Array<Token>;
-    }
+}
 
 // @public (undocumented)
 namespace Function_2 {
@@ -622,7 +622,6 @@ namespace Function_2 {
     const // (undocumented)
     parse: <T>(name?: string | undefined, body?: Parser<Slice<Token>, T, string, []> | undefined) => Parser<Slice<Token>, readonly [Function_2, T], string, []>;
 }
-
 export { Function_2 as Function }
 
 // @public (undocumented)
@@ -739,7 +738,7 @@ export class Hex extends Value<"color"> {
     get type(): "color";
     // (undocumented)
     get value(): number;
-    }
+}
 
 // @public (undocumented)
 export namespace Hex {
@@ -944,7 +943,7 @@ export class Keyword<T extends string = string> extends Value<"keyword"> {
     get type(): "keyword";
     // (undocumented)
     get value(): T;
-    }
+}
 
 // @public (undocumented)
 export namespace Keyword {
@@ -982,7 +981,7 @@ export class Length<U extends Unit.Length = Unit.Length> extends Dimension<"leng
     // (undocumented)
     static of<U extends Unit.Length>(value: number, unit: U): Length<U>;
     // (undocumented)
-    toJSON(): Length.JSON;
+    toJSON(): Length.JSON<U>;
     // (undocumented)
     toString(): string;
     // (undocumented)
@@ -1000,9 +999,9 @@ export namespace Length {
     const // (undocumented)
     parse: Parser<Slice<Token>, Length, string>;
     // (undocumented)
-    export interface JSON extends Dimension.JSON<"length"> {
+    export interface JSON<U extends Unit.Length = Unit.Length> extends Dimension.JSON<"length"> {
         // (undocumented)
-        unit: Unit.Length;
+        unit: U;
     }
 }
 
@@ -1058,7 +1057,7 @@ export namespace Linear {
         get type(): "corner";
         // (undocumented)
         get vertical(): Position.Vertical;
-        }
+    }
     // (undocumented)
     export namespace Corner {
         // (undocumented)
@@ -1157,7 +1156,7 @@ export class Matrix extends Value<"transform"> {
     get type(): "transform";
     // (undocumented)
     get values(): Matrix.Values<Number_2>;
-    }
+}
 
 // @public (undocumented)
 export namespace Matrix {
@@ -1172,30 +1171,30 @@ export namespace Matrix {
     }
     // (undocumented)
     export type Values<T> = [
-        [
-            T,
-            T,
-            T,
-            T
-        ],
-        [
-            T,
-            T,
-            T,
-            T
-        ],
-        [
-            T,
-            T,
-            T,
-            T
-        ],
-        [
-            T,
-            T,
-            T,
-            T
-        ]
+    [
+    T,
+    T,
+    T,
+    T
+    ],
+    [
+    T,
+    T,
+    T,
+    T
+    ],
+    [
+    T,
+    T,
+    T,
+    T
+    ],
+    [
+    T,
+    T,
+    T,
+    T
+    ]
     ];
     const // (undocumented)
     parse: Parser<Slice<Token>, Matrix, string>;
@@ -1312,7 +1311,6 @@ namespace Number_2 {
     const // (undocumented)
     parse: Parser<Slice<Token>, Number_2, string>;
 }
-
 export { Number_2 as Number }
 
 // @public (undocumented)
@@ -1432,7 +1430,7 @@ export class Polygon<F extends Polygon.Fill = Polygon.Fill, V extends Length | P
     get type(): "basic-shape";
     // (undocumented)
     get vertices(): ReadonlyArray<Polygon.Vertex<V>>;
-    }
+}
 
 // @public (undocumented)
 export namespace Polygon {
@@ -1471,7 +1469,7 @@ export class Position<H extends Position.Component<Position.Horizontal> = Positi
     get type(): "position";
     // (undocumented)
     get vertical(): V;
-    }
+}
 
 // @public (undocumented)
 export namespace Position {
@@ -1639,7 +1637,7 @@ export namespace Radial {
         get type(): "ellipse";
         // (undocumented)
         get vertical(): R;
-        }
+    }
     // (undocumented)
     export namespace Ellipse {
         // (undocumented)
@@ -1751,7 +1749,7 @@ export class Radius<R extends Length | Percentage | Radius.Side = Length | Perce
     get type(): "basic-shape";
     // (undocumented)
     get value(): R;
-    }
+}
 
 // @public (undocumented)
 export namespace Radius {
@@ -1907,7 +1905,7 @@ export class Rotate<A extends Angle = Angle> extends Value<"transform"> {
     get y(): Number_2;
     // (undocumented)
     get z(): Number_2;
-    }
+}
 
 // @public (undocumented)
 export namespace Rotate {
@@ -1950,7 +1948,7 @@ export class Scale extends Value<"transform"> {
     get x(): Number_2;
     // (undocumented)
     get y(): Number_2;
-    }
+}
 
 // @public (undocumented)
 export namespace Scale {
@@ -1995,7 +1993,7 @@ export class Shadow<V extends Length = Length, H extends Length = V, B extends L
     get type(): "shadow";
     // (undocumented)
     get vertical(): V;
-    }
+}
 
 // @public (undocumented)
 export namespace Shadow {
@@ -2073,7 +2071,7 @@ export class Skew<X extends Angle = Angle, Y extends Angle = Angle> extends Valu
     get x(): X;
     // (undocumented)
     get y(): Y;
-    }
+}
 
 // @public (undocumented)
 export namespace Skew {
@@ -2108,7 +2106,7 @@ class String_2 extends Value<"string"> {
     get type(): "string";
     // (undocumented)
     get value(): string;
-    }
+}
 
 // @public (undocumented)
 namespace String_2 {
@@ -2122,7 +2120,6 @@ namespace String_2 {
     const // (undocumented)
     parse: Parser<Slice<Token>, String_2, string>;
 }
-
 export { String_2 as String }
 
 // @public (undocumented)
@@ -2155,7 +2152,7 @@ export namespace Token {
         get type(): "at-keyword";
         // (undocumented)
         get value(): string;
-        }
+    }
     // (undocumented)
     export namespace AtKeyword {
         // (undocumented)
@@ -2375,7 +2372,7 @@ export namespace Token {
         get type(): "delim";
         // (undocumented)
         get value(): number;
-        }
+    }
     const // (undocumented)
     url: typeof URL.of, // (undocumented)
     isURL: typeof URL.isURL;
@@ -2413,7 +2410,7 @@ export namespace Token {
         get unit(): string;
         // (undocumented)
         get value(): number;
-        }
+    }
     // (undocumented)
     export namespace Dimension {
         // (undocumented)
@@ -2452,7 +2449,7 @@ export namespace Token {
         get type(): "function";
         // (undocumented)
         get value(): string;
-        }
+    }
     // (undocumented)
     export namespace Function {
         // (undocumented)
@@ -2486,7 +2483,7 @@ export namespace Token {
         get type(): "hash";
         // (undocumented)
         get value(): string;
-        }
+    }
     // (undocumented)
     export namespace Hash {
         // (undocumented)
@@ -2517,7 +2514,7 @@ export namespace Token {
         get type(): "ident";
         // (undocumented)
         get value(): string;
-        }
+    }
     const // (undocumented)
     number: typeof Number.of, // (undocumented)
     isNumber: typeof Number.isNumber;
@@ -2555,7 +2552,7 @@ export namespace Token {
         get type(): "number";
         // (undocumented)
         get value(): number;
-        }
+    }
     const // (undocumented)
     percentage: typeof Percentage.of, // (undocumented)
     isPercentage: typeof Percentage.isPercentage;
@@ -2755,7 +2752,7 @@ export namespace Token {
         get type(): "percentage";
         // (undocumented)
         get value(): number;
-        }
+    }
     // (undocumented)
     export namespace Percentage {
         // (undocumented)
@@ -2821,7 +2818,7 @@ export namespace Token {
         get type(): "string";
         // (undocumented)
         get value(): string;
-        }
+    }
     // (undocumented)
     export namespace String {
         // (undocumented)
@@ -2855,7 +2852,7 @@ export namespace Token {
         get type(): "url";
         // (undocumented)
         get value(): string;
-        }
+    }
     // (undocumented)
     export namespace URL {
         // (undocumented)
@@ -2952,7 +2949,7 @@ export class Translate<X extends Length | Percentage = Length | Percentage, Y ex
     get y(): Y;
     // (undocumented)
     get z(): Z;
-    }
+}
 
 // @public (undocumented)
 export namespace Translate {
@@ -3043,7 +3040,7 @@ export class URL extends Value<"url"> {
     get type(): "url";
     // (undocumented)
     get url(): string;
-    }
+}
 
 // @public (undocumented)
 export namespace URL {
@@ -3085,7 +3082,6 @@ export namespace Value {
         type: T;
     }
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/alfa-css/src/value/length.ts
+++ b/packages/alfa-css/src/value/length.ts
@@ -17,7 +17,8 @@ const { map, either } = Parser;
  */
 export class Length<U extends Unit.Length = Unit.Length>
   extends Dimension<"length", Unit.Length, U>
-  implements Convertible<Unit.Length.Absolute> {
+  implements Convertible<Unit.Length.Absolute>
+{
   public static of<U extends Unit.Length>(value: number, unit: U): Length<U> {
     return new Length(value, unit);
   }
@@ -75,7 +76,7 @@ export class Length<U extends Unit.Length = Unit.Length>
     hash.writeString(this._unit);
   }
 
-  public toJSON(): Length.JSON {
+  public toJSON(): Length.JSON<U> {
     return {
       type: "length",
       value: this._value,
@@ -92,8 +93,9 @@ export class Length<U extends Unit.Length = Unit.Length>
  * @public
  */
 export namespace Length {
-  export interface JSON extends Dimension.JSON<"length"> {
-    unit: Unit.Length;
+  export interface JSON<U extends Unit.Length = Unit.Length>
+    extends Dimension.JSON<"length"> {
+    unit: U;
   }
 
   export function isLength(value: unknown): value is Length {

--- a/packages/alfa-rules/src/common/expectation/get-colors.ts
+++ b/packages/alfa-rules/src/common/expectation/get-colors.ts
@@ -74,6 +74,14 @@ export function getBackground(
   device: Device = Device.standard(),
   fakeLastOpacity?: number
 ): Option<Array<RGB<Percentage, Percentage>>> {
+  // If the element has a text-shadow, we don't try to guess how it looks and
+  // ask the user for help.
+  if (
+    Style.from(element, device).computed("text-shadow").value.type !== "keyword"
+  ) {
+    return None;
+  }
+
   return getLayers(element, device, fakeLastOpacity).map((layers) =>
     layers.reduce<Array<RGB<Percentage, Percentage>>>(
       (backdrops, layer) =>

--- a/packages/alfa-rules/test/sia-r69/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r69/rule.spec.tsx
@@ -438,3 +438,12 @@ test(`evaluate() cannot tell when a background has a fixed size`, async (t) => {
 
   t.deepEqual(await evaluate(R69, { document }), [cantTell(R69, target)]);
 });
+
+test(`evaluate() cannot tell when encountering a text shadow`, async (t) => {
+  const target = h.text("Hello World");
+
+  const div = <div style={{ textShadow: "1px 1px" }}>{target}</div>;
+  const document = h.document([div]);
+
+  t.deepEqual(await evaluate(R69, { document }), [cantTell(R69, target)]);
+});

--- a/packages/alfa-style/src/index.ts
+++ b/packages/alfa-style/src/index.ts
@@ -125,6 +125,7 @@ import "./property/text-decoration-thickness";
 import "./property/text-indent";
 import "./property/text-overflow";
 import "./property/text-transform";
+import "./property/text-shadow";
 import "./property/top";
 import "./property/transform";
 import "./property/visibility";

--- a/packages/alfa-style/src/property/text-shadow.ts
+++ b/packages/alfa-style/src/property/text-shadow.ts
@@ -1,0 +1,109 @@
+import {
+  Color,
+  Current,
+  Keyword,
+  Length,
+  Percentage,
+  RGB,
+  System,
+  Token,
+} from "@siteimprove/alfa-css";
+import { Option } from "@siteimprove/alfa-option";
+import { Parser } from "@siteimprove/alfa-parser";
+import { Slice } from "@siteimprove/alfa-slice";
+
+import { Property } from "../property";
+import { Resolver } from "../resolver";
+import { Tuple } from "./value/tuple";
+
+const { isKeyword } = Keyword;
+const { either, map, option, separated } = Parser;
+
+declare module "../property" {
+  interface Longhands {
+    "text-shadow": Property<Specified, Computed>;
+  }
+}
+
+/**
+ * @internal
+ */
+export type Specified =
+  | Keyword<"none">
+  | Tuple<[Option<Color>, Specified.Offset, Option<Length>]>;
+
+namespace Specified {
+  export type Offset = Tuple<[Length, Length]>;
+}
+
+/**
+ * @internal
+ */
+export type Computed =
+  | Keyword<"none">
+  | Tuple<
+      [
+        // Technically, the color always compute, but to a UA dependent value
+        // if none was specified.
+        // Given our current use case, we can keep None in that case.
+        Option<RGB<Percentage, Percentage> | Current | System>,
+        Computed.Offset,
+        Length<"px">
+      ]
+    >;
+
+namespace Computed {
+  export type Offset = Tuple<[Length<"px">, Length<"px">]>;
+}
+
+const parseOffset = map(
+  separated(Length.parse, Token.parseWhitespace),
+  ([x, y]) => Tuple.of(x, y)
+);
+
+const parseLengths = separated(
+  parseOffset,
+  Token.parseWhitespace,
+  option(Length.parse)
+);
+
+/**
+ * @internal
+ */
+export const parse = either<Slice<Token>, Specified, string>(
+  Keyword.parse("none"),
+  map(
+    separated(parseLengths, Token.parseWhitespace, option(Color.parse)),
+    ([[offset, blur], color]) => Tuple.of(color, offset, blur)
+  ),
+  map(
+    separated(option(Color.parse), Token.parseWhitespace, parseLengths),
+    ([color, [offset, blur]]) => Tuple.of(color, offset, blur)
+  )
+);
+
+/**
+ * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/text-shadow}
+ * @internal
+ */
+export default Property.register(
+  "text-shadow",
+  Property.of<Specified, Computed>(Keyword.of("none"), parse, (shadow, style) =>
+    shadow.map((shadow) => {
+      if (isKeyword(shadow)) {
+        return shadow;
+      }
+
+      const [color, offset, blur] = shadow.values;
+      const [x, y] = offset.values;
+
+      return Tuple.of(
+        color.map(Resolver.color),
+        Tuple.of(Resolver.length(x, style), Resolver.length(y, style)),
+        blur
+          .map((blur) => Resolver.length(blur, style))
+          .getOrElse(() => Length.of(0, "px"))
+      );
+    })
+  )
+);

--- a/packages/alfa-style/src/property/text-shadow.ts
+++ b/packages/alfa-style/src/property/text-shadow.ts
@@ -5,19 +5,15 @@ import {
   Length,
   Percentage,
   RGB,
+  Shadow,
   System,
   Token,
-  Unit,
-  Value,
 } from "@siteimprove/alfa-css";
-import { Hash } from "@siteimprove/alfa-hash";
-import { Option } from "@siteimprove/alfa-option";
 import { Parser } from "@siteimprove/alfa-parser";
 import { Slice } from "@siteimprove/alfa-slice";
 
 import { Property } from "../property";
 import { Resolver } from "../resolver";
-import { Tuple } from "./value/tuple";
 
 const { isKeyword } = Keyword;
 const { either, left, map, option, pair, right, separated } = Parser;
@@ -31,23 +27,28 @@ declare module "../property" {
 /**
  * @internal
  */
-export type Specified = Keyword<"none"> | TextShadow;
+export type Specified = Keyword<"none"> | Shadow;
 
 /**
  * @internal
  */
 export type Computed =
   | Keyword<"none">
-  | TextShadow<RGB<Percentage, Percentage> | Current | System, "px">;
+  | Shadow<
+      Length<"px">,
+      Length<"px">,
+      Length<"px">,
+      Length<"px">,
+      RGB<Percentage, Percentage> | Current | System
+    >;
 
-const parseOffset = map(
-  separated(Length.parse, Token.parseWhitespace),
-  ([x, y]) => Tuple.of(x, y)
-);
+const parseOffset = separated(Length.parse, Token.parseWhitespace);
 
 const parseLengths = pair(
   parseOffset,
-  option(right(Token.parseWhitespace, Length.parse))
+  map(option(right(Token.parseWhitespace, Length.parse)), (blur) =>
+    blur.getOr(Length.of(0, "px"))
+  )
 );
 
 /**
@@ -57,13 +58,27 @@ export const parse = either<Slice<Token>, Specified, string>(
   Keyword.parse("none"),
   map(
     pair(parseLengths, option(right(Token.parseWhitespace, Color.parse))),
-    ([[offset, blur], color]) =>
-      TextShadow.of(color, offset, blur.getOr(Length.of(0, "px")))
+    ([[[x, y], blur], color]) =>
+      Shadow.of(
+        y,
+        x,
+        blur,
+        Length.of(0, "px"),
+        color.getOr(Color.current),
+        false
+      )
   ),
   map(
     pair(option(left(Color.parse, Token.parseWhitespace)), parseLengths),
-    ([color, [offset, blur]]) =>
-      TextShadow.of(color, offset, blur.getOr(Length.of(0, "px")))
+    ([color, [[x, y], blur]]) =>
+      Shadow.of(
+        y,
+        x,
+        blur,
+        Length.of(0, "px"),
+        color.getOr(Color.current),
+        false
+      )
   )
 );
 
@@ -82,109 +97,15 @@ export default Property.register(
           return shadow;
         }
 
-        const [x, y] = shadow.offset.values;
-
-        return TextShadow.of(
-          shadow.color.map(Resolver.color),
-          Tuple.of(Resolver.length(x, style), Resolver.length(y, style)),
-          Resolver.length(shadow.blur, style)
+        return Shadow.of(
+          Resolver.length(shadow.vertical, style),
+          Resolver.length(shadow.horizontal, style),
+          Resolver.length(shadow.blur, style),
+          Resolver.length(shadow.spread, style),
+          Resolver.color(shadow.color),
+          false
         );
       }),
     { inherits: true }
   )
 );
-
-class TextShadow<
-  C extends Color = Color,
-  U extends Unit.Length = Unit.Length
-> extends Value<"text-shadow"> {
-  public static of<
-    C extends Color = Color,
-    U extends Unit.Length = Unit.Length
-  >(
-    color: Option<C>,
-    offset: Tuple<[Length<U>, Length<U>]>,
-    blur: Length<U>
-  ): TextShadow<C, U> {
-    return new TextShadow<C, U>(color, offset, blur);
-  }
-
-  private readonly _color: Option<C>;
-  private readonly _offset: Tuple<[Length<U>, Length<U>]>;
-  private readonly _blur: Length<U>;
-
-  private constructor(
-    color: Option<C>,
-    offset: Tuple<[Length<U>, Length<U>]>,
-    blur: Length<U>
-  ) {
-    super();
-
-    this._color = color;
-    this._offset = offset;
-    this._blur = blur;
-  }
-
-  public get type(): "text-shadow" {
-    return "text-shadow";
-  }
-
-  public get color(): Option<C> {
-    return this._color;
-  }
-
-  public get offset(): Tuple<[Length<U>, Length<U>]> {
-    return this._offset;
-  }
-
-  public get blur(): Length<U> {
-    return this._blur;
-  }
-
-  public equals(value: TextShadow): boolean;
-
-  public equals(value: unknown): value is this;
-
-  public equals(value: unknown): boolean {
-    return (
-      value instanceof TextShadow &&
-      value._color.equals(this._color) &&
-      value._offset.equals(this._offset) &&
-      value._blur.equals(this._blur)
-    );
-  }
-
-  public hash(hash: Hash): void {
-    this._color.hash(hash);
-    this._offset.hash(hash);
-    this._blur.hash(hash);
-  }
-
-  public toJSON(): TextShadow.JSON<C, U> {
-    return {
-      type: "text-shadow",
-      color: this._color.toJSON(),
-      offset: this._offset.toJSON(),
-      blur: this._blur.toJSON(),
-    };
-  }
-
-  public toString(): string {
-    return `${this._color.getOr("")} ${this._offset} ${this._blur}`;
-  }
-}
-
-namespace TextShadow {
-  export interface JSON<
-    C extends Color = Color,
-    U extends Unit.Length = Unit.Length
-  > extends Value.JSON<"text-shadow"> {
-    color: Option.JSON<C>;
-    offset: Tuple.JSON<[Length<U>, Length<U>]>;
-    blur: Length.JSON<U>;
-  }
-
-  export function isTextShadow(value: unknown): value is TextShadow {
-    return value instanceof TextShadow;
-  }
-}

--- a/packages/alfa-style/src/property/text-shadow.ts
+++ b/packages/alfa-style/src/property/text-shadow.ts
@@ -7,7 +7,10 @@ import {
   RGB,
   System,
   Token,
+  Unit,
+  Value,
 } from "@siteimprove/alfa-css";
+import { Hash } from "@siteimprove/alfa-hash";
 import { Option } from "@siteimprove/alfa-option";
 import { Parser } from "@siteimprove/alfa-parser";
 import { Slice } from "@siteimprove/alfa-slice";
@@ -28,33 +31,14 @@ declare module "../property" {
 /**
  * @internal
  */
-export type Specified =
-  | Keyword<"none">
-  | Tuple<[Option<Color>, Specified.Offset, Option<Length>]>;
-
-namespace Specified {
-  export type Offset = Tuple<[Length, Length]>;
-}
+export type Specified = Keyword<"none"> | TextShadow;
 
 /**
  * @internal
  */
 export type Computed =
   | Keyword<"none">
-  | Tuple<
-      [
-        // Technically, the color always compute, but to a UA dependent value
-        // if none was specified.
-        // Given our current use case, we can keep None in that case.
-        Option<RGB<Percentage, Percentage> | Current | System>,
-        Computed.Offset,
-        Length<"px">
-      ]
-    >;
-
-namespace Computed {
-  export type Offset = Tuple<[Length<"px">, Length<"px">]>;
-}
+  | TextShadow<RGB<Percentage, Percentage> | Current | System, "px">;
 
 const parseOffset = map(
   separated(Length.parse, Token.parseWhitespace),
@@ -74,11 +58,13 @@ export const parse = either<Slice<Token>, Specified, string>(
   Keyword.parse("none"),
   map(
     separated(parseLengths, Token.parseWhitespace, option(Color.parse)),
-    ([[offset, blur], color]) => Tuple.of(color, offset, blur)
+    ([[offset, blur], color]) =>
+      TextShadow.of(color, offset, blur.getOr(Length.of(0, "px")))
   ),
   map(
     separated(option(Color.parse), Token.parseWhitespace, parseLengths),
-    ([color, [offset, blur]]) => Tuple.of(color, offset, blur)
+    ([color, [offset, blur]]) =>
+      TextShadow.of(color, offset, blur.getOr(Length.of(0, "px")))
   )
 );
 
@@ -94,16 +80,108 @@ export default Property.register(
         return shadow;
       }
 
-      const [color, offset, blur] = shadow.values;
-      const [x, y] = offset.values;
+      const [x, y] = shadow.offset.values;
 
-      return Tuple.of(
-        color.map(Resolver.color),
+      return TextShadow.of(
+        shadow.color.map(Resolver.color),
         Tuple.of(Resolver.length(x, style), Resolver.length(y, style)),
-        blur
-          .map((blur) => Resolver.length(blur, style))
-          .getOrElse(() => Length.of(0, "px"))
+        Resolver.length(shadow.blur, style)
       );
     })
   )
 );
+
+class TextShadow<
+  C extends Color = Color,
+  U extends Unit.Length = Unit.Length
+> extends Value<"text-shadow"> {
+  public static of<
+    C extends Color = Color,
+    U extends Unit.Length = Unit.Length
+  >(
+    color: Option<C>,
+    offset: Tuple<[Length<U>, Length<U>]>,
+    blur: Length<U>
+  ): TextShadow<C, U> {
+    return new TextShadow<C, U>(color, offset, blur);
+  }
+
+  private readonly _color: Option<C>;
+  private readonly _offset: Tuple<[Length<U>, Length<U>]>;
+  private readonly _blur: Length<U>;
+
+  private constructor(
+    color: Option<C>,
+    offset: Tuple<[Length<U>, Length<U>]>,
+    blur: Length<U>
+  ) {
+    super();
+
+    this._color = color;
+    this._offset = offset;
+    this._blur = blur;
+  }
+
+  public get type(): "text-shadow" {
+    return "text-shadow";
+  }
+
+  public get color(): Option<C> {
+    return this._color;
+  }
+
+  public get offset(): Tuple<[Length<U>, Length<U>]> {
+    return this._offset;
+  }
+
+  public get blur(): Length<U> {
+    return this._blur;
+  }
+
+  public equals(value: TextShadow): boolean;
+
+  public equals(value: unknown): value is this;
+
+  public equals(value: unknown): boolean {
+    return (
+      value instanceof TextShadow &&
+      value._color.equals(this._color) &&
+      value._offset.equals(this._offset) &&
+      value._blur.equals(this._blur)
+    );
+  }
+
+  public hash(hash: Hash): void {
+    this._color.hash(hash);
+    this._offset.hash(hash);
+    this._blur.hash(hash);
+  }
+
+  public toJSON(): TextShadow.JSON<C, U> {
+    return {
+      type: "text-shadow",
+      color: this._color.toJSON(),
+      offset: this._offset.toJSON(),
+      blur: this._blur.toJSON(),
+    };
+  }
+
+  public toString(): string {
+    return `${this._color.getOr("")} ${this._offset} ${this._blur}`;
+  }
+}
+
+namespace TextShadow {
+  export interface JSON<
+    C extends Color = Color,
+    U extends Unit.Length = Unit.Length
+  > extends Value.JSON<"text-shadow"> {
+    color: Option.JSON<C>;
+    offset: Tuple.JSON<[Length<U>, Length<U>]>;
+    blur: Length.JSON<U>;
+  }
+
+  export function isTextShadow(value: unknown): value is TextShadow {
+    return value instanceof TextShadow;
+  }
+}

--- a/packages/alfa-style/test/property/text-shadow.spec.tsx
+++ b/packages/alfa-style/test/property/text-shadow.spec.tsx
@@ -1,0 +1,32 @@
+import { test } from "@siteimprove/alfa-test";
+import { h } from "@siteimprove/alfa-dom/h";
+
+import { Device } from "@siteimprove/alfa-device";
+
+import { Style } from "../../src/style";
+
+const device = Device.standard();
+
+test(`.cascaded() parses \`text-shadow: 1px 1px 2px black;\``, (t) => {
+  const element = (
+    <span style={{ textShadow: "1px 1px 2px black" }}>Hello world</span>
+  );
+
+  const style = Style.from(element, device);
+
+  t.deepEqual(style.cascaded("text-shadow").get().toJSON().value, {
+    type: "text-shadow",
+    color: {
+      type: "some",
+      value: { type: "color", format: "named", color: "black" },
+    },
+    offset: {
+      type: "tuple",
+      values: [
+        { type: "length", value: 1, unit: "px" },
+        { type: "length", value: 1, unit: "px" },
+      ],
+    },
+    blur: { type: "length", value: 2, unit: "px" },
+  });
+});

--- a/packages/alfa-style/test/property/text-shadow.spec.tsx
+++ b/packages/alfa-style/test/property/text-shadow.spec.tsx
@@ -30,3 +30,74 @@ test(`.cascaded() parses \`text-shadow: 1px 1px 2px black;\``, (t) => {
     blur: { type: "length", value: 2, unit: "px" },
   });
 });
+
+test(`.cascaded() parses \`text-shadow: 1px 1px 2px;\``, (t) => {
+  const element = (
+    <span style={{ textShadow: "1px 1px 2px" }}>Hello world</span>
+  );
+
+  const style = Style.from(element, device);
+
+  t.deepEqual(style.cascaded("text-shadow").get().toJSON().value, {
+    type: "text-shadow",
+    color: {
+      type: "none",
+    },
+    offset: {
+      type: "tuple",
+      values: [
+        { type: "length", value: 1, unit: "px" },
+        { type: "length", value: 1, unit: "px" },
+      ],
+    },
+    blur: { type: "length", value: 2, unit: "px" },
+  });
+});
+
+test(`.cascaded() parses \`text-shadow: 1px 1px black;\``, (t) => {
+  const element = (
+    <span style={{ textShadow: "1px 1px black" }}>Hello world</span>
+  );
+
+  const style = Style.from(element, device);
+
+  t.deepEqual(style.cascaded("text-shadow").get().toJSON().value, {
+    type: "text-shadow",
+    color: {
+      type: "some",
+      value: { type: "color", format: "named", color: "black" },
+    },
+    offset: {
+      type: "tuple",
+      values: [
+        { type: "length", value: 1, unit: "px" },
+        { type: "length", value: 1, unit: "px" },
+      ],
+    },
+    blur: { type: "length", value: 0, unit: "px" },
+  });
+});
+
+test(`.cascaded() parses \`text-shadow: black 1px 1px;\``, (t) => {
+  const element = (
+    <span style={{ textShadow: "black 1px 1px" }}>Hello world</span>
+  );
+
+  const style = Style.from(element, device);
+
+  t.deepEqual(style.cascaded("text-shadow").get().toJSON().value, {
+    type: "text-shadow",
+    color: {
+      type: "some",
+      value: { type: "color", format: "named", color: "black" },
+    },
+    offset: {
+      type: "tuple",
+      values: [
+        { type: "length", value: 1, unit: "px" },
+        { type: "length", value: 1, unit: "px" },
+      ],
+    },
+    blur: { type: "length", value: 0, unit: "px" },
+  });
+});

--- a/packages/alfa-style/test/property/text-shadow.spec.tsx
+++ b/packages/alfa-style/test/property/text-shadow.spec.tsx
@@ -13,19 +13,13 @@ test(`.cascaded() parses \`text-shadow: 1px 1px 2px black;\``, (t) => {
   const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("text-shadow").get().toJSON().value, {
-    type: "text-shadow",
-    color: {
-      type: "some",
-      value: { type: "color", format: "named", color: "black" },
-    },
-    offset: {
-      type: "tuple",
-      values: [
-        { type: "length", value: 1, unit: "px" },
-        { type: "length", value: 1, unit: "px" },
-      ],
-    },
+    type: "shadow",
+    vertical: { type: "length", value: 1, unit: "px" },
+    horizontal: { type: "length", value: 1, unit: "px" },
     blur: { type: "length", value: 2, unit: "px" },
+    spread: { type: "length", value: 0, unit: "px" },
+    color: { type: "color", format: "named", color: "black" },
+    isInset: false,
   });
 });
 
@@ -37,16 +31,13 @@ test(`.cascaded() parses \`text-shadow: 1px 1px 2px;\``, (t) => {
   const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("text-shadow").get().toJSON().value, {
-    type: "text-shadow",
-    color: { type: "none" },
-    offset: {
-      type: "tuple",
-      values: [
-        { type: "length", value: 1, unit: "px" },
-        { type: "length", value: 1, unit: "px" },
-      ],
-    },
+    type: "shadow",
+    vertical: { type: "length", value: 1, unit: "px" },
+    horizontal: { type: "length", value: 1, unit: "px" },
     blur: { type: "length", value: 2, unit: "px" },
+    spread: { type: "length", value: 0, unit: "px" },
+    color: { type: "keyword", value: "currentcolor" },
+    isInset: false,
   });
 });
 
@@ -58,19 +49,13 @@ test(`.cascaded() parses \`text-shadow: 1px 1px black;\``, (t) => {
   const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("text-shadow").get().toJSON().value, {
-    type: "text-shadow",
-    color: {
-      type: "some",
-      value: { type: "color", format: "named", color: "black" },
-    },
-    offset: {
-      type: "tuple",
-      values: [
-        { type: "length", value: 1, unit: "px" },
-        { type: "length", value: 1, unit: "px" },
-      ],
-    },
+    type: "shadow",
+    vertical: { type: "length", value: 1, unit: "px" },
+    horizontal: { type: "length", value: 1, unit: "px" },
     blur: { type: "length", value: 0, unit: "px" },
+    spread: { type: "length", value: 0, unit: "px" },
+    color: { type: "color", format: "named", color: "black" },
+    isInset: false,
   });
 });
 
@@ -82,18 +67,12 @@ test(`.cascaded() parses \`text-shadow: black 1px 1px;\``, (t) => {
   const style = Style.from(element, device);
 
   t.deepEqual(style.cascaded("text-shadow").get().toJSON().value, {
-    type: "text-shadow",
-    color: {
-      type: "some",
-      value: { type: "color", format: "named", color: "black" },
-    },
-    offset: {
-      type: "tuple",
-      values: [
-        { type: "length", value: 1, unit: "px" },
-        { type: "length", value: 1, unit: "px" },
-      ],
-    },
+    type: "shadow",
+    vertical: { type: "length", value: 1, unit: "px" },
+    horizontal: { type: "length", value: 1, unit: "px" },
     blur: { type: "length", value: 0, unit: "px" },
+    spread: { type: "length", value: 0, unit: "px" },
+    color: { type: "color", format: "named", color: "black" },
+    isInset: false,
   });
 });

--- a/packages/alfa-style/test/property/text-shadow.spec.tsx
+++ b/packages/alfa-style/test/property/text-shadow.spec.tsx
@@ -1,6 +1,4 @@
 import { test } from "@siteimprove/alfa-test";
-import { h } from "@siteimprove/alfa-dom/h";
-
 import { Device } from "@siteimprove/alfa-device";
 
 import { Style } from "../../src/style";
@@ -40,9 +38,7 @@ test(`.cascaded() parses \`text-shadow: 1px 1px 2px;\``, (t) => {
 
   t.deepEqual(style.cascaded("text-shadow").get().toJSON().value, {
     type: "text-shadow",
-    color: {
-      type: "none",
-    },
+    color: { type: "none" },
     offset: {
       type: "tuple",
       values: [

--- a/packages/alfa-style/tsconfig.json
+++ b/packages/alfa-style/tsconfig.json
@@ -176,6 +176,7 @@
     "test/property/inset-block.spec.tsx",
     "test/property/text-decoration.spec.tsx",
     "test/property/text-indent.spec.tsx",
+    "test/property/text-shadow.spec.tsx",
     "test/style.spec.tsx"
   ],
   "references": [

--- a/packages/alfa-style/tsconfig.json
+++ b/packages/alfa-style/tsconfig.json
@@ -130,6 +130,7 @@
     "src/property/text-indent.ts",
     "src/property/text-overflow.ts",
     "src/property/text-transform.ts",
+    "src/property/text-shadow.ts",
     "src/property/top.ts",
     "src/property/transform.ts",
     "src/property/value/list.ts",


### PR DESCRIPTION
Resolves #743 
Plus add support for `text-shadow`.