### PR TITLE
Refactor collection types and associates

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -14,8 +14,6 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         node: [14, 16]
     runs-on: ${{ matrix.os }}
-    env:
-      NODE_OPTIONS: "--max-old-space-size=4096"
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions/setup-node@v2.2.0

--- a/docs/review/api/alfa-act.api.md
+++ b/docs/review/api/alfa-act.api.md
@@ -392,6 +392,8 @@ export class Question<Q, S, A, T = A> implements Functor<T>, Applicative<T>, Mon
     // (undocumented)
     flatMap<U>(mapper: Mapper<T, Question<Q, S, A, U>>): Question<Q, S, A, U>;
     // (undocumented)
+    flatten<Q, S, A, T>(this: Question<Q, S, A, Question<Q, S, A, T>>): Question<Q, S, A, T>;
+    // (undocumented)
     map<U>(mapper: Mapper<T, U>): Question<Q, S, A, U>;
     // (undocumented)
     get message(): string;

--- a/docs/review/api/alfa-act.api.md
+++ b/docs/review/api/alfa-act.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { Applicative } from '@siteimprove/alfa-applicative';
 import * as earl from '@siteimprove/alfa-earl';
 import { Equatable } from '@siteimprove/alfa-equatable';
 import { Functor } from '@siteimprove/alfa-functor';
