### PR TITLE
Handle duplicate `id`s and `for` attributes in `Name.from()`

### DIFF
--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -146,8 +146,8 @@ const nameFromLabel = (element: Element, device: Device, state: Name.State) => {
 
   const elements = root.inclusiveDescendants().filter(isElement);
 
-  for (const id of element.id) {
-    const target = ids
+  const isFirstReference = element.id.some((id) =>
+    ids
       .get(root, () =>
         Map.from(
           elements
@@ -157,21 +157,19 @@ const nameFromLabel = (element: Element, device: Device, state: Name.State) => {
             .reverse()
         )
       )
-      .get(id);
-
-    if (target.includes(element)) {
-      continue;
-    } else {
-      return None;
-    }
-  }
+      .get(id)
+      .includes(element)
+  );
 
   const references = labels
     .get(root, () => elements.filter(hasName("label")))
     .filter(
       or(
-        (label) => label.descendants().includes(element),
         (label) =>
+          label.attribute("for").isNone() &&
+          label.descendants().includes(element),
+        (label) =>
+          isFirstReference &&
           label
             .attribute("for")
             .some((attribute) => element.id.includes(attribute.value))

--- a/packages/alfa-aria/test/name.spec.tsx
+++ b/packages/alfa-aria/test/name.spec.tsx
@@ -1599,3 +1599,146 @@ test(`.from() behaves correctly when encountering a descendant that doesn't
     },
   });
 });
+
+test(`.from() does not use implicit <label> elements for naming <input> elements
+      if the <label> element has a non-matching for attribute`, (t) => {
+  const input = <input />;
+
+  <form>
+    <label for="bar">
+      {input}
+      Hello world
+    </label>
+  </form>;
+
+  t.deepEqual(Name.from(input, device).toJSON(), {
+    type: "none",
+  });
+});
+
+test(`.from() correctly assigns names to <input> elements with implicit <label>
+      elements even if IDs are duplicated`, (t) => {
+  const foo = <input id="foo" />;
+  const bar = <input id="foo" />;
+
+  <form>
+    <label>
+      Hello world
+      {foo}
+    </label>
+
+    <label>
+      Lorem ipsum
+      {bar}
+    </label>
+  </form>;
+
+  t.deepEqual(Name.from(foo, device).toJSON(), {
+    type: "some",
+    value: {
+      value: "Hello world",
+      sources: [
+        {
+          type: "ancestor",
+          element: "/form[1]/label[1]",
+          name: {
+            value: "Hello world",
+            sources: [
+              {
+                type: "descendant",
+                element: "/form[1]/label[1]",
+                name: {
+                  value: "Hello world",
+                  sources: [
+                    {
+                      text: "/form[1]/label[1]/text()[1]",
+                      type: "data",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  });
+
+  t.deepEqual(Name.from(bar, device).toJSON(), {
+    type: "some",
+    value: {
+      value: "Lorem ipsum",
+      sources: [
+        {
+          type: "ancestor",
+          element: "/form[1]/label[2]",
+          name: {
+            value: "Lorem ipsum",
+            sources: [
+              {
+                type: "descendant",
+                element: "/form[1]/label[2]",
+                name: {
+                  value: "Lorem ipsum",
+                  sources: [
+                    {
+                      text: "/form[1]/label[2]/text()[1]",
+                      type: "data",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  });
+});
+
+test(`.from() only associates <label> elements with for attributes with the
+      first matching element`, (t) => {
+  const foo = <input id="foo" />;
+  const bar = <input id="foo" />;
+
+  <form>
+    <label for="foo">Hello world</label>
+    {foo}
+    {bar}
+  </form>;
+
+  t.deepEqual(Name.from(foo, device).toJSON(), {
+    type: "some",
+    value: {
+      value: "Hello world",
+      sources: [
+        {
+          type: "reference",
+          attribute: "/form[1]/label[1]/@for",
+          name: {
+            value: "Hello world",
+            sources: [
+              {
+                type: "descendant",
+                element: "/form[1]/label[1]",
+                name: {
+                  value: "Hello world",
+                  sources: [
+                    {
+                      text: "/form[1]/label[1]/text()[1]",
+                      type: "data",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  });
+
+  t.deepEqual(Name.from(bar, device).toJSON(), {
+    type: "none",
+  });
+});


### PR DESCRIPTION
Resolves #780
Resolves #781