@@ -27,7 +28,7 @@ export class Audit<I, T = unknown, Q = never> {
     evaluate(performance?: Performance<Audit.Event<I, T, Q>>): Future<Iterable_2<Outcome<I, T, Q>>>;
     // (undocumented)
     static of<I, T = unknown, Q = never>(input: I, rules: Iterable_2<Rule<I, T, Q>>, oracle?: Oracle<I, T, Q>): Audit<I, T, Q>;
-    }
+}
 
 // @public (undocumented)
 export namespace Audit {
@@ -72,7 +73,7 @@ export class Cache {
     static empty(): Cache;
     // (undocumented)
     get<I, T, Q>(rule: Rule<I, T, Q>, ifMissing: Thunk<Future<Iterable<Outcome<I, T, Q>>>>): Future<Iterable<Outcome<I, T, Q>>>;
-    }
+}
 
 // @public (undocumented)
 export class Diagnostic implements Equatable, Serializable<Diagnostic.JSON> {
@@ -382,10 +383,12 @@ export namespace Outcome {
 }
 
 // @public (undocumented)
-export class Question<Q, S, A, T = A> implements Functor<T>, Monad<T>, Serializable<Question.JSON<Q, S>> {
+export class Question<Q, S, A, T = A> implements Functor<T>, Applicative<T>, Monad<T>, Serializable<Question.JSON<Q, S>> {
     protected constructor(uri: string, type: Q, subject: S, message: string, quester: Mapper<A, T>);
     // (undocumented)
     answer(answer: A): T;
+    // (undocumented)
+    apply<U>(mapper: Question<Q, S, A, Mapper<T, U>>): Question<Q, S, A, U>;
     // (undocumented)
     flatMap<U>(mapper: Mapper<T, Question<Q, S, A, U>>): Question<Q, S, A, U>;
     // (undocumented)
@@ -402,7 +405,7 @@ export class Question<Q, S, A, T = A> implements Functor<T>, Monad<T>, Serializa
     get type(): Q;
     // (undocumented)
     get uri(): string;
-    }
+}
 
 // @public (undocumented)
 export namespace Question {
@@ -638,6 +641,5 @@ export namespace Tag {
         type: string;
     }
 }
-
 
 ```

--- a/docs/review/api/alfa-applicative.api.md
+++ b/docs/review/api/alfa-applicative.api.md
@@ -4,13 +4,13 @@
 
 ```ts
 
+import { Functor } from '@siteimprove/alfa-functor';
 import { Mapper } from '@siteimprove/alfa-mapper';
 
 // @public (undocumented)
-export interface Applicative<T> {
+export interface Applicative<T> extends Functor<T> {
     // (undocumented)
     apply<U>(mapper: Applicative<Mapper<T, U>>): Applicative<U>;
 }
-
 
 ```

--- a/docs/review/api/alfa-applicative.api.md
+++ b/docs/review/api/alfa-applicative.api.md
@@ -11,6 +11,8 @@ import { Mapper } from '@siteimprove/alfa-mapper';
 export interface Applicative<T> extends Functor<T> {
     // (undocumented)
     apply<U>(mapper: Applicative<Mapper<T, U>>): Applicative<U>;
+    // (undocumented)
+    map<U>(mapper: Mapper<T, U>): Applicative<U>;
 }
 
 ```

--- a/docs/review/api/alfa-array.api.md
+++ b/docs/review/api/alfa-array.api.md
@@ -28,7 +28,7 @@ namespace Array_2 {
     // (undocumented)
     function append<T>(array: Array_2<T>, value: T): Array_2<T>;
     // (undocumented)
-    function apply<T, U>(iterable: ReadonlyArray<T>, mapper: ReadonlyArray<Mapper<T, U>>): Array_2<U>;
+    function apply<T, U>(array: ReadonlyArray<T>, mapper: ReadonlyArray<Mapper<T, U>>): Array_2<U>;
     // (undocumented)
     function clone<T extends Clone<T>>(array: ReadonlyArray<T>): Array_2<T>;
     // (undocumented)

--- a/docs/review/api/alfa-array.api.md
+++ b/docs/review/api/alfa-array.api.md
@@ -36,9 +36,9 @@ namespace Array_2 {
     // (undocumented)
     function collectFirst<T, U>(array: ReadonlyArray<T>, mapper: Mapper<T, Option<U>, [index: number]>): Option<U>;
     // (undocumented)
-    function compare<T extends Comparable<T>>(a: ReadonlyArray<T>, b: Iterable_2<T>): Comparison;
+    function compare<T extends Comparable<U>, U = T>(a: ReadonlyArray<T>, b: Iterable_2<U>): Comparison;
     // (undocumented)
-    function compareWith<T>(a: ReadonlyArray<T>, b: Iterable_2<T>, comparer: Comparer<T>): Comparison;
+    function compareWith<T, U = T>(a: ReadonlyArray<T>, b: Iterable_2<U>, comparer: Comparer<T, U, [index: number]>): Comparison;
     // (undocumented)
     function concat<T>(array: ReadonlyArray<T>, ...iterables: Array_2<Iterable_2<T>>): Array_2<T>;
     // (undocumented)
@@ -134,8 +134,6 @@ namespace Array_2 {
     // (undocumented)
     function zip<T, U = T>(array: ReadonlyArray<T>, iterable: Iterable_2<U>): Array_2<[T, U]>;
 }
-
 export { Array_2 as Array }
-
 
 ```

--- a/docs/review/api/alfa-branched.api.md
+++ b/docs/review/api/alfa-branched.api.md
@@ -48,6 +48,8 @@ export class Branched<T, B = never> implements Collection<T>, Iterable_2<[T, Ite
     // (undocumented)
     flatMap<U>(mapper: Mapper<T, Branched<U, B>, [Iterable_2<B>]>): Branched<U, B>;
     // (undocumented)
+    flatten<T, B>(this: Branched<Branched<T, B>, B>): Branched<T, B>;
+    // (undocumented)
     forEach(callback: Callback<T, void, [Iterable_2<B>]>): void;
     // (undocumented)
     hash(hash: Hash): void;
@@ -75,7 +77,7 @@ export class Branched<T, B = never> implements Collection<T>, Iterable_2<[T, Ite
     toArray(): Array<[T, Array<B>]>;
     // (undocumented)
     toJSON(): Branched.JSON<T, B>;
-    }
+}
 
 // @public (undocumented)
 export namespace Branched {
@@ -85,15 +87,14 @@ export namespace Branched {
     export function isBranched<T, B = never>(value: unknown): value is Branched<T, B>;
     // (undocumented)
     export type JSON<T, B = never> = Array<[
-        Serializable.ToJSON<T>,
-        Array<Serializable.ToJSON<B>>
+    Serializable.ToJSON<T>,
+    Array<Serializable.ToJSON<B>>
     ]>;
     // (undocumented)
     export function sequence<T, B>(values: Iterable_2<Branched<T, B>>): Branched<Iterable_2<T>, B>;
     // (undocumented)
     export function traverse<T, U, B>(values: Iterable_2<T>, mapper: Mapper<T, Branched<U, B>, [index: number]>): Branched<Iterable_2<U>, B>;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/docs/review/api/alfa-collection.api.md
+++ b/docs/review/api/alfa-collection.api.md
@@ -23,7 +23,7 @@ import { Refinement } from '@siteimprove/alfa-refinement';
 import { Serializable } from '@siteimprove/alfa-json';
 
 // @public (undocumented)
-export interface Collection<T> extends Functor<T>, Monad<T>, Foldable<T>, Applicative<T>, Equatable, Hashable {
+export interface Collection<T> extends Functor<T>, Applicative<T>, Monad<T>, Foldable<T>, Equatable, Hashable {
     // (undocumented)
     apply<U>(mapper: Collection<Mapper<T, U>>): Collection<U>;
     // (undocumented)
@@ -46,6 +46,8 @@ export interface Collection<T> extends Functor<T>, Monad<T>, Foldable<T>, Applic
     find(predicate: Predicate<T>): Option<T>;
     // (undocumented)
     flatMap<U>(mapper: Mapper<T, Collection<U>>): Collection<U>;
+    // (undocumented)
+    flatten<T>(this: Collection<Collection<T>>): Collection<T>;
     // (undocumented)
     forEach(callback: Callback<T>): void;
     // (undocumented)
@@ -71,9 +73,7 @@ export interface Collection<T> extends Functor<T>, Monad<T>, Foldable<T>, Applic
 // @public (undocumented)
 export namespace Collection {
     // (undocumented)
-    export function compare<T extends Comparable<T>>(a: Indexed<T>, b: Iterable_2<T>): Comparison;
-    // (undocumented)
-    export interface Indexed<T> extends Collection<T>, Iterable_2<T>, Serializable<Indexed.JSON<T>> {
+    export interface Indexed<T> extends Collection<T>, Iterable_2<T>, Comparable<Iterable_2<T>>, Serializable<Indexed.JSON<T>> {
         // (undocumented)
         append(value: T): Indexed<T>;
         // (undocumented)
@@ -83,7 +83,9 @@ export namespace Collection {
         // (undocumented)
         collectFirst<U>(mapper: Mapper<T, Option<U>, [index: number]>): Option<U>;
         // (undocumented)
-        compareWith(iterable: Iterable_2<T>, comparer: Comparer<T>): Comparison;
+        compare(this: Indexed<Comparable<T>>, iterable: Iterable_2<T>): Comparison;
+        // (undocumented)
+        compareWith<U = T>(iterable: Iterable_2<U>, comparer: Comparer<T, U, [index: number]>): Comparison;
         // (undocumented)
         concat(iterable: Iterable_2<T>): Indexed<T>;
         // (undocumented)
@@ -104,6 +106,8 @@ export namespace Collection {
         first(): Option<T>;
         // (undocumented)
         flatMap<U>(mapper: Mapper<T, Indexed<U>, [index: number]>): Indexed<U>;
+        // (undocumented)
+        flatten<T>(this: Indexed<Indexed<T>>): Indexed<T>;
         // (undocumented)
         forEach(callback: Callback<T, void, [index: number]>): void;
         // (undocumented)
@@ -160,6 +164,8 @@ export namespace Collection {
         slice(start: number, end?: number): Indexed<T>;
         // (undocumented)
         some(predicate: Predicate<T, [index: number]>): boolean;
+        // (undocumented)
+        sort<T extends Comparable<T>>(this: Indexed<T>): Indexed<T>;
         // (undocumented)
         sortWith(comparer: Comparer<T>): Indexed<T>;
         // (undocumented)
@@ -223,6 +229,8 @@ export namespace Collection {
         // (undocumented)
         flatMap<U>(mapper: Mapper<V, Keyed<K, U>, [key: K]>): Keyed<K, U>;
         // (undocumented)
+        flatten<K, V>(this: Keyed<K, Keyed<K, V>>): Keyed<K, V>;
+        // (undocumented)
         forEach(callback: Callback<V, void, [key: K]>): void;
         // (undocumented)
         get(key: K): Option<V>;
@@ -260,8 +268,6 @@ export namespace Collection {
         ]>;
     }
     // (undocumented)
-    export function sort<T extends Comparable<T>>(collection: Indexed<T>): Indexed<T>;
-    // (undocumented)
     export interface Unkeyed<T> extends Collection<T>, Iterable_2<T>, Serializable<Unkeyed.JSON<T>> {
         // (undocumented)
         add(value: T): Unkeyed<T>;
@@ -291,6 +297,8 @@ export namespace Collection {
         find(predicate: Predicate<T>): Option<T>;
         // (undocumented)
         flatMap<U>(mapper: Mapper<T, Unkeyed<U>>): Unkeyed<U>;
+        // (undocumented)
+        flatten<T>(this: Unkeyed<Unkeyed<T>>): Unkeyed<T>;
         // (undocumented)
         forEach(callback: Callback<T>): void;
         // (undocumented)

--- a/docs/review/api/alfa-comparable.api.md
+++ b/docs/review/api/alfa-comparable.api.md
@@ -4,48 +4,38 @@
 
 ```ts
 
-// @public (undocumented)
+// @public
 export interface Comparable<T> {
-    // (undocumented)
     compare(value: T): Comparison;
 }
 
-// @public (undocumented)
+// @public
 export namespace Comparable {
-    // (undocumented)
     export function compare(a: string, b: string): Comparison;
-    // (undocumented)
     export function compare(a: number, b: number): Comparison;
-    // (undocumented)
     export function compare(a: bigint, b: bigint): Comparison;
-    // (undocumented)
     export function compare(a: boolean, b: boolean): Comparison;
-    // (undocumented)
-    export function compare<T>(a: Comparable<T>, b: T): Comparison;
+    export function compare<T extends Comparable<U>, U = T>(a: T, b: U): Comparison;
     // (undocumented)
     export function compareBigInt(a: bigint, b: bigint): Comparison;
     // (undocumented)
     export function compareBoolean(a: boolean, b: boolean): Comparison;
     // (undocumented)
-    export function compareComparable<T>(a: Comparable<T>, b: T): Comparison;
+    export function compareComparable<T extends Comparable<U>, U = T>(a: T, b: U): Comparison;
     // (undocumented)
     export function compareNumber(a: number, b: number): Comparison;
     // (undocumented)
     export function compareString(a: string, b: string): Comparison;
-    // (undocumented)
     export function isComparable<T>(value: unknown): value is Comparable<T>;
-    // (undocumented)
+    export function isEqual<T>(a: Comparable<T>, b: T): boolean;
     export function isGreaterThan<T>(a: Comparable<T>, b: T): boolean;
-    // (undocumented)
     export function isGreaterThanOrEqual<T>(a: Comparable<T>, b: T): boolean;
-    // (undocumented)
     export function isLessThan<T>(a: Comparable<T>, b: T): boolean;
-    // (undocumented)
     export function isLessThanOrEqual<T>(a: Comparable<T>, b: T): boolean;
 }
 
 // @public (undocumented)
-export type Comparer<T, A extends Array<unknown> = []> = (a: T, b: T, ...args: A) => Comparison;
+export type Comparer<T, U = T, A extends Array<unknown> = []> = (a: T, b: U, ...args: A) => Comparison;
 
 // @public (undocumented)
 export enum Comparison {
@@ -56,7 +46,6 @@ export enum Comparison {
     // (undocumented)
     Less = -1
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/docs/review/api/alfa-either.api.md
+++ b/docs/review/api/alfa-either.api.md
@@ -27,6 +27,8 @@ export interface Either<L, R = L> extends Functor<R>, Applicative<R>, Monad<R>, 
     // (undocumented)
     flatMap<T>(mapper: Mapper<R, Either<L, T>>): Either<L, T>;
     // (undocumented)
+    flatten<L, R>(this: Either<L, Either<L, R>>): Either<L, R>;
+    // (undocumented)
     get(): L | R;
     // (undocumented)
     isLeft(): this is Left<L>;
@@ -72,6 +74,8 @@ export class Left<L> implements Either<L, never> {
     equals(value: unknown): value is this;
     // (undocumented)
     flatMap(): Left<L>;
+    // (undocumented)
+    flatten<L, R>(this: Either<L, never>): Either<L, R>;
     // (undocumented)
     get(): L;
     // (undocumented)
@@ -127,6 +131,8 @@ export class Right<R> implements Either<never, R> {
     equals(value: unknown): value is this;
     // (undocumented)
     flatMap<L, T>(mapper: Mapper<R, Either<L, T>>): Either<L, T>;
+    // (undocumented)
+    flatten<L, R>(this: Right<Either<L, R>>): Either<L, R>;
     // (undocumented)
     get(): R;
     // (undocumented)

--- a/docs/review/api/alfa-either.api.md
+++ b/docs/review/api/alfa-either.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { Applicative } from '@siteimprove/alfa-applicative';
 import { Equatable } from '@siteimprove/alfa-equatable';
 import { Foldable } from '@siteimprove/alfa-foldable';
 import { Functor } from '@siteimprove/alfa-functor';
@@ -18,11 +19,13 @@ import { Reducer } from '@siteimprove/alfa-reducer';
 import { Serializable } from '@siteimprove/alfa-json';
 
 // @public (undocumented)
-export interface Either<L, R = L> extends Functor<L | R>, Monad<L | R>, Foldable<L | R>, Iterable<L | R>, Equatable, Hashable, Serializable<Either.JSON<L, R>> {
+export interface Either<L, R = L> extends Functor<R>, Applicative<R>, Monad<R>, Foldable<R>, Iterable<L | R>, Equatable, Hashable, Serializable<Either.JSON<L, R>> {
+    // (undocumented)
+    apply<T>(mapper: Either<L, Mapper<R, T>>): Either<L, T>;
     // (undocumented)
     either<T>(left: Mapper<L, T>, right: Mapper<R, T>): T;
     // (undocumented)
-    flatMap<T>(mapper: Mapper<L | R, Either<T, T>>): Either<T, T>;
+    flatMap<T>(mapper: Mapper<R, Either<L, T>>): Either<L, T>;
     // (undocumented)
     get(): L | R;
     // (undocumented)
@@ -32,9 +35,9 @@ export interface Either<L, R = L> extends Functor<L | R>, Monad<L | R>, Foldable
     // (undocumented)
     left(): Option<L>;
     // (undocumented)
-    map<T>(mapper: Mapper<L | R, T>): Either<T, T>;
+    map<T>(mapper: Mapper<R, T>): Either<L, T>;
     // (undocumented)
-    reduce<T>(reducer: Reducer<L | R, T>, accumulator: T): T;
+    reduce<T>(reducer: Reducer<R, T>, accumulator: T): T;
     // (undocumented)
     right(): Option<R>;
     // (undocumented)
@@ -60,13 +63,15 @@ export class Left<L> implements Either<L, never> {
     // (undocumented)
     [Symbol.iterator](): Iterator<L>;
     // (undocumented)
+    apply(): Left<L>;
+    // (undocumented)
     either<T>(left: Mapper<L, T>): T;
     // (undocumented)
     equals<L>(value: Left<L>): boolean;
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
-    flatMap<T>(mapper: Mapper<L, Either<T, T>>): Either<T, T>;
+    flatMap(): Left<L>;
     // (undocumented)
     get(): L;
     // (undocumented)
@@ -78,18 +83,18 @@ export class Left<L> implements Either<L, never> {
     // (undocumented)
     left(): Option<L>;
     // (undocumented)
-    map<T>(mapper: Mapper<L, T>): Either<T, T>;
+    map(): Left<L>;
     // (undocumented)
     static of<L>(value: L): Left<L>;
     // (undocumented)
-    reduce<T>(reducer: Reducer<L, T>, accumulator: T): T;
+    reduce<T>(reducer: unknown, accumulator: T): T;
     // (undocumented)
     right(): None;
     // (undocumented)
     toJSON(): Left.JSON<L>;
     // (undocumented)
     toString(): string;
-    }
+}
 
 // @public (undocumented)
 export namespace Left {
@@ -113,13 +118,15 @@ export class Right<R> implements Either<never, R> {
     // (undocumented)
     [Symbol.iterator](): Iterator<R>;
     // (undocumented)
+    apply<L, T>(mapper: Either<L, Mapper<R, T>>): Either<L, T>;
+    // (undocumented)
     either<T>(left: unknown, right: Mapper<R, T>): T;
     // (undocumented)
     equals<R>(value: Right<R>): boolean;
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
-    flatMap<T>(mapper: Mapper<R, Either<T, T>>): Either<T, T>;
+    flatMap<L, T>(mapper: Mapper<R, Either<L, T>>): Either<L, T>;
     // (undocumented)
     get(): R;
     // (undocumented)
@@ -131,7 +138,7 @@ export class Right<R> implements Either<never, R> {
     // (undocumented)
     left(): None;
     // (undocumented)
-    map<T>(mapper: Mapper<R, T>): Either<T, T>;
+    map<T>(mapper: Mapper<R, T>): Right<T>;
     // (undocumented)
     static of<R>(value: R): Right<R>;
     // (undocumented)
@@ -142,7 +149,7 @@ export class Right<R> implements Either<never, R> {
     toJSON(): Right.JSON<R>;
     // (undocumented)
     toString(): string;
-    }
+}
 
 // @public (undocumented)
 export namespace Right {
@@ -160,7 +167,6 @@ export namespace Right {
         value: Serializable.ToJSON<R>;
     }
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/docs/review/api/alfa-equatable.api.md
+++ b/docs/review/api/alfa-equatable.api.md
@@ -4,18 +4,17 @@
 
 ```ts
 
-// @public (undocumented)
+// @public
 export interface Equatable {
     equals(value: this): boolean;
     equals(value: unknown): value is this;
 }
 
-// @public (undocumented)
+// @public
 export namespace Equatable {
     export function equals(a: unknown, b: unknown): boolean;
     export function isEquatable(value: unknown): value is Equatable;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/docs/review/api/alfa-future.api.md
+++ b/docs/review/api/alfa-future.api.md
@@ -15,7 +15,7 @@ import { Thenable } from '@siteimprove/alfa-thenable';
 import { Thunk } from '@siteimprove/alfa-thunk';
 
 // @public (undocumented)
-export abstract class Future<T> implements Functor<T>, Monad<T>, Applicative<T>, Thenable<T>, AsyncIterable<T> {
+export abstract class Future<T> implements Functor<T>, Applicative<T>, Monad<T>, Thenable<T>, AsyncIterable<T> {
     // (undocumented)
     [Symbol.asyncIterator](): AsyncIterator<T>;
     // (undocumented)
@@ -24,6 +24,8 @@ export abstract class Future<T> implements Functor<T>, Monad<T>, Applicative<T>,
     asyncIterator(): AsyncIterator<T>;
     // (undocumented)
     abstract flatMap<U>(mapper: Mapper<T, Future<U>>): Future<U>;
+    // (undocumented)
+    flatten<T>(this: Future<Future<T>>): Future<T>;
     // (undocumented)
     get(): T;
     // (undocumented)
@@ -69,7 +71,6 @@ export namespace Future {
     // (undocumented)
     export function traverse<T, U>(values: Iterable_2<T>, mapper: Mapper<T, Future<U>, [index: number]>): Future<Iterable_2<U>>;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/docs/review/api/alfa-iterable.api.md
+++ b/docs/review/api/alfa-iterable.api.md
@@ -30,9 +30,9 @@ namespace Iterable_2 {
     // (undocumented)
     function collectFirst<T, U>(iterable: Iterable_2<T>, mapper: Mapper<T, Option<U>, [index: number]>): Option<U>;
     // (undocumented)
-    function compare<T extends Comparable<T>>(a: Iterable_2<T>, b: Iterable_2<T>): Comparison;
+    function compare<T extends Comparable<U>, U = T>(a: Iterable_2<T>, b: Iterable_2<U>): Comparison;
     // (undocumented)
-    function compareWith<T>(a: Iterable_2<T>, b: Iterable_2<T>, comparer: Comparer<T>): Comparison;
+    function compareWith<T, U = T>(a: Iterable_2<T>, b: Iterable_2<U>, comparer: Comparer<T, U, [index: number]>): Comparison;
     // (undocumented)
     function concat<T>(iterable: Iterable_2<T>, ...iterables: Array<Iterable_2<T>>): Iterable_2<T>;
     // (undocumented)

--- a/docs/review/api/alfa-lazy.api.md
+++ b/docs/review/api/alfa-lazy.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { Applicative } from '@siteimprove/alfa-applicative';
 import { Equatable } from '@siteimprove/alfa-equatable';
 import { Functor } from '@siteimprove/alfa-functor';
 import { Mapper } from '@siteimprove/alfa-mapper';
@@ -12,15 +13,19 @@ import { Serializable } from '@siteimprove/alfa-json';
 import { Thunk } from '@siteimprove/alfa-thunk';
 
 // @public (undocumented)
-export class Lazy<T> implements Functor<T>, Monad<T>, Iterable<T>, Equatable, Serializable<Lazy.JSON<T>> {
+export class Lazy<T> implements Functor<T>, Applicative<T>, Monad<T>, Iterable<T>, Equatable, Serializable<Lazy.JSON<T>> {
     // (undocumented)
     [Symbol.iterator](): Iterator<T>;
+    // (undocumented)
+    apply<U>(mapper: Lazy<Mapper<T, U>>): Lazy<U>;
     // (undocumented)
     equals<T>(value: Lazy<T>): boolean;
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
     flatMap<U>(mapper: Mapper<T, Lazy<U>>): Lazy<U>;
+    // (undocumented)
+    flatten<T>(this: Lazy<Lazy<T>>): Lazy<T>;
     // (undocumented)
     static force<T>(value: T): Lazy<T>;
     // (undocumented)
@@ -37,14 +42,13 @@ export class Lazy<T> implements Functor<T>, Monad<T>, Iterable<T>, Equatable, Se
     toString(): string;
     // (undocumented)
     toThunk(): Thunk<T>;
-    }
+}
 
 // @public (undocumented)
 export namespace Lazy {
     // (undocumented)
     export type JSON<T> = Serializable.ToJSON<T>;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/docs/review/api/alfa-list.api.md
+++ b/docs/review/api/alfa-list.api.md
@@ -97,7 +97,9 @@ export class List<T> implements Collection.Indexed<T> {
     // (undocumented)
     collectFirst<U>(mapper: Mapper<T, Option<U>, [index: number]>): Option<U>;
     // (undocumented)
-    compareWith(iterable: Iterable_2<T>, comparer: Comparer<T>): Comparison;
+    compare(this: List<Comparable<T>>, iterable: Iterable_2<T>): Comparison;
+    // (undocumented)
+    compareWith<U = T>(iterable: Iterable_2<U>, comparer: Comparer<T, U, [index: number]>): Comparison;
     // (undocumented)
     concat(iterable: Iterable_2<T>): List<T>;
     // (undocumented)
@@ -124,6 +126,8 @@ export class List<T> implements Collection.Indexed<T> {
     first(): Option<T>;
     // (undocumented)
     flatMap<U>(mapper: Mapper<T, List<U>, [index: number]>): List<U>;
+    // (undocumented)
+    flatten<T>(this: List<List<T>>): List<T>;
     // (undocumented)
     forEach(callback: Callback<T, void, [index: number]>): void;
     // (undocumented)
@@ -189,6 +193,8 @@ export class List<T> implements Collection.Indexed<T> {
     // (undocumented)
     some(predicate: Predicate<T, [index: number]>): boolean;
     // (undocumented)
+    sort<T extends Comparable<T>>(this: List<T>): List<T>;
+    // (undocumented)
     sortWith(comparer: Comparer<T>): List<T>;
     // (undocumented)
     subtract(iterable: Iterable_2<T>): List<T>;
@@ -227,8 +233,6 @@ export class List<T> implements Collection.Indexed<T> {
 // @public (undocumented)
 export namespace List {
     // (undocumented)
-    export function compare<T extends Comparable<T>>(a: List<T>, b: Iterable_2<T>): Comparison;
-    // (undocumented)
     export function from<T>(iterable: Iterable_2<T>): List<T>;
     // (undocumented)
     export function fromArray<T>(array: Array_2<T>): List<T>;
@@ -240,8 +244,6 @@ export namespace List {
     export function isList<T>(value: unknown): value is List<T>;
     // (undocumented)
     export type JSON<T> = Collection.Indexed.JSON<T>;
-    // (undocumented)
-    export function sort<T extends Comparable<T>>(list: List<T>): List<T>;
 }
 
 // Warning: (ae-internal-missing-underscore) The name "Node" should be prefixed with an underscore because the declaration is marked as @internal

--- a/docs/review/api/alfa-map.api.md
+++ b/docs/review/api/alfa-map.api.md
@@ -78,7 +78,7 @@ export class Leaf<K, V> implements Node<K, V> {
     set(key: K, value: V, hash: number, shift: number): Status<Node<K, V>>;
     // (undocumented)
     get value(): V;
-    }
+}
 
 // @public (undocumented)
 class Map_2<K, V> implements Collection.Keyed<K, V> {
@@ -87,13 +87,13 @@ class Map_2<K, V> implements Collection.Keyed<K, V> {
     // (undocumented)
     apply<U>(mapper: Map_2<K, Mapper<V, U>>): Map_2<K, U>;
     // (undocumented)
-    collect<U>(mapper: Mapper<V, Option<U>, [K]>): Map_2<K, U>;
+    collect<U>(mapper: Mapper<V, Option<U>, [key: K]>): Map_2<K, U>;
     // (undocumented)
-    collectFirst<U>(mapper: Mapper<V, Option<U>, [K]>): Option<U>;
+    collectFirst<U>(mapper: Mapper<V, Option<U>, [key: K]>): Option<U>;
     // (undocumented)
     concat(iterable: Iterable_2<readonly [K, V]>): Map_2<K, V>;
     // (undocumented)
-    count(predicate: Predicate<V, [K]>): number;
+    count(predicate: Predicate<V, [key: K]>): number;
     // (undocumented)
     delete(key: K): Map_2<K, V>;
     // (undocumented)
@@ -105,19 +105,21 @@ class Map_2<K, V> implements Collection.Keyed<K, V> {
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
-    every(predicate: Predicate<V, [K]>): boolean;
+    every(predicate: Predicate<V, [key: K]>): boolean;
     // (undocumented)
-    filter<U extends V>(refinement: Refinement<V, U, [K]>): Map_2<K, U>;
+    filter<U extends V>(refinement: Refinement<V, U, [key: K]>): Map_2<K, U>;
     // (undocumented)
-    filter(predicate: Predicate<V, [K]>): Map_2<K, V>;
+    filter(predicate: Predicate<V, [key: K]>): Map_2<K, V>;
     // (undocumented)
-    find<U extends V>(refinement: Refinement<V, U, [K]>): Option<U>;
+    find<U extends V>(refinement: Refinement<V, U, [key: K]>): Option<U>;
     // (undocumented)
-    find(predicate: Predicate<V, [K]>): Option<V>;
+    find(predicate: Predicate<V, [key: K]>): Option<V>;
     // (undocumented)
-    flatMap<L, U>(mapper: Mapper<V, Map_2<L, U>, [K]>): Map_2<L, U>;
+    flatMap<L, U>(mapper: Mapper<V, Map_2<L, U>, [key: K]>): Map_2<L, U>;
     // (undocumented)
-    forEach(callback: Callback<V, void, [K]>): void;
+    flatten<K, V>(this: Map_2<K, Map_2<K, V>>): Map_2<K, V>;
+    // (undocumented)
+    forEach(callback: Callback<V, void, [key: K]>): void;
     // (undocumented)
     get(key: K): Option<V>;
     // (undocumented)
@@ -135,23 +137,23 @@ class Map_2<K, V> implements Collection.Keyed<K, V> {
     // (undocumented)
     keys(): Iterable_2<K>;
     // (undocumented)
-    map<U>(mapper: Mapper<V, U, [K]>): Map_2<K, U>;
+    map<U>(mapper: Mapper<V, U, [key: K]>): Map_2<K, U>;
     // (undocumented)
-    none(predicate: Predicate<V, [K]>): boolean;
+    none(predicate: Predicate<V, [key: K]>): boolean;
     // (undocumented)
     static of<K, V>(...entries: Array_2<readonly [K, V]>): Map_2<K, V>;
     // (undocumented)
-    reduce<R>(reducer: Reducer<V, R, [K]>, accumulator: R): R;
+    reduce<R>(reducer: Reducer<V, R, [key: K]>, accumulator: R): R;
     // (undocumented)
-    reject<U extends V>(refinement: Refinement<V, U, [K]>): Map_2<K, Exclude<V, U>>;
+    reject<U extends V>(refinement: Refinement<V, U, [key: K]>): Map_2<K, Exclude<V, U>>;
     // (undocumented)
-    reject(predicate: Predicate<V, [K]>): Map_2<K, V>;
+    reject(predicate: Predicate<V, [key: K]>): Map_2<K, V>;
     // (undocumented)
     set(key: K, value: V): Map_2<K, V>;
     // (undocumented)
     get size(): number;
     // (undocumented)
-    some(predicate: Predicate<V, [K]>): boolean;
+    some(predicate: Predicate<V, [key: K]>): boolean;
     // (undocumented)
     subtract(iterable: Iterable_2<readonly [K, V]>): Map_2<K, V>;
     // (undocumented)
@@ -179,7 +181,6 @@ namespace Map_2 {
     // (undocumented)
     type JSON<K, V> = Collection.Keyed.JSON<K, V>;
 }
-
 export { Map_2 as Map }
 
 // Warning: (ae-internal-missing-underscore) The name "Node" should be prefixed with an underscore because the declaration is marked as @internal
@@ -233,7 +234,6 @@ export class Sparse<K, V> implements Node<K, V> {
     // (undocumented)
     set(key: K, value: V, hash: number, shift: number): Status<Node<K, V>>;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/docs/review/api/alfa-map.api.md
+++ b/docs/review/api/alfa-map.api.md
@@ -84,7 +84,6 @@ export class Leaf<K, V> implements Node<K, V> {
 class Map_2<K, V> implements Collection.Keyed<K, V> {
     // (undocumented)
     [Symbol.iterator](): Iterator<[K, V]>;
-    // (undocumented)
     apply<U>(mapper: Map_2<K, Mapper<V, U>>): Map_2<K, U>;
     // (undocumented)
     collect<U>(mapper: Mapper<V, Option<U>, [key: K]>): Map_2<K, U>;

--- a/docs/review/api/alfa-monad.api.md
+++ b/docs/review/api/alfa-monad.api.md
@@ -4,14 +4,14 @@
 
 ```ts
 
+import { Applicative } from '@siteimprove/alfa-applicative';
 import { Mapper } from '@siteimprove/alfa-mapper';
 
 // @public (undocumented)
-export interface Monad<T> {
+export interface Monad<T> extends Applicative<T> {
     // (undocumented)
     flatMap<U>(mapper: Mapper<T, Monad<U>>): Monad<U>;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/docs/review/api/alfa-monad.api.md
+++ b/docs/review/api/alfa-monad.api.md
@@ -5,12 +5,19 @@
 ```ts
 
 import { Applicative } from '@siteimprove/alfa-applicative';
+import { Functor } from '@siteimprove/alfa-functor';
 import { Mapper } from '@siteimprove/alfa-mapper';
 
 // @public (undocumented)
-export interface Monad<T> extends Applicative<T> {
+export interface Monad<T> extends Functor<T>, Applicative<T> {
+    // (undocumented)
+    apply<U>(mapper: Monad<Mapper<T, U>>): Monad<U>;
     // (undocumented)
     flatMap<U>(mapper: Mapper<T, Monad<U>>): Monad<U>;
+    // (undocumented)
+    flatten<T>(this: Monad<Monad<T>>): Monad<T>;
+    // (undocumented)
+    map<U>(mapper: Mapper<T, U>): Monad<U>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/docs/review/api/alfa-option.api.md
+++ b/docs/review/api/alfa-option.api.md
@@ -41,7 +41,7 @@ export namespace None {
 }
 
 // @public (undocumented)
-export interface Option<T> extends Functor<T>, Monad<T>, Foldable<T>, Applicative<T>, Iterable<T>, Equatable, Hashable, Serializable<Option.JSON<T>> {
+export interface Option<T> extends Functor<T>, Applicative<T>, Monad<T>, Foldable<T>, Iterable<T>, Equatable, Hashable, Serializable<Option.JSON<T>> {
     // (undocumented)
     and<U>(option: Option<U>): Option<U>;
     // (undocumented)
@@ -49,7 +49,9 @@ export interface Option<T> extends Functor<T>, Monad<T>, Foldable<T>, Applicativ
     // (undocumented)
     apply<U>(mapper: Option<Mapper<T, U>>): Option<U>;
     // (undocumented)
-    compareWith(option: Option<T>, comparer: Comparer<T>): Comparison;
+    compare(this: Option<Comparable<T>>, option: Option<T>): Comparison;
+    // (undocumented)
+    compareWith<U = T>(option: Option<U>, comparer: Comparer<T, U>): Comparison;
     // (undocumented)
     every(predicate: Predicate<T>): boolean;
     // (undocumented)
@@ -58,6 +60,8 @@ export interface Option<T> extends Functor<T>, Monad<T>, Foldable<T>, Applicativ
     filter(predicate: Predicate<T>): Option<T>;
     // (undocumented)
     flatMap<U>(mapper: Mapper<T, Option<U>>): Option<U>;
+    // (undocumented)
+    flatten<T>(this: Option<Option<T>>): Option<T>;
     // (undocumented)
     get(): T;
     // (undocumented)
@@ -95,11 +99,7 @@ export interface Option<T> extends Functor<T>, Monad<T>, Foldable<T>, Applicativ
 // @public (undocumented)
 export namespace Option {
     // (undocumented)
-    export function compare<T extends Comparable<T>>(a: Option<T>, b: Option<T>): Comparison;
-    // (undocumented)
     export function empty<T>(): Option<T>;
-    // (undocumented)
-    export function flatten<T>(option: Option<Option<T>>): Option<T>;
     // (undocumented)
     export function from<T>(value: T | null | undefined): Option<NonNullable<T>>;
     // (undocumented)
@@ -133,7 +133,9 @@ export class Some<T> implements Option<T> {
     // (undocumented)
     apply<U>(mapper: Option<Mapper<T, U>>): Option<U>;
     // (undocumented)
-    compareWith(option: Option<T>, comparer: Comparer<T>): Comparison;
+    compare(this: Option<Comparable<T>>, option: Option<T>): Comparison;
+    // (undocumented)
+    compareWith<U = T>(option: Option<U>, comparer: Comparer<T, U>): Comparison;
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -144,6 +146,8 @@ export class Some<T> implements Option<T> {
     filter(predicate: Predicate<T>): Option<T>;
     // (undocumented)
     flatMap<U>(mapper: Mapper<T, Option<U>>): Option<U>;
+    // (undocumented)
+    flatten<T>(this: Some<Option<T>>): Option<T>;
     // (undocumented)
     get(): T;
     // (undocumented)
@@ -182,7 +186,7 @@ export class Some<T> implements Option<T> {
     toJSON(): Some.JSON<T>;
     // (undocumented)
     toString(): string;
-    }
+}
 
 // @public (undocumented)
 export namespace Some {
@@ -200,7 +204,6 @@ export namespace Some {
         value: Serializable.ToJSON<T>;
     }
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/docs/review/api/alfa-result.api.md
+++ b/docs/review/api/alfa-result.api.md
@@ -26,11 +26,11 @@ export class Err<E> implements Result<never, E> {
     // (undocumented)
     [Symbol.iterator](): Generator<never, void, unknown>;
     // (undocumented)
-    and(): this;
+    and(): Err<E>;
     // (undocumented)
-    andThen(): this;
+    andThen(): Err<E>;
     // (undocumented)
-    apply(): this;
+    apply(): Err<E>;
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -40,7 +40,9 @@ export class Err<E> implements Result<never, E> {
     // (undocumented)
     everyErr(predicate: Predicate<E>): boolean;
     // (undocumented)
-    flatMap(): this;
+    flatMap(): Err<E>;
+    // (undocumented)
+    flatten<T, E>(this: Err<E>): Result<T, E>;
     // (undocumented)
     get(): never;
     // (undocumented)
@@ -60,11 +62,11 @@ export class Err<E> implements Result<never, E> {
     // (undocumented)
     isOk(): this is Ok<never>;
     // (undocumented)
-    map(): this;
+    map(): Err<E>;
     // (undocumented)
     mapErr<F>(mapper: Mapper<E, F>): Err<F>;
     // (undocumented)
-    mapOrElse<T, U>(ok: Mapper<T, U>, err: Mapper<E, U>): U;
+    mapOrElse<U>(ok: unknown, err: Mapper<E, U>): U;
     // (undocumented)
     none(): boolean;
     // (undocumented)
@@ -129,6 +131,8 @@ export class Ok<T> implements Result<T, never> {
     // (undocumented)
     flatMap<U, F>(mapper: Mapper<T, Result<U, F>>): Result<U, F>;
     // (undocumented)
+    flatten<T, E>(this: Ok<Result<T, E>>): Result<T, E>;
+    // (undocumented)
     get(): T;
     // (undocumented)
     getErr(): never;
@@ -149,9 +153,9 @@ export class Ok<T> implements Result<T, never> {
     // (undocumented)
     map<U>(mapper: Mapper<T, U>): Ok<U>;
     // (undocumented)
-    mapErr(): this;
+    mapErr(): Ok<T>;
     // (undocumented)
-    mapOrElse<E, U>(ok: Mapper<T, U>): U;
+    mapOrElse<U>(ok: Mapper<T, U>): U;
     // (undocumented)
     none(predicate: Predicate<T>): boolean;
     // (undocumented)
@@ -161,9 +165,9 @@ export class Ok<T> implements Result<T, never> {
     // (undocumented)
     ok(): Option<T>;
     // (undocumented)
-    or(): this;
+    or(): Ok<T>;
     // (undocumented)
-    orElse(): this;
+    orElse(): Ok<T>;
     // (undocumented)
     reduce<U>(reducer: Reducer<T, U>, accumulator: U): U;
     // (undocumented)
@@ -178,7 +182,7 @@ export class Ok<T> implements Result<T, never> {
     toJSON(): Ok.JSON<T>;
     // (undocumented)
     toString(): string;
-    }
+}
 
 // @public (undocumented)
 export namespace Ok {
@@ -196,7 +200,7 @@ export namespace Ok {
 }
 
 // @public (undocumented)
-export interface Result<T, E = T> extends Functor<T>, Monad<T>, Foldable<T>, Applicative<T>, Iterable<T>, Equatable, Hashable, Serializable<Result.JSON<T, E>> {
+export interface Result<T, E = T> extends Functor<T>, Applicative<T>, Monad<T>, Foldable<T>, Iterable<T>, Equatable, Hashable, Serializable<Result.JSON<T, E>> {
     // (undocumented)
     and<U>(result: Result<U, E>): Result<U, E>;
     // (undocumented)
@@ -211,6 +215,8 @@ export interface Result<T, E = T> extends Functor<T>, Monad<T>, Foldable<T>, App
     everyErr(predicate: Predicate<E>): boolean;
     // (undocumented)
     flatMap<U>(mapper: Mapper<T, Result<U, E>>): Result<U, E>;
+    // (undocumented)
+    flatten<T, E>(this: Result<Result<T, E>, E>): Result<T, E>;
     // (undocumented)
     get(): T;
     // (undocumented)
@@ -270,7 +276,6 @@ export namespace Result {
     // (undocumented)
     export function of<T, E>(value: T): Result<T, E>;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/docs/review/api/alfa-result.api.md
+++ b/docs/review/api/alfa-result.api.md
@@ -42,7 +42,7 @@ export class Err<E> implements Result<never, E> {
     // (undocumented)
     flatMap(): Err<E>;
     // (undocumented)
-    flatten<T, E>(this: Err<E>): Result<T, E>;
+    flatten<T, E>(this: Result<never, E>): Result<T, E>;
     // (undocumented)
     get(): never;
     // (undocumented)

--- a/docs/review/api/alfa-selective.api.md
+++ b/docs/review/api/alfa-selective.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { Applicative } from '@siteimprove/alfa-applicative';
 import { Either } from '@siteimprove/alfa-either';
 import { Equatable } from '@siteimprove/alfa-equatable';
 import { Functor } from '@siteimprove/alfa-functor';
@@ -16,9 +17,11 @@ import { Refinement } from '@siteimprove/alfa-refinement';
 import { Serializable } from '@siteimprove/alfa-json';
 
 // @public (undocumented)
-export class Selective<S, T = never> implements Functor<T>, Monad<T>, Iterable<S | T>, Equatable, Hashable, Serializable<Selective.JSON<S, T>> {
+export class Selective<S, T = never> implements Functor<T>, Applicative<T>, Monad<T>, Iterable<S | T>, Equatable, Hashable, Serializable<Selective.JSON<S, T>> {
     // (undocumented)
     [Symbol.iterator](): Iterator<S | T>;
+    // (undocumented)
+    apply<U>(mapper: Selective<S, Mapper<T, U>>): Selective<S, U>;
     // (undocumented)
     else<U>(mapper: Mapper<S, U>): Selective<never, T | U>;
     // (undocumented)
@@ -45,7 +48,7 @@ export class Selective<S, T = never> implements Functor<T>, Monad<T>, Iterable<S
     toJSON(): Selective.JSON<S, T>;
     // (undocumented)
     toString(): string;
-    }
+}
 
 // @public (undocumented)
 export namespace Selective {
@@ -53,7 +56,6 @@ export namespace Selective {
     // (undocumented)
     export type JSON<S, T = never> = Either.JSON<S, T>;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/docs/review/api/alfa-selective.api.md
+++ b/docs/review/api/alfa-selective.api.md
@@ -31,6 +31,8 @@ export class Selective<S, T = never> implements Functor<T>, Applicative<T>, Mona
     // (undocumented)
     flatMap<U>(mapper: Mapper<T, Selective<S, U>>): Selective<S, U>;
     // (undocumented)
+    flatten<S, T>(this: Selective<S, Selective<S, T>>): Selective<S, T>;
+    // (undocumented)
     get(): S | T;
     // (undocumented)
     hash(hash: Hash): void;

--- a/docs/review/api/alfa-selective.api.md
+++ b/docs/review/api/alfa-selective.api.md
@@ -28,6 +28,7 @@ export class Selective<S, T = never> implements Functor<T>, Applicative<T>, Mona
     equals<S, T>(value: Selective<S, T>): boolean;
     // (undocumented)
     equals(value: unknown): value is this;
+    exhaust<T>(this: Selective<never, T>): T;
     // (undocumented)
     flatMap<U>(mapper: Mapper<T, Selective<S, U>>): Selective<S, U>;
     // (undocumented)
@@ -54,7 +55,6 @@ export class Selective<S, T = never> implements Functor<T>, Applicative<T>, Mona
 
 // @public (undocumented)
 export namespace Selective {
-    export function exhaust<T>(selective: Selective<never, T>): T;
     // (undocumented)
     export type JSON<S, T = never> = Either.JSON<S, T>;
 }

--- a/docs/review/api/alfa-sequence.api.md
+++ b/docs/review/api/alfa-sequence.api.md
@@ -36,7 +36,9 @@ export class Cons<T> implements Sequence<T> {
     // (undocumented)
     collectFirst<U>(mapper: Mapper<T, Option<U>, [index: number]>): Option<U>;
     // (undocumented)
-    compareWith(iterable: Iterable_2<T>, comparer: Comparer<T>): Comparison;
+    compare(this: Sequence<Comparable<T>>, iterable: Iterable_2<T>): Comparison;
+    // (undocumented)
+    compareWith<U = T>(iterable: Iterable_2<U>, comparer: Comparer<T, U, [index: number]>): Comparison;
     // (undocumented)
     concat(iterable: Iterable_2<T>): Cons<T>;
     // (undocumented)
@@ -65,6 +67,8 @@ export class Cons<T> implements Sequence<T> {
     flatMap<U>(mapper: Mapper<T, Sequence<U>, [index: number]>): Sequence<U>;
     // @internal (undocumented)
     flatMap<U>(mapper: Mapper<T, Sequence<U>, [index: number]>, index: number): Sequence<U>;
+    // (undocumented)
+    flatten<T>(this: Sequence<Sequence<T>>): Sequence<T>;
     // (undocumented)
     forEach(callback: Callback<T, void, [index: number]>): void;
     // (undocumented)
@@ -133,6 +137,8 @@ export class Cons<T> implements Sequence<T> {
     slice(start: number, end?: number): Sequence<T>;
     // (undocumented)
     some(predicate: Predicate<T, [index: number]>): boolean;
+    // (undocumented)
+    sort<T extends Comparable<T>>(this: Sequence<T>): Sequence<T>;
     // (undocumented)
     sortWith(comparer: Comparer<T>): Sequence<T>;
     // (undocumented)
@@ -205,7 +211,9 @@ export interface Sequence<T> extends Collection.Indexed<T> {
     // (undocumented)
     collectFirst<U>(mapper: Mapper<T, Option<U>, [index: number]>): Option<U>;
     // (undocumented)
-    compareWith(iterable: Iterable<T>, comparer: Comparer<T>): Comparison;
+    compare(this: Sequence<Comparable<T>>, iterable: Iterable<T>): Comparison;
+    // (undocumented)
+    compareWith<U = T>(iterable: Iterable<U>, comparer: Comparer<T, U, [index: number]>): Comparison;
     // (undocumented)
     concat(iterable: Iterable<T>): Sequence<T>;
     // (undocumented)
@@ -226,6 +234,8 @@ export interface Sequence<T> extends Collection.Indexed<T> {
     first(): Option<T>;
     // (undocumented)
     flatMap<U>(mapper: Mapper<T, Sequence<U>, [index: number]>): Sequence<U>;
+    // (undocumented)
+    flatten<T>(this: Sequence<Sequence<T>>): Sequence<T>;
     // (undocumented)
     forEach(callback: Callback<T, void, [index: number]>): void;
     // (undocumented)
@@ -285,6 +295,8 @@ export interface Sequence<T> extends Collection.Indexed<T> {
     // (undocumented)
     some(predicate: Predicate<T, [index: number]>): boolean;
     // (undocumented)
+    sort<T extends Comparable<T>>(this: Sequence<T>): Sequence<T>;
+    // (undocumented)
     sortWith(comparer: Comparer<T>): Sequence<T>;
     // (undocumented)
     subtract(iterable: Iterable<T>): Sequence<T>;
@@ -321,11 +333,7 @@ export interface Sequence<T> extends Collection.Indexed<T> {
 // @public (undocumented)
 export namespace Sequence {
     // (undocumented)
-    export function compare<T extends Comparable<T>>(a: Sequence<T>, b: Iterable<T>): Comparison;
-    // (undocumented)
     export function empty<T = never>(): Sequence<T>;
-    // (undocumented)
-    export function flatten<T>(sequence: Sequence<Sequence<T>>): Sequence<T>;
     // (undocumented)
     export function from<T>(iterable: Iterable<T>): Sequence<T>;
     // (undocumented)
@@ -350,8 +358,6 @@ export namespace Sequence {
     export type JSON<T> = Cons.JSON<T> | Nil.JSON;
     // (undocumented)
     export function of<T>(head: T, tail?: Lazy<Sequence<T>>): Sequence<T>;
-    // (undocumented)
-    export function sort<T extends Comparable<T>>(sequence: Sequence<T>): Sequence<T>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/docs/review/api/alfa-set.api.md
+++ b/docs/review/api/alfa-set.api.md
@@ -54,6 +54,8 @@ class Set_2<T> implements Collection.Unkeyed<T> {
     // (undocumented)
     flatMap<U>(mapper: Mapper<T, Set_2<U>>): Set_2<U>;
     // (undocumented)
+    flatten<T>(this: Set_2<Set_2<T>>): Set_2<T>;
+    // (undocumented)
     forEach(callback: Callback<T>): void;
     // (undocumented)
     get(value: T): Option<T>;
@@ -93,7 +95,7 @@ class Set_2<T> implements Collection.Unkeyed<T> {
     toJSON(): Set_2.JSON<T>;
     // (undocumented)
     toString(): string;
-    }
+}
 
 // @public (undocumented)
 namespace Set_2 {
@@ -110,9 +112,7 @@ namespace Set_2 {
     // (undocumented)
     type JSON<T> = Collection.Unkeyed.JSON<T>;
 }
-
 export { Set_2 as Set }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/docs/review/api/alfa-slice.api.md
+++ b/docs/review/api/alfa-slice.api.md
@@ -7,6 +7,7 @@
 import { Array as Array_2 } from '@siteimprove/alfa-array';
 import { Callback } from '@siteimprove/alfa-callback';
 import { Collection } from '@siteimprove/alfa-collection';
+import { Comparable } from '@siteimprove/alfa-comparable';
 import { Comparer } from '@siteimprove/alfa-comparable';
 import { Comparison } from '@siteimprove/alfa-comparable';
 import { Hash } from '@siteimprove/alfa-hash';
@@ -33,7 +34,9 @@ export class Slice<T> implements Collection.Indexed<T> {
     // (undocumented)
     collectFirst<U>(mapper: Mapper<T, Option<U>, [index: number]>): Option<U>;
     // (undocumented)
-    compareWith(iterable: Iterable_2<T>, comparer: Comparer<T>): Comparison;
+    compare(this: Slice<Comparable<T>>, iterable: Iterable_2<T>): Comparison;
+    // (undocumented)
+    compareWith<U = T>(iterable: Iterable_2<U>, comparer: Comparer<T, U, [index: number]>): Comparison;
     // (undocumented)
     concat(iterable: Iterable_2<T>): Slice<T>;
     // (undocumented)
@@ -60,6 +63,8 @@ export class Slice<T> implements Collection.Indexed<T> {
     first(): Option<T>;
     // (undocumented)
     flatMap<U>(mapper: Mapper<T, Slice<U>, [index: number]>): Slice<U>;
+    // (undocumented)
+    flatten<T>(this: Slice<Slice<T>>): Slice<T>;
     // (undocumented)
     forEach(callback: Callback<T, void, [index: number]>): void;
     // (undocumented)
@@ -128,6 +133,8 @@ export class Slice<T> implements Collection.Indexed<T> {
     slice(start: number, end?: number): Slice<T>;
     // (undocumented)
     some(predicate: Predicate<T, [index: number]>): boolean;
+    // (undocumented)
+    sort<T extends Comparable<T>>(this: Slice<T>): Slice<T>;
     // (undocumented)
     sortWith(comparer: Comparer<T>): Slice<T>;
     // (undocumented)

--- a/docs/review/api/alfa-style.api.md
+++ b/docs/review/api/alfa-style.api.md
@@ -233,6 +233,8 @@ export class Value<T = unknown> implements Functor<T>, Applicative<T>, Monad<T>,
     // (undocumented)
     flatMap<U>(mapper: Mapper<T, Value<U>>): Value<U>;
     // (undocumented)
+    flatten<T>(this: Value<Value<T>>): Value<T>;
+    // (undocumented)
     includes(value: T): boolean;
     // (undocumented)
     map<U>(mapper: Mapper<T, U>): Value<U>;

--- a/docs/review/api/alfa-style.api.md
+++ b/docs/review/api/alfa-style.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { Angle } from '@siteimprove/alfa-css';
+import { Applicative } from '@siteimprove/alfa-applicative';
 import { Color } from '@siteimprove/alfa-css';
 import { Context } from '@siteimprove/alfa-selector';
 import { Current } from '@siteimprove/alfa-css';
@@ -222,9 +223,11 @@ export namespace Style {
 }
 
 // @public (undocumented)
-export class Value<T = unknown> implements Functor<T>, Monad<T>, Iterable<T>, Equatable, Serializable<Value.JSON<T>> {
+export class Value<T = unknown> implements Functor<T>, Applicative<T>, Monad<T>, Iterable<T>, Equatable, Serializable<Value.JSON<T>> {
     // (undocumented)
     [Symbol.iterator](): Iterator<T>;
+    // (undocumented)
+    apply<U>(mapper: Value<Mapper<T, U>>): Value<U>;
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)

--- a/docs/review/api/alfa-trampoline.api.md
+++ b/docs/review/api/alfa-trampoline.api.md
@@ -15,13 +15,15 @@ import { Reducer } from '@siteimprove/alfa-reducer';
 import { Thunk } from '@siteimprove/alfa-thunk';
 
 // @public (undocumented)
-export abstract class Trampoline<T> implements Functor<T>, Monad<T>, Foldable<T>, Applicative<T>, Iterable_2<T> {
+export abstract class Trampoline<T> implements Functor<T>, Applicative<T>, Monad<T>, Foldable<T>, Iterable_2<T> {
     // (undocumented)
     [Symbol.iterator](): Iterator<T>;
     // (undocumented)
     apply<U>(mapper: Trampoline<Mapper<T, U>>): Trampoline<U>;
     // (undocumented)
     abstract flatMap<U>(mapper: Mapper<T, Trampoline<U>>): Trampoline<U>;
+    // (undocumented)
+    flatten<T>(this: Trampoline<Trampoline<T>>): Trampoline<T>;
     // (undocumented)
     abstract isDone(): boolean;
     // (undocumented)
@@ -59,7 +61,6 @@ export namespace Trampoline {
     // (undocumented)
     export function traverse<T, U>(values: Iterable_2<T>, mapper: Mapper<T, Trampoline<U>, [index: number]>): Trampoline<Iterable_2<U>>;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "scripts": {
-    "build": "node scripts/build.js --pretty",
+    "build": "node --max-old-space-size=4096 scripts/build.js --pretty",
     "clean": "node scripts/clean.js --pretty",
     "test": "node scripts/test.js --pretty",
     "watch": "node scripts/watch.js --pretty",

--- a/packages/alfa-act/package.json
+++ b/packages/alfa-act/package.json
@@ -18,6 +18,7 @@
     "src/**/*.d.ts"
   ],
   "dependencies": {
+    "@siteimprove/alfa-applicative": "workspace:^0.20.0",
     "@siteimprove/alfa-earl": "workspace:^0.20.0",
     "@siteimprove/alfa-equatable": "workspace:^0.20.0",
     "@siteimprove/alfa-functor": "workspace:^0.20.0",

--- a/packages/alfa-act/src/question.ts
+++ b/packages/alfa-act/src/question.ts
@@ -1,3 +1,4 @@
+import { Applicative } from "@siteimprove/alfa-applicative";
 import { Functor } from "@siteimprove/alfa-functor";
 import { Serializable } from "@siteimprove/alfa-json";
 import { Mapper } from "@siteimprove/alfa-mapper";
@@ -9,7 +10,12 @@ import * as json from "@siteimprove/alfa-json";
  * @public
  */
 export class Question<Q, S, A, T = A>
-  implements Functor<T>, Monad<T>, Serializable<Question.JSON<Q, S>> {
+  implements
+    Functor<T>,
+    Applicative<T>,
+    Monad<T>,
+    Serializable<Question.JSON<Q, S>>
+{
   public static of<Q, A, S>(
     uri: string,
     type: Q,
@@ -63,6 +69,12 @@ export class Question<Q, S, A, T = A>
       this._message,
       (answer) => mapper(this._quester(answer))
     );
+  }
+
+  public apply<U>(
+    mapper: Question<Q, S, A, Mapper<T, U>>
+  ): Question<Q, S, A, U> {
+    return mapper.flatMap((mapper) => this.map(mapper));
   }
 
   public flatMap<U>(

--- a/packages/alfa-act/src/question.ts
+++ b/packages/alfa-act/src/question.ts
@@ -89,6 +89,12 @@ export class Question<Q, S, A, T = A>
     );
   }
 
+  public flatten<Q, S, A, T>(
+    this: Question<Q, S, A, Question<Q, S, A, T>>
+  ): Question<Q, S, A, T> {
+    return this.flatMap((question) => question);
+  }
+
   public answer(answer: A): T {
     return this._quester(answer);
   }

--- a/packages/alfa-act/tsconfig.json
+++ b/packages/alfa-act/tsconfig.json
@@ -16,6 +16,9 @@
   ],
   "references": [
     {
+      "path": "../alfa-applicative"
+    },
+    {
       "path": "../alfa-earl"
     },
     {

--- a/packages/alfa-applicative/package.json
+++ b/packages/alfa-applicative/package.json
@@ -18,6 +18,7 @@
     "src/**/*.d.ts"
   ],
   "dependencies": {
+    "@siteimprove/alfa-functor": "workspace:^0.20.0",
     "@siteimprove/alfa-mapper": "workspace:^0.20.0"
   },
   "devDependencies": {

--- a/packages/alfa-applicative/src/applicative.ts
+++ b/packages/alfa-applicative/src/applicative.ts
@@ -1,8 +1,9 @@
+import { Functor } from "@siteimprove/alfa-functor";
 import { Mapper } from "@siteimprove/alfa-mapper";
 
 /**
  * @public
  */
-export interface Applicative<T> {
+export interface Applicative<T> extends Functor<T> {
   apply<U>(mapper: Applicative<Mapper<T, U>>): Applicative<U>;
 }

--- a/packages/alfa-applicative/src/applicative.ts
+++ b/packages/alfa-applicative/src/applicative.ts
@@ -5,5 +5,6 @@ import { Mapper } from "@siteimprove/alfa-mapper";
  * @public
  */
 export interface Applicative<T> extends Functor<T> {
+  map<U>(mapper: Mapper<T, U>): Applicative<U>;
   apply<U>(mapper: Applicative<Mapper<T, U>>): Applicative<U>;
 }

--- a/packages/alfa-applicative/tsconfig.json
+++ b/packages/alfa-applicative/tsconfig.json
@@ -4,6 +4,9 @@
   "files": ["src/applicative.ts", "src/index.ts"],
   "references": [
     {
+      "path": "../alfa-functor"
+    },
+    {
       "path": "../alfa-mapper"
     },
     {

--- a/packages/alfa-array/src/array.ts
+++ b/packages/alfa-array/src/array.ts
@@ -158,10 +158,10 @@ export namespace Array {
   }
 
   export function apply<T, U>(
-    iterable: ReadonlyArray<T>,
+    array: ReadonlyArray<T>,
     mapper: ReadonlyArray<Mapper<T, U>>
   ): Array<U> {
-    return flatMap(iterable, (value) => map(mapper, (mapper) => mapper(value)));
+    return flatMap(mapper, (mapper) => map(array, mapper));
   }
 
   export function filter<T, U extends T>(

--- a/packages/alfa-array/src/array.ts
+++ b/packages/alfa-array/src/array.ts
@@ -373,7 +373,10 @@ export namespace Array {
     index: number,
     value: T
   ): Array<T> {
-    array.splice(index, 0, value);
+    if (index <= array.length) {
+      array.splice(index, 0, value);
+    }
+
     return array;
   }
 
@@ -447,17 +450,17 @@ export namespace Array {
     return array.sort(comparer);
   }
 
-  export function compare<T extends Comparable<T>>(
+  export function compare<T extends Comparable<U>, U = T>(
     a: ReadonlyArray<T>,
-    b: Iterable<T>
+    b: Iterable<U>
   ): Comparison {
     return compareWith(a, b, compareComparable);
   }
 
-  export function compareWith<T>(
+  export function compareWith<T, U = T>(
     a: ReadonlyArray<T>,
-    b: Iterable<T>,
-    comparer: Comparer<T>
+    b: Iterable<U>,
+    comparer: Comparer<T, U, [index: number]>
   ): Comparison {
     return Iterable.compareWith(a, b, comparer);
   }

--- a/packages/alfa-branched/src/branched.ts
+++ b/packages/alfa-branched/src/branched.ts
@@ -17,7 +17,8 @@ const { not } = Predicate;
  * @public
  */
 export class Branched<T, B = never>
-  implements Collection<T>, Iterable<[T, Iterable<B>]> {
+  implements Collection<T>, Iterable<[T, Iterable<B>]>
+{
   public static of<T, B = never>(
     value: T,
     ...branches: Array<B>
@@ -72,6 +73,10 @@ export class Branched<T, B = never>
     );
   }
 
+  public apply<U>(mapper: Branched<Mapper<T, U>, B>): Branched<U, B> {
+    return mapper.flatMap((mapper) => this.map(mapper));
+  }
+
   public flatMap<U>(
     mapper: Mapper<T, Branched<U, B>, [Iterable<B>]>
   ): Branched<U, B> {
@@ -95,6 +100,10 @@ export class Branched<T, B = never>
     );
   }
 
+  public flatten<T, B>(this: Branched<Branched<T, B>, B>): Branched<T, B> {
+    return this.flatMap((branched) => branched);
+  }
+
   public reduce<U>(reducer: Reducer<T, U, [Iterable<B>]>, accumulator: U): U {
     return this._values.reduce(
       (accumulator, value) =>
@@ -105,10 +114,6 @@ export class Branched<T, B = never>
         ),
       accumulator
     );
-  }
-
-  public apply<U>(mapper: Branched<Mapper<T, U>, B>): Branched<U, B> {
-    return this.flatMap((value) => mapper.map((mapper) => mapper(value)));
   }
 
   public filter<U extends T>(

--- a/packages/alfa-collection/src/collection.ts
+++ b/packages/alfa-collection/src/collection.ts
@@ -14,25 +14,24 @@ import { Predicate } from "@siteimprove/alfa-predicate";
 import { Reducer } from "@siteimprove/alfa-reducer";
 import { Refinement } from "@siteimprove/alfa-refinement";
 
-const { compareComparable } = Comparable;
-
 /**
  * @public
  */
 export interface Collection<T>
   extends Functor<T>,
+    Applicative<T>,
     Monad<T>,
     Foldable<T>,
-    Applicative<T>,
     Equatable,
     Hashable {
   readonly size: number;
   isEmpty(): this is Collection<never>;
   forEach(callback: Callback<T>): void;
   map<U>(mapper: Mapper<T, U>): Collection<U>;
-  flatMap<U>(mapper: Mapper<T, Collection<U>>): Collection<U>;
-  reduce<U>(reducer: Reducer<T, U>, accumulator: U): U;
   apply<U>(mapper: Collection<Mapper<T, U>>): Collection<U>;
+  flatMap<U>(mapper: Mapper<T, Collection<U>>): Collection<U>;
+  flatten<T>(this: Collection<Collection<T>>): Collection<T>;
+  reduce<U>(reducer: Reducer<T, U>, accumulator: U): U;
   filter<U extends T>(refinement: Refinement<T, U>): Collection<U>;
   filter(predicate: Predicate<T>): Collection<T>;
   reject<U extends T>(refinement: Refinement<T, U>): Collection<Exclude<T, U>>;
@@ -60,9 +59,10 @@ export namespace Collection {
     isEmpty(): this is Keyed<K, never>;
     forEach(callback: Callback<V, void, [key: K]>): void;
     map<U>(mapper: Mapper<V, U, [key: K]>): Keyed<K, U>;
-    flatMap<U>(mapper: Mapper<V, Keyed<K, U>, [key: K]>): Keyed<K, U>;
-    reduce<U>(reducer: Reducer<V, U, [key: K]>, accumulator: U): U;
     apply<U>(mapper: Keyed<K, Mapper<V, U>>): Keyed<K, U>;
+    flatMap<U>(mapper: Mapper<V, Keyed<K, U>, [key: K]>): Keyed<K, U>;
+    flatten<K, V>(this: Keyed<K, Keyed<K, V>>): Keyed<K, V>;
+    reduce<U>(reducer: Reducer<V, U, [key: K]>, accumulator: U): U;
     filter<U extends V>(refinement: Refinement<V, U, [key: K]>): Keyed<K, U>;
     filter(predicate: Predicate<V, [key: K]>): Keyed<K, V>;
     reject<U extends V>(
@@ -101,9 +101,10 @@ export namespace Collection {
     isEmpty(): this is Unkeyed<never>;
     forEach(callback: Callback<T>): void;
     map<U>(mapper: Mapper<T, U>): Unkeyed<U>;
-    flatMap<U>(mapper: Mapper<T, Unkeyed<U>>): Unkeyed<U>;
-    reduce<U>(reducer: Reducer<T, U>, accumulator: U): U;
     apply<U>(mapper: Unkeyed<Mapper<T, U>>): Unkeyed<U>;
+    flatMap<U>(mapper: Mapper<T, Unkeyed<U>>): Unkeyed<U>;
+    flatten<T>(this: Unkeyed<Unkeyed<T>>): Unkeyed<T>;
+    reduce<U>(reducer: Reducer<T, U>, accumulator: U): U;
     filter<U extends T>(refinement: Refinement<T, U>): Unkeyed<U>;
     filter(predicate: Predicate<T>): Unkeyed<T>;
     reject<U extends T>(refinement: Refinement<T, U>): Unkeyed<Exclude<T, U>>;
@@ -134,11 +135,14 @@ export namespace Collection {
   export interface Indexed<T>
     extends Collection<T>,
       Iterable<T>,
+      Comparable<Iterable<T>>,
       Serializable<Indexed.JSON<T>> {
     isEmpty(): this is Indexed<never>;
     forEach(callback: Callback<T, void, [index: number]>): void;
     map<U>(mapper: Mapper<T, U, [index: number]>): Indexed<U>;
+    apply<U>(mapper: Indexed<Mapper<T, U>>): Indexed<U>;
     flatMap<U>(mapper: Mapper<T, Indexed<U>, [index: number]>): Indexed<U>;
+    flatten<T>(this: Indexed<Indexed<T>>): Indexed<T>;
     reduce<U>(reducer: Reducer<T, U, [index: number]>, accumulator: U): U;
     reduceWhile<U>(
       predicate: Predicate<T, [index: number]>,
@@ -150,7 +154,6 @@ export namespace Collection {
       reducer: Reducer<T, U, [index: number]>,
       accumulator: U
     ): U;
-    apply<U>(mapper: Indexed<Mapper<T, U>>): Indexed<U>;
     filter<U extends T>(
       refinement: Refinement<T, U, [index: number]>
     ): Indexed<U>;
@@ -206,24 +209,16 @@ export namespace Collection {
     slice(start: number, end?: number): Indexed<T>;
     reverse(): Indexed<T>;
     join(separator: string): string;
+    sort<T extends Comparable<T>>(this: Indexed<T>): Indexed<T>;
     sortWith(comparer: Comparer<T>): Indexed<T>;
-    compareWith(iterable: Iterable<T>, comparer: Comparer<T>): Comparison;
+    compare(this: Indexed<Comparable<T>>, iterable: Iterable<T>): Comparison;
+    compareWith<U = T>(
+      iterable: Iterable<U>,
+      comparer: Comparer<T, U, [index: number]>
+    ): Comparison;
   }
 
   export namespace Indexed {
     export type JSON<T> = Array<Serializable.ToJSON<T>>;
-  }
-
-  export function sort<T extends Comparable<T>>(
-    collection: Indexed<T>
-  ): Indexed<T> {
-    return collection.sortWith(compareComparable);
-  }
-
-  export function compare<T extends Comparable<T>>(
-    a: Indexed<T>,
-    b: Iterable<T>
-  ): Comparison {
-    return a.compareWith(b, compareComparable);
   }
 }

--- a/packages/alfa-comparable/src/comparable.ts
+++ b/packages/alfa-comparable/src/comparable.ts
@@ -2,43 +2,91 @@ import { Refinement } from "@siteimprove/alfa-refinement";
 
 import { Comparison } from "./comparison";
 
-const {
-  isString,
-  isNumber,
-  isBigInt,
-  isBoolean,
-  isFunction,
-  isObject,
-} = Refinement;
+const { isString, isNumber, isBigInt, isBoolean, isFunction, isObject } =
+  Refinement;
 
 /**
+ * This interface describes strcutures that define a
+ * {@link https://en.wikipedia.org/wiki/Total_order | total order}.
+ *
+ * @example
+ * ```ts
+ * class Foo implements Comparable<Foo> {
+ *   readonly value: number;
+ *
+ *  constructor(value: number) {
+ *    this.value = value;
+ *  }
+ *
+ *  compare(value: Foo): Comparison {
+ *    if (this.value < value.value) {
+ *      return Comparison.Less;
+ *    }
+ *
+ *    if (this.value > value.value) {
+ *      return Comparison.Greater;
+ *    }
+ *
+ *    return Comparison.Equal;
+ *  }
+ *}
+ * ```
+ *
  * @public
  */
 export interface Comparable<T> {
+  /**
+   * Compare a value to this.
+   */
   compare(value: T): Comparison;
 }
 
 /**
+ * This namespace provides additional functions for the
+ * {@link (Comparable:interface)} interface.
+ *
  * @public
  */
 export namespace Comparable {
+  /**
+   * Check if an unknown value implements the {@link (Comparable:interface)}
+   * interface.
+   */
   export function isComparable<T>(value: unknown): value is Comparable<T> {
     return isObject(value) && isFunction(value.compare);
   }
 
+  /**
+   * Compare two strings.
+   */
   export function compare(a: string, b: string): Comparison;
 
+  /**
+   * Compare two numbers.
+   */
   export function compare(a: number, b: number): Comparison;
 
+  /**
+   * Compare two big integers.
+   */
   export function compare(a: bigint, b: bigint): Comparison;
 
+  /**
+   * Compare two booleans.
+   */
   export function compare(a: boolean, b: boolean): Comparison;
 
-  export function compare<T>(a: Comparable<T>, b: T): Comparison;
+  /**
+   * Compare two comparable values.
+   */
+  export function compare<T extends Comparable<U>, U = T>(
+    a: T,
+    b: U
+  ): Comparison;
 
-  export function compare<T extends unknown>(
-    a: string | number | bigint | boolean | Comparable<T>,
-    b: T
+  export function compare(
+    a: string | number | bigint | boolean | Comparable<unknown>,
+    b: unknown
   ): Comparison {
     if (isString(a)) {
       return compareString(a, b as string);
@@ -100,10 +148,16 @@ export namespace Comparable {
    * This should only be used in cases where branch mispredictions caused by the
    * more general {@link (Comparable:namespace).(compare:5)} are undesired.
    */
-  export function compareComparable<T>(a: Comparable<T>, b: T): Comparison {
+  export function compareComparable<T extends Comparable<U>, U = T>(
+    a: T,
+    b: U
+  ): Comparison {
     return a.compare(b);
   }
 
+  /**
+   * Compare two primitive values.
+   */
   function comparePrimitive<T extends string | number | bigint | boolean>(
     a: T,
     b: T
@@ -119,18 +173,37 @@ export namespace Comparable {
     return Comparison.Equal;
   }
 
+  /**
+   * Check if one value is less than another.
+   */
   export function isLessThan<T>(a: Comparable<T>, b: T): boolean {
     return a.compare(b) < 0;
   }
 
+  /**
+   * Check if one value is less than or equal to another.
+   */
   export function isLessThanOrEqual<T>(a: Comparable<T>, b: T): boolean {
     return a.compare(b) <= 0;
   }
 
+  /**
+   * Check if one value is equal to another
+   */
+  export function isEqual<T>(a: Comparable<T>, b: T): boolean {
+    return a.compare(b) === 0;
+  }
+
+  /**
+   * Check if one value is greater than another.
+   */
   export function isGreaterThan<T>(a: Comparable<T>, b: T): boolean {
     return a.compare(b) > 0;
   }
 
+  /**
+   * Check if one value is greater than or equal to another.
+   */
   export function isGreaterThanOrEqual<T>(a: Comparable<T>, b: T): boolean {
     return a.compare(b) >= 0;
   }

--- a/packages/alfa-comparable/src/comparer.ts
+++ b/packages/alfa-comparable/src/comparer.ts
@@ -3,8 +3,8 @@ import { Comparison } from "./comparison";
 /**
  * @public
  */
-export type Comparer<T, A extends Array<unknown> = []> = (
+export type Comparer<T, U = T, A extends Array<unknown> = []> = (
   a: T,
-  b: T,
+  b: U,
   ...args: A
 ) => Comparison;

--- a/packages/alfa-either/package.json
+++ b/packages/alfa-either/package.json
@@ -18,6 +18,7 @@
     "src/**/*.d.ts"
   ],
   "dependencies": {
+    "@siteimprove/alfa-applicative": "workspace:^0.20.0",
     "@siteimprove/alfa-equatable": "workspace:^0.20.0",
     "@siteimprove/alfa-foldable": "workspace:^0.20.0",
     "@siteimprove/alfa-functor": "workspace:^0.20.0",

--- a/packages/alfa-either/src/either.ts
+++ b/packages/alfa-either/src/either.ts
@@ -29,6 +29,7 @@ export interface Either<L, R = L>
   map<T>(mapper: Mapper<R, T>): Either<L, T>;
   apply<T>(mapper: Either<L, Mapper<R, T>>): Either<L, T>;
   flatMap<T>(mapper: Mapper<R, Either<L, T>>): Either<L, T>;
+  flatten<L, R>(this: Either<L, Either<L, R>>): Either<L, R>;
   reduce<T>(reducer: Reducer<R, T>, accumulator: T): T;
   either<T>(left: Mapper<L, T>, right: Mapper<R, T>): T;
   get(): L | R;

--- a/packages/alfa-either/src/either.ts
+++ b/packages/alfa-either/src/either.ts
@@ -1,3 +1,4 @@
+import { Applicative } from "@siteimprove/alfa-applicative";
 import { Equatable } from "@siteimprove/alfa-equatable";
 import { Foldable } from "@siteimprove/alfa-foldable";
 import { Functor } from "@siteimprove/alfa-functor";
@@ -15,18 +16,20 @@ import { Right } from "./right";
  * @public
  */
 export interface Either<L, R = L>
-  extends Functor<L | R>,
-    Monad<L | R>,
-    Foldable<L | R>,
+  extends Functor<R>,
+    Applicative<R>,
+    Monad<R>,
+    Foldable<R>,
     Iterable<L | R>,
     Equatable,
     Hashable,
     Serializable<Either.JSON<L, R>> {
   isLeft(): this is Left<L>;
   isRight(): this is Right<R>;
-  map<T>(mapper: Mapper<L | R, T>): Either<T, T>;
-  flatMap<T>(mapper: Mapper<L | R, Either<T, T>>): Either<T, T>;
-  reduce<T>(reducer: Reducer<L | R, T>, accumulator: T): T;
+  map<T>(mapper: Mapper<R, T>): Either<L, T>;
+  apply<T>(mapper: Either<L, Mapper<R, T>>): Either<L, T>;
+  flatMap<T>(mapper: Mapper<R, Either<L, T>>): Either<L, T>;
+  reduce<T>(reducer: Reducer<R, T>, accumulator: T): T;
   either<T>(left: Mapper<L, T>, right: Mapper<R, T>): T;
   get(): L | R;
   left(): Option<L>;

--- a/packages/alfa-either/src/left.ts
+++ b/packages/alfa-either/src/left.ts
@@ -3,7 +3,6 @@ import { Hash } from "@siteimprove/alfa-hash";
 import { Serializable } from "@siteimprove/alfa-json";
 import { Mapper } from "@siteimprove/alfa-mapper";
 import { None, Option } from "@siteimprove/alfa-option";
-import { Reducer } from "@siteimprove/alfa-reducer";
 
 import * as json from "@siteimprove/alfa-json";
 
@@ -32,16 +31,20 @@ export class Left<L> implements Either<L, never> {
     return false;
   }
 
-  public map<T>(mapper: Mapper<L, T>): Either<T, T> {
-    return new Left(mapper(this._value));
+  public map(): Left<L> {
+    return this;
   }
 
-  public flatMap<T>(mapper: Mapper<L, Either<T, T>>): Either<T, T> {
-    return mapper(this._value);
+  public apply(): Left<L> {
+    return this;
   }
 
-  public reduce<T>(reducer: Reducer<L, T>, accumulator: T): T {
-    return reducer(accumulator, this._value);
+  public flatMap(): Left<L> {
+    return this;
+  }
+
+  public reduce<T>(reducer: unknown, accumulator: T): T {
+    return accumulator;
   }
 
   public either<T>(left: Mapper<L, T>): T {

--- a/packages/alfa-either/src/left.ts
+++ b/packages/alfa-either/src/left.ts
@@ -43,6 +43,10 @@ export class Left<L> implements Either<L, never> {
     return this;
   }
 
+  public flatten<L>(this: Either<L, never>): Left<L> {
+    return this as Left<L>;
+  }
+
   public reduce<T>(reducer: unknown, accumulator: T): T {
     return accumulator;
   }

--- a/packages/alfa-either/src/left.ts
+++ b/packages/alfa-either/src/left.ts
@@ -43,8 +43,8 @@ export class Left<L> implements Either<L, never> {
     return this;
   }
 
-  public flatten<L>(this: Either<L, never>): Left<L> {
-    return this as Left<L>;
+  public flatten<L, R>(this: Either<L, never>): Either<L, R> {
+    return this;
   }
 
   public reduce<T>(reducer: unknown, accumulator: T): T {

--- a/packages/alfa-either/src/right.ts
+++ b/packages/alfa-either/src/right.ts
@@ -32,11 +32,15 @@ export class Right<R> implements Either<never, R> {
     return true;
   }
 
-  public map<T>(mapper: Mapper<R, T>): Either<T, T> {
+  public map<T>(mapper: Mapper<R, T>): Right<T> {
     return new Right(mapper(this._value));
   }
 
-  public flatMap<T>(mapper: Mapper<R, Either<T, T>>): Either<T, T> {
+  public apply<L, T>(mapper: Either<L, Mapper<R, T>>): Either<L, T> {
+    return mapper.map((mapper) => mapper(this._value));
+  }
+
+  public flatMap<L, T>(mapper: Mapper<R, Either<L, T>>): Either<L, T> {
     return mapper(this._value);
   }
 

--- a/packages/alfa-either/src/right.ts
+++ b/packages/alfa-either/src/right.ts
@@ -44,6 +44,10 @@ export class Right<R> implements Either<never, R> {
     return mapper(this._value);
   }
 
+  public flatten<L, R>(this: Right<Either<L, R>>): Either<L, R> {
+    return this._value;
+  }
+
   public reduce<T>(reducer: Reducer<R, T>, accumulator: T): T {
     return reducer(accumulator, this._value);
   }

--- a/packages/alfa-either/tsconfig.json
+++ b/packages/alfa-either/tsconfig.json
@@ -4,6 +4,9 @@
   "files": ["src/either.ts", "src/index.ts", "src/left.ts", "src/right.ts"],
   "references": [
     {
+      "path": "../alfa-applicative"
+    },
+    {
       "path": "../alfa-equatable"
     },
     {

--- a/packages/alfa-equatable/src/equatable.ts
+++ b/packages/alfa-equatable/src/equatable.ts
@@ -1,4 +1,26 @@
 /**
+ * This interface describes structures that define an
+ * {@link https://en.wikipedia.org/wiki/Equivalence_relation | equivalence relation}.
+ *
+ * @example
+ * ```ts
+ * class Foo implements Equatable {
+ *   readonly value: number;
+ *
+ *   constructor(value: number) {
+ *     this.value = value;
+ *   }
+ *
+ *   equals(value: Foo): boolean;
+ *
+ *   equals(value: unknown): value is this;
+ *
+ *   equals(value: unknown): boolean {
+ *     return value instanceof Foo && value.value === this.value;
+ *   }
+ * }
+ * ```
+ *
  * @public
  */
 export interface Equatable {
@@ -20,6 +42,9 @@ export interface Equatable {
 }
 
 /**
+ * This namespace provides additional types and functions for the
+ * {@link (Equatable:interface)} interface.
+ *
  * @public
  */
 export namespace Equatable {

--- a/packages/alfa-future/src/future.ts
+++ b/packages/alfa-future/src/future.ts
@@ -17,10 +17,11 @@ import { Thunk } from "@siteimprove/alfa-thunk";
 export abstract class Future<T>
   implements
     Functor<T>,
-    Monad<T>,
     Applicative<T>,
+    Monad<T>,
     Thenable<T>,
-    AsyncIterable<T> {
+    AsyncIterable<T>
+{
   protected abstract step(): Future<T>;
 
   public then(callback: Callback<T>): void {
@@ -61,10 +62,14 @@ export abstract class Future<T>
     return this.flatMap((value) => Now.of(mapper(value)));
   }
 
-  public abstract flatMap<U>(mapper: Mapper<T, Future<U>>): Future<U>;
-
   public apply<U>(mapper: Future<Mapper<T, U>>): Future<U> {
     return this.flatMap((value) => mapper.map((mapper) => mapper(value)));
+  }
+
+  public abstract flatMap<U>(mapper: Mapper<T, Future<U>>): Future<U>;
+
+  public flatten<T>(this: Future<Future<T>>): Future<T> {
+    return this.flatMap((future) => future);
   }
 
   public tee(callback: Callback<T>): Future<T> {

--- a/packages/alfa-future/src/future.ts
+++ b/packages/alfa-future/src/future.ts
@@ -63,7 +63,7 @@ export abstract class Future<T>
   }
 
   public apply<U>(mapper: Future<Mapper<T, U>>): Future<U> {
-    return this.flatMap((value) => mapper.map((mapper) => mapper(value)));
+    return mapper.flatMap((mapper) => this.map(mapper));
   }
 
   public abstract flatMap<U>(mapper: Mapper<T, Future<U>>): Future<U>;

--- a/packages/alfa-iterable/src/iterable.ts
+++ b/packages/alfa-iterable/src/iterable.ts
@@ -747,20 +747,22 @@ export namespace Iterable {
     yield* [...iterable].sort(comparer);
   }
 
-  export function compare<T extends Comparable<T>>(
+  export function compare<T extends Comparable<U>, U = T>(
     a: Iterable<T>,
-    b: Iterable<T>
+    b: Iterable<U>
   ): Comparison {
     return compareWith(a, b, compareComparable);
   }
 
-  export function compareWith<T>(
+  export function compareWith<T, U = T>(
     a: Iterable<T>,
-    b: Iterable<T>,
-    comparer: Comparer<T>
+    b: Iterable<U>,
+    comparer: Comparer<T, U, [index: number]>
   ): Comparison {
     const itA = iterator(a);
     const itB = iterator(b);
+
+    let index = 0;
 
     while (true) {
       const a = itA.next();
@@ -774,7 +776,7 @@ export namespace Iterable {
         return Comparison.Greater;
       }
 
-      const result = comparer(a.value, b.value);
+      const result = comparer(a.value, b.value, index++);
 
       if (result !== 0) {
         return result;

--- a/packages/alfa-iterable/src/iterable.ts
+++ b/packages/alfa-iterable/src/iterable.ts
@@ -137,7 +137,7 @@ export namespace Iterable {
     iterable: Iterable<T>,
     mapper: Iterable<Mapper<T, U>>
   ): Iterable<U> {
-    return flatMap(iterable, (value) => map(mapper, (mapper) => mapper(value)));
+    return flatMap(mapper, (mapper) => map(iterable, mapper));
   }
 
   export function filter<T, U extends T>(

--- a/packages/alfa-json/src/serializable.ts
+++ b/packages/alfa-json/src/serializable.ts
@@ -4,14 +4,8 @@ import { JSON } from "./json";
 
 const { keys } = Object;
 const { isArray } = Array;
-const {
-  isFunction,
-  isObject,
-  isString,
-  isNumber,
-  isBoolean,
-  isNull,
-} = Refinement;
+const { isFunction, isObject, isString, isNumber, isBoolean, isNull } =
+  Refinement;
 
 /**
  * @public

--- a/packages/alfa-lazy/package.json
+++ b/packages/alfa-lazy/package.json
@@ -18,6 +18,7 @@
     "src/**/*.d.ts"
   ],
   "dependencies": {
+    "@siteimprove/alfa-applicative": "workspace:^0.20.0",
     "@siteimprove/alfa-equatable": "workspace:^0.20.0",
     "@siteimprove/alfa-functor": "workspace:^0.20.0",
     "@siteimprove/alfa-json": "workspace:^0.20.0",

--- a/packages/alfa-lazy/src/lazy.ts
+++ b/packages/alfa-lazy/src/lazy.ts
@@ -1,3 +1,4 @@
+import { Applicative } from "@siteimprove/alfa-applicative";
 import { Equatable } from "@siteimprove/alfa-equatable";
 import { Functor } from "@siteimprove/alfa-functor";
 import { Serializable } from "@siteimprove/alfa-json";
@@ -12,10 +13,12 @@ import { Trampoline } from "@siteimprove/alfa-trampoline";
 export class Lazy<T>
   implements
     Functor<T>,
+    Applicative<T>,
     Monad<T>,
     Iterable<T>,
     Equatable,
-    Serializable<Lazy.JSON<T>> {
+    Serializable<Lazy.JSON<T>>
+{
   public static of<T>(thunk: Thunk<T>): Lazy<T> {
     return new Lazy(Trampoline.delay(thunk));
   }
@@ -50,6 +53,10 @@ export class Lazy<T>
     );
   }
 
+  public apply<U>(mapper: Lazy<Mapper<T, U>>): Lazy<U> {
+    return mapper.map((mapper) => mapper(this.force()));
+  }
+
   public flatMap<U>(mapper: Mapper<T, Lazy<U>>): Lazy<U> {
     return new Lazy(
       this._value.flatMap((value) => {
@@ -60,6 +67,10 @@ export class Lazy<T>
         return mapper(value)._value;
       })
     );
+  }
+
+  public flatten<T>(this: Lazy<Lazy<T>>): Lazy<T> {
+    return this.flatMap((lazy) => lazy);
   }
 
   public equals<T>(value: Lazy<T>): boolean;

--- a/packages/alfa-lazy/tsconfig.json
+++ b/packages/alfa-lazy/tsconfig.json
@@ -4,6 +4,9 @@
   "files": ["src/index.ts", "src/lazy.ts", "test/lazy.spec.ts"],
   "references": [
     {
+      "path": "../alfa-applicative"
+    },
+    {
       "path": "../alfa-equatable"
     },
     {

--- a/packages/alfa-list/package.json
+++ b/packages/alfa-list/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://alfa.siteimprove.com",
   "version": "0.20.0",
   "license": "MIT",
-  "description": "An implementation of an immutable list structure, based on a persistent vector trie",
+  "description": "An implementation of an immutable list structure, based on a bit-partitioned vector trie",
   "repository": {
     "type": "git",
     "url": "https://github.com/siteimprove/alfa.git",

--- a/packages/alfa-list/src/list.ts
+++ b/packages/alfa-list/src/list.ts
@@ -90,6 +90,10 @@ export class List<T> implements Collection.Indexed<T> {
     );
   }
 
+  public flatten<T>(this: List<List<T>>): List<T> {
+    return this.flatMap((list) => list);
+  }
+
   public reduce<U>(reducer: Reducer<T, U, [index: number]>, accumulator: U): U {
     return Iterable.reduce(this, reducer, accumulator);
   }
@@ -395,11 +399,22 @@ export class List<T> implements Collection.Indexed<T> {
     return Iterable.join(this, separator);
   }
 
+  public sort<T extends Comparable<T>>(this: List<T>): List<T> {
+    return this.sortWith(compareComparable);
+  }
+
   public sortWith(comparer: Comparer<T>): List<T> {
     return List.from(Iterable.sortWith(this, comparer));
   }
 
-  public compareWith(iterable: Iterable<T>, comparer: Comparer<T>): Comparison {
+  public compare(this: List<Comparable<T>>, iterable: Iterable<T>): Comparison {
+    return this.compareWith(iterable, compareComparable);
+  }
+
+  public compareWith<U = T>(
+    iterable: Iterable<U>,
+    comparer: Comparer<T, U, [index: number]>
+  ): Comparison {
     return Iterable.compareWith(this, iterable, comparer);
   }
 
@@ -686,16 +701,5 @@ export namespace List {
       (list, value) => list.append(value),
       List.empty()
     );
-  }
-
-  export function sort<T extends Comparable<T>>(list: List<T>): List<T> {
-    return list.sortWith(compareComparable);
-  }
-
-  export function compare<T extends Comparable<T>>(
-    a: List<T>,
-    b: Iterable<T>
-  ): Comparison {
-    return a.compareWith(b, compareComparable);
   }
 }

--- a/packages/alfa-list/src/list.ts
+++ b/packages/alfa-list/src/list.ts
@@ -83,6 +83,10 @@ export class List<T> implements Collection.Indexed<T> {
     );
   }
 
+  public apply<U>(mapper: List<Mapper<T, U>>): List<U> {
+    return mapper.flatMap((mapper) => this.map(mapper));
+  }
+
   public flatMap<U>(mapper: Mapper<T, List<U>, [index: number]>): List<U> {
     return this.reduce(
       (list, value, index) => list.concat(mapper(value, index)),
@@ -112,10 +116,6 @@ export class List<T> implements Collection.Indexed<T> {
     accumulator: U
   ): U {
     return Iterable.reduceUntil(this, predicate, reducer, accumulator);
-  }
-
-  public apply<U>(mapper: List<Mapper<T, U>>): List<U> {
-    return this.flatMap((value) => mapper.map((mapper) => mapper(value)));
   }
 
   public filter<U extends T>(

--- a/packages/alfa-list/test/list.spec.ts
+++ b/packages/alfa-list/test/list.spec.ts
@@ -18,6 +18,13 @@ test("#map() does not overflow for large lists", (t) => {
   t.deepEqual([...list.map((n) => n * 2)], [2, 4, 6, 8]);
 });
 
+test("#apply() applies a list of functions to each value of a list", (t) => {
+  t.deepEqual(
+    [...list.apply(List.from([(n) => n + 1, (n) => n * 2]))],
+    [2, 3, 4, 5, 2, 4, 6, 8]
+  );
+});
+
 test("#flatMap() applies a function to every value of a list and flattens the result", (t) => {
   t.deepEqual(
     [...list.flatMap((n) => List.of(n, n))],

--- a/packages/alfa-map/src/map.ts
+++ b/packages/alfa-map/src/map.ts
@@ -48,22 +48,30 @@ export class Map<K, V> implements Collection.Keyed<K, V> {
     return this._size === 0;
   }
 
-  public forEach(callback: Callback<V, void, [K]>): void {
+  public forEach(callback: Callback<V, void, [key: K]>): void {
     Iterable.forEach(this, ([key, value]) => callback(value, key));
   }
 
-  public map<U>(mapper: Mapper<V, U, [K]>): Map<K, U> {
+  public map<U>(mapper: Mapper<V, U, [key: K]>): Map<K, U> {
     return new Map(this._root.map(mapper), this._size);
   }
 
-  public flatMap<L, U>(mapper: Mapper<V, Map<L, U>, [K]>): Map<L, U> {
+  public apply<U>(mapper: Map<K, Mapper<V, U>>): Map<K, U> {
+    return mapper.flatMap((mapper) => this.map(mapper));
+  }
+
+  public flatMap<L, U>(mapper: Mapper<V, Map<L, U>, [key: K]>): Map<L, U> {
     return this.reduce(
       (map, value, key) => map.concat(mapper(value, key)),
       Map.empty<L, U>()
     );
   }
 
-  public reduce<R>(reducer: Reducer<V, R, [K]>, accumulator: R): R {
+  public flatten<K, V>(this: Map<K, Map<K, V>>): Map<K, V> {
+    return this.flatMap((map) => map);
+  }
+
+  public reduce<R>(reducer: Reducer<V, R, [key: K]>, accumulator: R): R {
     return Iterable.reduce(
       this,
       (accumulator, [key, value]) => reducer(accumulator, value, key),
@@ -71,15 +79,11 @@ export class Map<K, V> implements Collection.Keyed<K, V> {
     );
   }
 
-  public apply<U>(mapper: Map<K, Mapper<V, U>>): Map<K, U> {
-    return this.flatMap((value) => mapper.map((mapper) => mapper(value)));
-  }
+  public filter<U extends V>(refinement: Refinement<V, U, [key: K]>): Map<K, U>;
 
-  public filter<U extends V>(refinement: Refinement<V, U, [K]>): Map<K, U>;
+  public filter(predicate: Predicate<V, [key: K]>): Map<K, V>;
 
-  public filter(predicate: Predicate<V, [K]>): Map<K, V>;
-
-  public filter(predicate: Predicate<V, [K]>): Map<K, V> {
+  public filter(predicate: Predicate<V, [key: K]>): Map<K, V> {
     return this.reduce(
       (map, value, key) => (predicate(value, key) ? map.set(key, value) : map),
       Map.empty()
@@ -87,20 +91,20 @@ export class Map<K, V> implements Collection.Keyed<K, V> {
   }
 
   public reject<U extends V>(
-    refinement: Refinement<V, U, [K]>
+    refinement: Refinement<V, U, [key: K]>
   ): Map<K, Exclude<V, U>>;
 
-  public reject(predicate: Predicate<V, [K]>): Map<K, V>;
+  public reject(predicate: Predicate<V, [key: K]>): Map<K, V>;
 
-  public reject(predicate: Predicate<V, [K]>): Map<K, V> {
+  public reject(predicate: Predicate<V, [key: K]>): Map<K, V> {
     return this.filter(not(predicate));
   }
 
-  public find<U extends V>(refinement: Refinement<V, U, [K]>): Option<U>;
+  public find<U extends V>(refinement: Refinement<V, U, [key: K]>): Option<U>;
 
-  public find(predicate: Predicate<V, [K]>): Option<V>;
+  public find(predicate: Predicate<V, [key: K]>): Option<V>;
 
-  public find(predicate: Predicate<V, [K]>): Option<V> {
+  public find(predicate: Predicate<V, [key: K]>): Option<V> {
     return Iterable.find(this, ([key, value]) => predicate(value, key)).map(
       ([, value]) => value
     );
@@ -110,7 +114,7 @@ export class Map<K, V> implements Collection.Keyed<K, V> {
     return Iterable.includes(this.values(), value);
   }
 
-  public collect<U>(mapper: Mapper<V, Option<U>, [K]>): Map<K, U> {
+  public collect<U>(mapper: Mapper<V, Option<U>, [key: K]>): Map<K, U> {
     return Map.from(
       Iterable.collect(this, ([key, value]) =>
         mapper(value, key).map((value) => [key, value])
@@ -118,23 +122,23 @@ export class Map<K, V> implements Collection.Keyed<K, V> {
     );
   }
 
-  public collectFirst<U>(mapper: Mapper<V, Option<U>, [K]>): Option<U> {
+  public collectFirst<U>(mapper: Mapper<V, Option<U>, [key: K]>): Option<U> {
     return Iterable.collectFirst(this, ([key, value]) => mapper(value, key));
   }
 
-  public some(predicate: Predicate<V, [K]>): boolean {
+  public some(predicate: Predicate<V, [key: K]>): boolean {
     return Iterable.some(this, ([key, value]) => predicate(value, key));
   }
 
-  public none(predicate: Predicate<V, [K]>): boolean {
+  public none(predicate: Predicate<V, [key: K]>): boolean {
     return Iterable.none(this, ([key, value]) => predicate(value, key));
   }
 
-  public every(predicate: Predicate<V, [K]>): boolean {
+  public every(predicate: Predicate<V, [key: K]>): boolean {
     return Iterable.every(this, ([key, value]) => predicate(value, key));
   }
 
-  public count(predicate: Predicate<V, [K]>): number {
+  public count(predicate: Predicate<V, [key: K]>): number {
     return Iterable.count(this, ([key, value]) => predicate(value, key));
   }
 

--- a/packages/alfa-map/src/status.ts
+++ b/packages/alfa-map/src/status.ts
@@ -39,9 +39,7 @@ export namespace Status {
     }
   }
 
-  export function created<T>(result: T): Created<T> {
-    return Created.of(result);
-  }
+  export const { of: created } = Created;
 
   export class Updated<T> extends Status<T> {
     public static of<T>(result: T): Updated<T> {
@@ -57,9 +55,7 @@ export namespace Status {
     }
   }
 
-  export function updated<T>(result: T): Updated<T> {
-    return Updated.of(result);
-  }
+  export const { of: updated } = Updated;
 
   export class Deleted<T> extends Status<T> {
     public static of<T>(result: T): Deleted<T> {
@@ -75,9 +71,7 @@ export namespace Status {
     }
   }
 
-  export function deleted<T>(result: T): Deleted<T> {
-    return Deleted.of(result);
-  }
+  export const { of: deleted } = Deleted;
 
   export class Unchanged<T> extends Status<T> {
     public static of<T>(result: T): Unchanged<T> {
@@ -93,7 +87,5 @@ export namespace Status {
     }
   }
 
-  export function unchanged<T>(result: T): Unchanged<T> {
-    return Unchanged.of(result);
-  }
+  export const { of: unchanged } = Unchanged;
 }

--- a/packages/alfa-map/test/map.spec.ts
+++ b/packages/alfa-map/test/map.spec.ts
@@ -32,6 +32,58 @@ test("#size returns the size of a map", (t) => {
   t.equal(map.size, 4);
 });
 
+test("#map() applies a function to each value of a map", (t) => {
+  t.deepEqual(
+    [...map.map((x) => x * 2)],
+    [
+      ["baz", 6],
+      ["qux", 8],
+      ["foo", 2],
+      ["bar", 4],
+    ]
+  );
+});
+
+test("#apply() applies a map of functions to each corresponding value of a map", (t) => {
+  t.deepEqual(
+    [
+      ...map.apply(
+        Map.of(
+          ["foo", (x) => x + 1],
+          ["bar", (x) => x * 2],
+          ["baz", (x) => x - 3],
+          ["qux", (x) => x / 4]
+        )
+      ),
+    ],
+    [
+      ["baz", 0],
+      ["qux", 1],
+      ["foo", 2],
+      ["bar", 4],
+    ]
+  );
+});
+
+test("#apply() drops keys with no corresponding function or value", (t) => {
+  t.deepEqual(
+    [...map.apply(Map.of(["foo", (x) => x + 1], ["fez", (x) => x * 2]))],
+    [["foo", 2]]
+  );
+});
+
+test("#flatMap() applies a function to each value of a map and flattens the result", (t) => {
+  t.deepEqual(
+    [...map.flatMap((x) => Map.of([x.toString(), x]))],
+    [
+      ["3", 3],
+      ["4", 4],
+      ["2", 2],
+      ["1", 1],
+    ]
+  );
+});
+
 test("#distinct() removes duplicate values from a map", (t) => {
   t.deepEqual(
     [

--- a/packages/alfa-monad/package.json
+++ b/packages/alfa-monad/package.json
@@ -19,6 +19,7 @@
   ],
   "dependencies": {
     "@siteimprove/alfa-applicative": "workspace:^0.20.0",
+    "@siteimprove/alfa-functor": "workspace:^0.20.0",
     "@siteimprove/alfa-mapper": "workspace:^0.20.0"
   },
   "devDependencies": {

--- a/packages/alfa-monad/package.json
+++ b/packages/alfa-monad/package.json
@@ -18,6 +18,7 @@
     "src/**/*.d.ts"
   ],
   "dependencies": {
+    "@siteimprove/alfa-applicative": "workspace:^0.20.0",
     "@siteimprove/alfa-mapper": "workspace:^0.20.0"
   },
   "devDependencies": {

--- a/packages/alfa-monad/src/monad.ts
+++ b/packages/alfa-monad/src/monad.ts
@@ -1,8 +1,9 @@
+import { Applicative } from "@siteimprove/alfa-applicative";
 import { Mapper } from "@siteimprove/alfa-mapper";
 
 /**
  * @public
  */
-export interface Monad<T> {
+export interface Monad<T> extends Applicative<T> {
   flatMap<U>(mapper: Mapper<T, Monad<U>>): Monad<U>;
 }

--- a/packages/alfa-monad/src/monad.ts
+++ b/packages/alfa-monad/src/monad.ts
@@ -1,9 +1,13 @@
 import { Applicative } from "@siteimprove/alfa-applicative";
+import { Functor } from "@siteimprove/alfa-functor";
 import { Mapper } from "@siteimprove/alfa-mapper";
 
 /**
  * @public
  */
-export interface Monad<T> extends Applicative<T> {
+export interface Monad<T> extends Functor<T>, Applicative<T> {
+  map<U>(mapper: Mapper<T, U>): Monad<U>;
+  apply<U>(mapper: Monad<Mapper<T, U>>): Monad<U>;
   flatMap<U>(mapper: Mapper<T, Monad<U>>): Monad<U>;
+  flatten<T>(this: Monad<Monad<T>>): Monad<T>;
 }

--- a/packages/alfa-monad/tsconfig.json
+++ b/packages/alfa-monad/tsconfig.json
@@ -7,6 +7,9 @@
       "path": "../alfa-applicative"
     },
     {
+      "path": "../alfa-functor"
+    },
+    {
       "path": "../alfa-mapper"
     },
     {

--- a/packages/alfa-monad/tsconfig.json
+++ b/packages/alfa-monad/tsconfig.json
@@ -4,6 +4,9 @@
   "files": ["src/index.ts", "src/monad.ts"],
   "references": [
     {
+      "path": "../alfa-applicative"
+    },
+    {
       "path": "../alfa-mapper"
     },
     {

--- a/packages/alfa-option/src/none.ts
+++ b/packages/alfa-option/src/none.ts
@@ -1,4 +1,4 @@
-import { Comparison } from "@siteimprove/alfa-comparable";
+import { Comparable, Comparison } from "@siteimprove/alfa-comparable";
 import { Hash } from "@siteimprove/alfa-hash";
 import { Thunk } from "@siteimprove/alfa-thunk";
 
@@ -6,6 +6,8 @@ import * as json from "@siteimprove/alfa-json";
 
 import { Option } from "./option";
 import { Some } from "./some";
+
+const { compareComparable } = Comparable;
 
 /**
  * @public
@@ -28,16 +30,20 @@ export const None: None = new (class None {
     return this;
   }
 
+  public apply(): None {
+    return this;
+  }
+
   public flatMap(): None {
+    return this;
+  }
+
+  public flatten(): None {
     return this;
   }
 
   public reduce<U>(reducer: unknown, accumulator: U): U {
     return accumulator;
-  }
-
-  public apply(): None {
-    return this;
   }
 
   public filter(): None {
@@ -90,6 +96,13 @@ export const None: None = new (class None {
 
   public getOrElse<U>(value: Thunk<U>): U {
     return value();
+  }
+
+  public compare<T>(
+    this: Option<Comparable<T>>,
+    option: Option<T>
+  ): Comparison {
+    return this.compareWith(option, compareComparable);
   }
 
   public compareWith<T>(option: Option<T>): Comparison {

--- a/packages/alfa-option/src/option.ts
+++ b/packages/alfa-option/src/option.ts
@@ -22,9 +22,9 @@ const { compareComparable } = Comparable;
  */
 export interface Option<T>
   extends Functor<T>,
+    Applicative<T>,
     Monad<T>,
     Foldable<T>,
-    Applicative<T>,
     Iterable<T>,
     Equatable,
     Hashable,
@@ -32,9 +32,10 @@ export interface Option<T>
   isSome(): this is Some<T>;
   isNone(): this is None;
   map<U>(mapper: Mapper<T, U>): Option<U>;
-  flatMap<U>(mapper: Mapper<T, Option<U>>): Option<U>;
-  reduce<U>(reducer: Reducer<T, U>, accumulator: U): U;
   apply<U>(mapper: Option<Mapper<T, U>>): Option<U>;
+  flatMap<U>(mapper: Mapper<T, Option<U>>): Option<U>;
+  flatten<T>(this: Option<Option<T>>): Option<T>;
+  reduce<U>(reducer: Reducer<T, U>, accumulator: U): U;
   filter<U extends T>(refinement: Refinement<T, U>): Option<U>;
   filter(predicate: Predicate<T>): Option<T>;
   reject<U extends T>(refinement: Refinement<T, U>): Option<Exclude<T, U>>;
@@ -50,7 +51,8 @@ export interface Option<T>
   get(): T;
   getOr<U>(value: U): T | U;
   getOrElse<U>(value: Thunk<U>): T | U;
-  compareWith(option: Option<T>, comparer: Comparer<T>): Comparison;
+  compare(this: Option<Comparable<T>>, option: Option<T>): Comparison;
+  compareWith<U = T>(option: Option<U>, comparer: Comparer<T, U>): Comparison;
   toArray(): Array<T>;
   toJSON(): Option.JSON<T>;
 }
@@ -95,18 +97,7 @@ export namespace Option {
     return None;
   }
 
-  export function flatten<T>(option: Option<Option<T>>): Option<T> {
-    return option.flatMap((option) => option);
-  }
-
   export function from<T>(value: T | null | undefined): Option<NonNullable<T>> {
     return value === null || value === undefined ? None : Some.of(value!);
-  }
-
-  export function compare<T extends Comparable<T>>(
-    a: Option<T>,
-    b: Option<T>
-  ): Comparison {
-    return a.compareWith(b, compareComparable);
   }
 }

--- a/packages/alfa-option/src/some.ts
+++ b/packages/alfa-option/src/some.ts
@@ -1,4 +1,4 @@
-import { Comparison, Comparer } from "@siteimprove/alfa-comparable";
+import { Comparable, Comparison, Comparer } from "@siteimprove/alfa-comparable";
 import { Equatable } from "@siteimprove/alfa-equatable";
 import { Hash } from "@siteimprove/alfa-hash";
 import { Serializable } from "@siteimprove/alfa-json";
@@ -13,6 +13,7 @@ import { Option } from "./option";
 import { None } from "./none";
 
 const { not, test } = Predicate;
+const { compareComparable } = Comparable;
 
 /**
  * @public
@@ -40,16 +41,20 @@ export class Some<T> implements Option<T> {
     return new Some(mapper(this._value));
   }
 
+  public apply<U>(mapper: Option<Mapper<T, U>>): Option<U> {
+    return mapper.map((mapper) => mapper(this._value));
+  }
+
   public flatMap<U>(mapper: Mapper<T, Option<U>>): Option<U> {
     return mapper(this._value);
   }
 
-  public reduce<U>(reducer: Reducer<T, U>, accumulator: U): U {
-    return reducer(accumulator, this._value);
+  public flatten<T>(this: Some<Option<T>>): Option<T> {
+    return this._value;
   }
 
-  public apply<U>(mapper: Option<Mapper<T, U>>): Option<U> {
-    return mapper.map((mapper) => mapper(this._value));
+  public reduce<U>(reducer: Reducer<T, U>, accumulator: U): U {
+    return reducer(accumulator, this._value);
   }
 
   public filter<U extends T>(refinement: Refinement<T, U>): Option<U>;
@@ -114,7 +119,14 @@ export class Some<T> implements Option<T> {
     return this._value;
   }
 
-  public compareWith(option: Option<T>, comparer: Comparer<T>): Comparison {
+  public compare(this: Option<Comparable<T>>, option: Option<T>): Comparison {
+    return this.compareWith(option, compareComparable);
+  }
+
+  public compareWith<U = T>(
+    option: Option<U>,
+    comparer: Comparer<T, U>
+  ): Comparison {
     return option.isSome()
       ? comparer(this._value, option._value)
       : Comparison.Greater;

--- a/packages/alfa-option/test/option.spec.ts
+++ b/packages/alfa-option/test/option.spec.ts
@@ -48,3 +48,7 @@ test("#flatMap() satisfies associativity", (t) => {
     option.flatMap((n) => f(n).flatMap(g))
   );
 });
+
+test("#flatten() unwraps a nested option", (t) => {
+  t.deepEqual(Option.of(Option.of(1)).flatten(), Some.of(1));
+});

--- a/packages/alfa-result/src/err.ts
+++ b/packages/alfa-result/src/err.ts
@@ -36,7 +36,7 @@ export class Err<E> implements Result<never, E> {
     return true;
   }
 
-  public map(): this {
+  public map(): Err<E> {
     return this;
   }
 
@@ -44,20 +44,24 @@ export class Err<E> implements Result<never, E> {
     return new Err(mapper(this._error));
   }
 
-  public mapOrElse<T, U>(ok: Mapper<T, U>, err: Mapper<E, U>): U {
+  public mapOrElse<U>(ok: unknown, err: Mapper<E, U>): U {
     return err(this._error);
   }
 
-  public flatMap(): this {
+  public apply(): Err<E> {
+    return this;
+  }
+
+  public flatMap(): Err<E> {
+    return this;
+  }
+
+  public flatten<T, E>(this: Err<E>): Result<T, E> {
     return this;
   }
 
   public reduce<U>(reducer: unknown, accumulator: U): U {
     return accumulator;
-  }
-
-  public apply(): this {
-    return this;
   }
 
   public includes(): boolean {
@@ -92,11 +96,11 @@ export class Err<E> implements Result<never, E> {
     return test(predicate, this._error);
   }
 
-  public and(): this {
+  public and(): Err<E> {
     return this;
   }
 
-  public andThen(): this {
+  public andThen(): Err<E> {
     return this;
   }
 

--- a/packages/alfa-result/src/err.ts
+++ b/packages/alfa-result/src/err.ts
@@ -56,7 +56,7 @@ export class Err<E> implements Result<never, E> {
     return this;
   }
 
-  public flatten<T, E>(this: Err<E>): Result<T, E> {
+  public flatten<E>(this: Err<E>): Err<E> {
     return this;
   }
 

--- a/packages/alfa-result/src/err.ts
+++ b/packages/alfa-result/src/err.ts
@@ -56,7 +56,7 @@ export class Err<E> implements Result<never, E> {
     return this;
   }
 
-  public flatten<E>(this: Err<E>): Err<E> {
+  public flatten<T, E>(this: Result<never, E>): Result<T, E> {
     return this;
   }
 

--- a/packages/alfa-result/src/ok.ts
+++ b/packages/alfa-result/src/ok.ts
@@ -40,24 +40,28 @@ export class Ok<T> implements Result<T, never> {
     return new Ok(mapper(this._value));
   }
 
-  public mapErr(): this {
+  public mapErr(): Ok<T> {
     return this;
   }
 
-  public mapOrElse<E, U>(ok: Mapper<T, U>): U {
+  public mapOrElse<U>(ok: Mapper<T, U>): U {
     return ok(this._value);
+  }
+
+  public apply<E, U>(mapper: Result<Mapper<T, U>, E>): Result<U, E> {
+    return mapper.map((mapper) => mapper(this._value));
   }
 
   public flatMap<U, F>(mapper: Mapper<T, Result<U, F>>): Result<U, F> {
     return mapper(this._value);
   }
 
-  public reduce<U>(reducer: Reducer<T, U>, accumulator: U): U {
-    return reducer(accumulator, this._value);
+  public flatten<T, E>(this: Ok<Result<T, E>>): Result<T, E> {
+    return this._value;
   }
 
-  public apply<E, U>(mapper: Result<Mapper<T, U>, E>): Result<U, E> {
-    return mapper.map((mapper) => mapper(this._value));
+  public reduce<U>(reducer: Reducer<T, U>, accumulator: U): U {
+    return reducer(accumulator, this._value);
   }
 
   public includes(value: T): boolean {
@@ -100,11 +104,11 @@ export class Ok<T> implements Result<T, never> {
     return result(this._value);
   }
 
-  public or(): this {
+  public or(): Ok<T> {
     return this;
   }
 
-  public orElse(): this {
+  public orElse(): Ok<T> {
     return this;
   }
 

--- a/packages/alfa-result/src/result.ts
+++ b/packages/alfa-result/src/result.ts
@@ -20,9 +20,9 @@ import { Ok } from "./ok";
  */
 export interface Result<T, E = T>
   extends Functor<T>,
+    Applicative<T>,
     Monad<T>,
     Foldable<T>,
-    Applicative<T>,
     Iterable<T>,
     Equatable,
     Hashable,
@@ -32,9 +32,10 @@ export interface Result<T, E = T>
   map<U>(mapper: Mapper<T, U>): Result<U, E>;
   mapErr<F>(mapper: Mapper<E, F>): Result<T, F>;
   mapOrElse<U>(ok: Mapper<T, U>, err: Mapper<E, U>): U;
-  flatMap<U>(mapper: Mapper<T, Result<U, E>>): Result<U, E>;
-  reduce<U>(reducer: Reducer<T, U>, accumulator: U): U;
   apply<U>(mapper: Result<Mapper<T, U>, E>): Result<U, E>;
+  flatMap<U>(mapper: Mapper<T, Result<U, E>>): Result<U, E>;
+  flatten<T, E>(this: Result<Result<T, E>, E>): Result<T, E>;
+  reduce<U>(reducer: Reducer<T, U>, accumulator: U): U;
   includes(value: T): boolean;
   includesErr(error: E): boolean;
   some(predicate: Predicate<T>): boolean;

--- a/packages/alfa-selective/package.json
+++ b/packages/alfa-selective/package.json
@@ -18,6 +18,7 @@
     "src/**/*.d.ts"
   ],
   "dependencies": {
+    "@siteimprove/alfa-applicative": "workspace:^0.20.0",
     "@siteimprove/alfa-either": "workspace:^0.20.0",
     "@siteimprove/alfa-equatable": "workspace:^0.20.0",
     "@siteimprove/alfa-functor": "workspace:^0.20.0",

--- a/packages/alfa-selective/src/selective.ts
+++ b/packages/alfa-selective/src/selective.ts
@@ -35,9 +35,7 @@ export class Selective<S, T = never>
   }
 
   public map<U>(mapper: Mapper<T, U>): Selective<S, U> {
-    return this.flatMap(
-      (value) => new Selective<S, U>(Right.of(mapper(value)))
-    );
+    return new Selective(this._value.map(mapper));
   }
 
   public apply<U>(mapper: Selective<S, Mapper<T, U>>): Selective<S, U> {
@@ -45,10 +43,7 @@ export class Selective<S, T = never>
   }
 
   public flatMap<U>(mapper: Mapper<T, Selective<S, U>>): Selective<S, U> {
-    return this._value.either(
-      (value) => new Selective(Left.of(value)),
-      (value) => mapper(value)
-    );
+    return new Selective(this._value.flatMap((value) => mapper(value)._value));
   }
 
   public flatten<S, T>(this: Selective<S, Selective<S, T>>): Selective<S, T> {
@@ -91,6 +86,18 @@ export class Selective<S, T = never>
     return this._value.get();
   }
 
+  /**
+   * Ensure that this {@link (Selective:class)} is exhaustively matched, returning
+   * its resulting value.
+   *
+   * @remarks
+   * This method should only be used for cases where {@link (Selective:class).get}
+   * is insufficient. If in doubt, assume that it isn't.
+   */
+  public exhaust<T>(this: Selective<never, T>): T {
+    return this.get();
+  }
+
   public equals<S, T>(value: Selective<S, T>): boolean;
 
   public equals(value: unknown): value is this;
@@ -125,16 +132,4 @@ export class Selective<S, T = never>
  */
 export namespace Selective {
   export type JSON<S, T = never> = Either.JSON<S, T>;
-
-  /**
-   * Ensure that a {@link (Selective:class)} is exhaustively matched, returning its
-   * resulting value.
-   *
-   * @remarks
-   * This function should only be used for cases where {@link (Selective:class).get}
-   * is insufficient. If in doubt, assume that it isn't.
-   */
-  export function exhaust<T>(selective: Selective<never, T>): T {
-    return selective.get();
-  }
 }

--- a/packages/alfa-selective/src/selective.ts
+++ b/packages/alfa-selective/src/selective.ts
@@ -51,6 +51,10 @@ export class Selective<S, T = never>
     );
   }
 
+  public flatten<S, T>(this: Selective<S, Selective<S, T>>): Selective<S, T> {
+    return this.flatMap((selective) => selective);
+  }
+
   public if<P extends S, U>(
     refinement: Refinement<S, P>,
     mapper: Mapper<P, U>

--- a/packages/alfa-selective/test/selective.spec.ts
+++ b/packages/alfa-selective/test/selective.spec.ts
@@ -56,3 +56,38 @@ test(`#map() applies a function to a matched selective value`, (t) => {
     "WAS FOO"
   );
 });
+
+test(`#apply() applies a selective function to a selective value`, (t) => {
+  t.equal(
+    Selective.of("foo")
+      .if(isFoo, () => 2)
+      .apply(Selective.of("bar").if(isBar, () => (n) => n * 2))
+      .get(),
+    4
+  );
+});
+
+test(`#flatMap() applies a function to a matched selective value and flattens
+      the result`, (t) => {
+  t.equal(
+    Selective.of("foo")
+      .if(isFoo, () => "was foo")
+      .flatMap((wasFoo) =>
+        Selective.of("bar")
+          .if(isBar, () => "was bar")
+          .map((wasBar) => `${wasFoo} and ${wasBar}`)
+      )
+      .get(),
+    "was foo and was bar"
+  );
+});
+
+test(`#flatten() unwraps a nested selective value`, (t) => {
+  t.equal(
+    Selective.of("foo")
+      .else(() => Selective.of("bar"))
+      .flatten()
+      .get(),
+    "bar"
+  );
+});

--- a/packages/alfa-selective/tsconfig.json
+++ b/packages/alfa-selective/tsconfig.json
@@ -4,6 +4,9 @@
   "files": ["src/index.ts", "src/selective.ts", "test/selective.spec.ts"],
   "references": [
     {
+      "path": "../alfa-applicative"
+    },
+    {
       "path": "../alfa-either"
     },
     {

--- a/packages/alfa-sequence/src/cons.ts
+++ b/packages/alfa-sequence/src/cons.ts
@@ -1,7 +1,7 @@
 import { Array } from "@siteimprove/alfa-array";
 import { Callback } from "@siteimprove/alfa-callback";
 import { Collection } from "@siteimprove/alfa-collection";
-import { Comparer, Comparison } from "@siteimprove/alfa-comparable";
+import { Comparable, Comparer, Comparison } from "@siteimprove/alfa-comparable";
 import { Equatable } from "@siteimprove/alfa-equatable";
 import { Hash } from "@siteimprove/alfa-hash";
 import { Iterable } from "@siteimprove/alfa-iterable";
@@ -19,6 +19,7 @@ import { Sequence } from "./sequence";
 import { Nil } from "./nil";
 
 const { not, equals } = Predicate;
+const { compareComparable } = Comparable;
 
 /**
  * @public
@@ -67,6 +68,10 @@ export class Cons<T> implements Sequence<T> {
     );
   }
 
+  public apply<U>(mapper: Sequence<Mapper<T, U>>): Sequence<U> {
+    return mapper.flatMap((mapper) => this.map(mapper));
+  }
+
   public flatMap<U>(
     mapper: Mapper<T, Sequence<U>, [index: number]>
   ): Sequence<U>;
@@ -109,6 +114,10 @@ export class Cons<T> implements Sequence<T> {
         return Nil;
       }
     }
+  }
+
+  public flatten<T>(this: Sequence<Sequence<T>>): Sequence<T> {
+    return this.flatMap((sequence) => sequence);
   }
 
   public reduce<U>(reducer: Reducer<T, U, [index: number]>, accumulator: U): U {
@@ -159,10 +168,6 @@ export class Cons<T> implements Sequence<T> {
     accumulator: U
   ): U {
     return this.reduceWhile(not(predicate), reducer, accumulator);
-  }
-
-  public apply<U>(mapper: Sequence<Mapper<T, U>>): Sequence<U> {
-    return this.flatMap((value) => mapper.map((mapper) => mapper(value)));
   }
 
   public filter<U extends T>(
@@ -400,6 +405,10 @@ export class Cons<T> implements Sequence<T> {
     }
 
     if (index === 0) {
+      if (Equatable.equals(value, this._head)) {
+        return this;
+      }
+
       return new Cons(value, this._tail);
     }
 
@@ -657,11 +666,25 @@ export class Cons<T> implements Sequence<T> {
     }
   }
 
+  public sort<T extends Comparable<T>>(this: Sequence<T>): Sequence<T> {
+    return this.sortWith(compareComparable);
+  }
+
   public sortWith(comparer: Comparer<T>): Sequence<T> {
     return Sequence.fromArray(Array.sortWith(this.toArray(), comparer));
   }
 
-  public compareWith(iterable: Iterable<T>, comparer: Comparer<T>): Comparison {
+  public compare(
+    this: Sequence<Comparable<T>>,
+    iterable: Iterable<T>
+  ): Comparison {
+    return this.compareWith(iterable, Comparable.compare);
+  }
+
+  public compareWith<U = T>(
+    iterable: Iterable<U>,
+    comparer: Comparer<T, U, [index: number]>
+  ): Comparison {
     return Iterable.compareWith(this, iterable, comparer);
   }
 

--- a/packages/alfa-sequence/src/nil.ts
+++ b/packages/alfa-sequence/src/nil.ts
@@ -1,5 +1,5 @@
 import { Collection } from "@siteimprove/alfa-collection";
-import { Comparer, Comparison } from "@siteimprove/alfa-comparable";
+import { Comparable, Comparer, Comparison } from "@siteimprove/alfa-comparable";
 import { Hash } from "@siteimprove/alfa-hash";
 import { Iterable } from "@siteimprove/alfa-iterable";
 import { Map } from "@siteimprove/alfa-map";
@@ -31,7 +31,15 @@ export const Nil: Nil = new (class Nil {
     return this;
   }
 
+  public apply(): Nil {
+    return this;
+  }
+
   public flatMap(): Nil {
+    return this;
+  }
+
+  public flatten(): Nil {
     return this;
   }
 
@@ -53,10 +61,6 @@ export const Nil: Nil = new (class Nil {
     accumulator: U
   ): U {
     return accumulator;
-  }
-
-  public apply(): Nil {
-    return this;
   }
 
   public filter(): Nil {
@@ -231,13 +235,24 @@ export const Nil: Nil = new (class Nil {
     return "";
   }
 
+  public sort(): Nil {
+    return this;
+  }
+
   public sortWith(): Nil {
     return this;
   }
 
-  public compareWith<T>(
-    iterable: Iterable<T>,
-    comparer: Comparer<T>
+  public compare<T>(
+    this: Sequence<Comparable<T>>,
+    iterable: Iterable<T>
+  ): Comparison {
+    return this.compareWith(iterable, Comparable.compare);
+  }
+
+  public compareWith<T, U = T>(
+    iterable: Iterable<U>,
+    comparer: Comparer<T, U, [index: number]>
   ): Comparison {
     return Iterable.compareWith(this, iterable, comparer);
   }

--- a/packages/alfa-sequence/src/sequence.ts
+++ b/packages/alfa-sequence/src/sequence.ts
@@ -13,8 +13,6 @@ import { Refinement } from "@siteimprove/alfa-refinement";
 import { Cons } from "./cons";
 import { Nil } from "./nil";
 
-const { compareComparable } = Comparable;
-
 /**
  * @public
  */
@@ -22,7 +20,9 @@ export interface Sequence<T> extends Collection.Indexed<T> {
   isEmpty(): this is Sequence<never>;
   forEach(callback: Callback<T, void, [index: number]>): void;
   map<U>(mapper: Mapper<T, U, [index: number]>): Sequence<U>;
+  apply<U>(mapper: Sequence<Mapper<T, U>>): Sequence<U>;
   flatMap<U>(mapper: Mapper<T, Sequence<U>, [index: number]>): Sequence<U>;
+  flatten<T>(this: Sequence<Sequence<T>>): Sequence<T>;
   reduce<U>(reducer: Reducer<T, U, [index: number]>, accumulator: U): U;
   reduceWhile<U>(
     predicate: Predicate<T, [index: number]>,
@@ -34,7 +34,6 @@ export interface Sequence<T> extends Collection.Indexed<T> {
     reducer: Reducer<T, U, [index: number]>,
     accumulator: U
   ): U;
-  apply<U>(mapper: Sequence<Mapper<T, U>>): Sequence<U>;
   filter<U extends T>(
     refinement: Refinement<T, U, [index: number]>
   ): Sequence<U>;
@@ -90,8 +89,13 @@ export interface Sequence<T> extends Collection.Indexed<T> {
   slice(start: number, end?: number): Sequence<T>;
   reverse(): Sequence<T>;
   join(separator: string): string;
+  sort<T extends Comparable<T>>(this: Sequence<T>): Sequence<T>;
   sortWith(comparer: Comparer<T>): Sequence<T>;
-  compareWith(iterable: Iterable<T>, comparer: Comparer<T>): Comparison;
+  compare(this: Sequence<Comparable<T>>, iterable: Iterable<T>): Comparison;
+  compareWith<U = T>(
+    iterable: Iterable<U>,
+    comparer: Comparer<T, U, [index: number]>
+  ): Comparison;
   groupBy<K>(grouper: Mapper<T, K, [index: number]>): Map<K, Sequence<T>>;
   toArray(): Array<T>;
   toJSON(): Sequence.JSON<T>;
@@ -133,10 +137,6 @@ export namespace Sequence {
 
   export function empty<T = never>(): Sequence<T> {
     return Nil;
-  }
-
-  export function flatten<T>(sequence: Sequence<Sequence<T>>): Sequence<T> {
-    return sequence.flatMap((sequence) => sequence);
   }
 
   export function from<T>(iterable: Iterable<T>): Sequence<T> {
@@ -181,18 +181,5 @@ export namespace Sequence {
     };
 
     return tail();
-  }
-
-  export function sort<T extends Comparable<T>>(
-    sequence: Sequence<T>
-  ): Sequence<T> {
-    return sequence.sortWith(compareComparable);
-  }
-
-  export function compare<T extends Comparable<T>>(
-    a: Sequence<T>,
-    b: Iterable<T>
-  ): Comparison {
-    return a.compareWith(b, compareComparable);
   }
 }

--- a/packages/alfa-sequence/test/sequence.spec.ts
+++ b/packages/alfa-sequence/test/sequence.spec.ts
@@ -58,6 +58,13 @@ test("#map() does not force the tail of a sequence", (t) => {
   ).map((n) => n + 1);
 });
 
+test("#apply() applies a sequence of functions to each value of a sequence", (t) => {
+  t.deepEqual(
+    [...seq.apply(Sequence.from([(n) => n + 1, (n) => n * 2]))],
+    [2, 3, 4, 5, 2, 4, 6, 8]
+  );
+});
+
 test("#flatMap() applies a function to each value of a sequence and flattens the result", (t) => {
   t.deepEqual(
     [...seq.flatMap((n) => Sequence.from([n, n]))],

--- a/packages/alfa-sequence/test/sequence.spec.ts
+++ b/packages/alfa-sequence/test/sequence.spec.ts
@@ -1,5 +1,6 @@
 import { test } from "@siteimprove/alfa-test";
 
+import { Comparable } from "@siteimprove/alfa-comparable";
 import { Option, None } from "@siteimprove/alfa-option";
 import { Lazy } from "@siteimprove/alfa-lazy";
 
@@ -75,6 +76,12 @@ test("#flatMap() behaves when a singleton sequence maps to an empty sequence", (
   const seq = Sequence.from([1]).flatMap(() => Sequence.empty());
 
   t.deepEqual([...seq], []);
+});
+
+test("#flatten() unwraps a nested sequence", (t) => {
+  const seq = Sequence.from([Sequence.from([1, 2]), Sequence.from([3, 4])]);
+
+  t.deepEqual(seq.flatten().toArray(), [1, 2, 3, 4]);
 });
 
 test("#reduce() reduces a sequence of values to a single value", (t) => {
@@ -221,6 +228,24 @@ test("#join() joins the values of a sequence to a string", (t) => {
   const seq = Sequence.from(["foo", "bar", "baz"]);
 
   t.equal(seq.join("-"), "foo-bar-baz");
+});
+
+test("#sort() sorts a sequence of comparable values", (t) => {
+  class Foo implements Comparable<Foo> {
+    value: number;
+
+    constructor(value: number) {
+      this.value = value;
+    }
+
+    compare(other: Foo) {
+      return Comparable.compare(this.value, other.value);
+    }
+  }
+
+  const seq = Sequence.from([new Foo(5), new Foo(3), new Foo(1)]);
+
+  t.deepEqual(seq.sort().toArray(), [new Foo(1), new Foo(3), new Foo(5)]);
 });
 
 test("#sortWith() sorts a sequence according to a comparer", (t) => {

--- a/packages/alfa-set/src/set.ts
+++ b/packages/alfa-set/src/set.ts
@@ -53,7 +53,7 @@ export class Set<T> implements Collection.Unkeyed<T> {
   }
 
   public apply<U>(mapper: Set<Mapper<T, U>>): Set<U> {
-    return this.flatMap((value) => mapper.map((mapper) => mapper(value)));
+    return mapper.flatMap((mapper) => this.map(mapper));
   }
 
   public flatMap<U>(mapper: Mapper<T, Set<U>>): Set<U> {

--- a/packages/alfa-set/src/set.ts
+++ b/packages/alfa-set/src/set.ts
@@ -52,6 +52,10 @@ export class Set<T> implements Collection.Unkeyed<T> {
     );
   }
 
+  public apply<U>(mapper: Set<Mapper<T, U>>): Set<U> {
+    return this.flatMap((value) => mapper.map((mapper) => mapper(value)));
+  }
+
   public flatMap<U>(mapper: Mapper<T, Set<U>>): Set<U> {
     return this.reduce(
       (set, value) => set.concat(mapper(value)),
@@ -59,12 +63,12 @@ export class Set<T> implements Collection.Unkeyed<T> {
     );
   }
 
-  public reduce<U>(reducer: Reducer<T, U>, accumulator: U): U {
-    return Iterable.reduce(this, reducer, accumulator);
+  public flatten<T>(this: Set<Set<T>>): Set<T> {
+    return this.flatMap((set) => set);
   }
 
-  public apply<U>(mapper: Set<Mapper<T, U>>): Set<U> {
-    return this.flatMap((value) => mapper.map((mapper) => mapper(value)));
+  public reduce<U>(reducer: Reducer<T, U>, accumulator: U): U {
+    return Iterable.reduce(this, reducer, accumulator);
   }
 
   public filter<U extends T>(refinement: Refinement<T, U>): Set<U>;

--- a/packages/alfa-style/package.json
+++ b/packages/alfa-style/package.json
@@ -18,6 +18,7 @@
     "src/**/*.d.ts"
   ],
   "dependencies": {
+    "@siteimprove/alfa-applicative": "workspace:^0.20.0",
     "@siteimprove/alfa-cache": "workspace:^0.20.0",
     "@siteimprove/alfa-cascade": "workspace:^0.20.0",
     "@siteimprove/alfa-css": "workspace:^0.20.0",

--- a/packages/alfa-style/src/style.ts
+++ b/packages/alfa-style/src/style.ts
@@ -477,7 +477,7 @@ const substitutionLimit = 1024;
 
 /**
  * Substitute `var()` functions in an array of tokens. If any syntactically
- * invalid `var()` functions are encountered, `null` is returned.
+ * invalid `var()` functions are encountered, `None` is returned.
  *
  * {@link https://drafts.csswg.org/css-variables/#substitute-a-var}
  *

--- a/packages/alfa-style/src/value.ts
+++ b/packages/alfa-style/src/value.ts
@@ -54,6 +54,10 @@ export class Value<T = unknown>
     return mapper(this._value);
   }
 
+  public flatten<T>(this: Value<Value<T>>): Value<T> {
+    return this._value;
+  }
+
   public includes(value: T): boolean {
     return Equatable.equals(this._value, value);
   }

--- a/packages/alfa-style/src/value.ts
+++ b/packages/alfa-style/src/value.ts
@@ -1,3 +1,4 @@
+import { Applicative } from "@siteimprove/alfa-applicative";
 import { Declaration } from "@siteimprove/alfa-dom";
 import { Equatable } from "@siteimprove/alfa-equatable";
 import { Functor } from "@siteimprove/alfa-functor";
@@ -15,10 +16,12 @@ import * as json from "@siteimprove/alfa-json";
 export class Value<T = unknown>
   implements
     Functor<T>,
+    Applicative<T>,
     Monad<T>,
     Iterable<T>,
     Equatable,
-    Serializable<Value.JSON<T>> {
+    Serializable<Value.JSON<T>>
+{
   public static of<T>(value: T, source: Option<Declaration> = None): Value<T> {
     return new Value(value, source);
   }
@@ -41,6 +44,10 @@ export class Value<T = unknown>
 
   public map<U>(mapper: Mapper<T, U>): Value<U> {
     return new Value(mapper(this._value), this._source);
+  }
+
+  public apply<U>(mapper: Value<Mapper<T, U>>): Value<U> {
+    return mapper.map((mapper) => mapper(this._value));
   }
 
   public flatMap<U>(mapper: Mapper<T, Value<U>>): Value<U> {

--- a/packages/alfa-style/tsconfig.json
+++ b/packages/alfa-style/tsconfig.json
@@ -181,6 +181,9 @@
   ],
   "references": [
     {
+      "path": "../alfa-applicative"
+    },
+    {
       "path": "../alfa-cache"
     },
     {

--- a/packages/alfa-trampoline/src/trampoline.ts
+++ b/packages/alfa-trampoline/src/trampoline.ts
@@ -15,7 +15,8 @@ import { Thunk } from "@siteimprove/alfa-thunk";
  * @public
  */
 export abstract class Trampoline<T>
-  implements Functor<T>, Monad<T>, Foldable<T>, Applicative<T>, Iterable<T> {
+  implements Functor<T>, Applicative<T>, Monad<T>, Foldable<T>, Iterable<T>
+{
   protected abstract step(): Trampoline<T>;
 
   public run(): T {
@@ -40,14 +41,18 @@ export abstract class Trampoline<T>
     return this.flatMap((value) => Done.of(mapper(value)));
   }
 
+  public apply<U>(mapper: Trampoline<Mapper<T, U>>): Trampoline<U> {
+    return mapper.flatMap((mapper) => this.map(mapper));
+  }
+
   public abstract flatMap<U>(mapper: Mapper<T, Trampoline<U>>): Trampoline<U>;
+
+  public flatten<T>(this: Trampoline<Trampoline<T>>): Trampoline<T> {
+    return this.flatMap((trampoline) => trampoline);
+  }
 
   public reduce<U>(reducer: Reducer<T, U>, accumulator: U): U {
     return reducer(accumulator, this.run());
-  }
-
-  public apply<U>(mapper: Trampoline<Mapper<T, U>>): Trampoline<U> {
-    return this.flatMap((value) => mapper.map((mapper) => mapper(value)));
   }
 
   public tee(callback: Callback<T>): Trampoline<T> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,6 +933,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@siteimprove/alfa-act@workspace:packages/alfa-act"
   dependencies:
+    "@siteimprove/alfa-applicative": "workspace:^0.20.0"
     "@siteimprove/alfa-earl": "workspace:^0.20.0"
     "@siteimprove/alfa-equatable": "workspace:^0.20.0"
     "@siteimprove/alfa-functor": "workspace:^0.20.0"
@@ -986,6 +987,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@siteimprove/alfa-applicative@workspace:packages/alfa-applicative"
   dependencies:
+    "@siteimprove/alfa-functor": "workspace:^0.20.0"
     "@siteimprove/alfa-mapper": "workspace:^0.20.0"
     "@siteimprove/alfa-test": "workspace:^0.20.0"
   languageName: unknown
@@ -1369,6 +1371,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@siteimprove/alfa-either@workspace:packages/alfa-either"
   dependencies:
+    "@siteimprove/alfa-applicative": "workspace:^0.20.0"
     "@siteimprove/alfa-equatable": "workspace:^0.20.0"
     "@siteimprove/alfa-foldable": "workspace:^0.20.0"
     "@siteimprove/alfa-functor": "workspace:^0.20.0"
@@ -1692,6 +1695,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@siteimprove/alfa-lazy@workspace:packages/alfa-lazy"
   dependencies:
+    "@siteimprove/alfa-applicative": "workspace:^0.20.0"
     "@siteimprove/alfa-equatable": "workspace:^0.20.0"
     "@siteimprove/alfa-functor": "workspace:^0.20.0"
     "@siteimprove/alfa-json": "workspace:^0.20.0"
@@ -1789,6 +1793,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@siteimprove/alfa-monad@workspace:packages/alfa-monad"
   dependencies:
+    "@siteimprove/alfa-applicative": "workspace:^0.20.0"
     "@siteimprove/alfa-mapper": "workspace:^0.20.0"
     "@siteimprove/alfa-test": "workspace:^0.20.0"
   languageName: unknown
@@ -2077,6 +2082,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@siteimprove/alfa-selective@workspace:packages/alfa-selective"
   dependencies:
+    "@siteimprove/alfa-applicative": "workspace:^0.20.0"
     "@siteimprove/alfa-either": "workspace:^0.20.0"
     "@siteimprove/alfa-equatable": "workspace:^0.20.0"
     "@siteimprove/alfa-functor": "workspace:^0.20.0"
@@ -2179,6 +2185,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@siteimprove/alfa-style@workspace:packages/alfa-style"
   dependencies:
+    "@siteimprove/alfa-applicative": "workspace:^0.20.0"
     "@siteimprove/alfa-cache": "workspace:^0.20.0"
     "@siteimprove/alfa-cascade": "workspace:^0.20.0"
     "@siteimprove/alfa-css": "workspace:^0.20.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1794,6 +1794,7 @@ __metadata:
   resolution: "@siteimprove/alfa-monad@workspace:packages/alfa-monad"
   dependencies:
     "@siteimprove/alfa-applicative": "workspace:^0.20.0"
+    "@siteimprove/alfa-functor": "workspace:^0.20.0"
     "@siteimprove/alfa-mapper": "workspace:^0.20.0"
     "@siteimprove/alfa-test": "workspace:^0.20.0"
   languageName: unknown


### PR DESCRIPTION
This pull request is a refactor of the collection types and some associated types, such as `Monad<T>`, `Result<T, E>`, and `Option<T>`. Notably, the way functionality that depends on details of `T` is implemented has changed from functions with argument constraints to methods with `this` constraints, such as sorting:

```ts
interface Collection<T> {
  sort<T extends Comparable<T>>(this: Collection<T>): Collection<T>
}

class Foo implements Comparable<Foo> {
  compare(other: Foo): Comparison {
    // ...
  }
}

const collection: Collection<Foo>;

collection.sort();
```