### PR TITLE
Accept native `<video>` and `<audio>` controls in SIA-R49

### DIFF
--- a/packages/alfa-rules/test/sia-r49/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r49/rule.spec.tsx
@@ -1,0 +1,135 @@
+import { h } from "@siteimprove/alfa-dom";
+import { test } from "@siteimprove/alfa-test";
+
+import { None, Option } from "@siteimprove/alfa-option";
+
+import R41, { Outcomes } from "../../src/sia-r49/rule";
+
+import { evaluate } from "../common/evaluate";
+import { oracle } from "../common/oracle";
+import { passed, failed } from "../common/outcome";
+
+test(`evaluate() passes an autoplaying <video> element that lasts more than 3
+      seconds, has audio, and uses native audio controls`, async (t) => {
+  const target = <video autoplay controls src="foo.mp4" />;
+
+  const document = h.document([target]);
+
+  t.deepEqual(
+    await evaluate(
+      R41,
+      { document },
+      oracle({
+        "is-above-duration-threshold": true,
+        "has-audio": true,
+      })
+    ),
+    [
+      passed(R41, target, {
+        1: Outcomes.HasPerceivablePauseMechanism("video"),
+      }),
+    ]
+  );
+});
+
+test(`evaluate() passes an autoplaying <video> element that lasts more than 3
+      seconds, has audio, and uses custom audio controls`, async (t) => {
+  const target = <video autoplay src="foo.mp4" />;
+
+  const controls = <button>Toggle audio</button>;
+
+  const document = h.document([target, controls]);
+
+  t.deepEqual(
+    await evaluate(
+      R41,
+      { document },
+      oracle({
+        "is-above-duration-threshold": true,
+        "has-audio": true,
+        "audio-control-mechanism": Option.of(controls),
+      })
+    ),
+    [
+      passed(R41, target, {
+        1: Outcomes.HasPerceivablePauseMechanism("video"),
+      }),
+    ]
+  );
+});
+
+test(`evaluate() fails an autoplaying <video> element that lasts more than 3
+      seconds, has audio, and lacks audio controls`, async (t) => {
+  const target = <video autoplay src="foo.mp4" />;
+
+  const document = h.document([target]);
+
+  t.deepEqual(
+    await evaluate(
+      R41,
+      { document },
+      oracle({
+        "is-above-duration-threshold": true,
+        "has-audio": true,
+        "audio-control-mechanism": None,
+      })
+    ),
+    [
+      failed(R41, target, {
+        1: Outcomes.HasNoPauseMechanism("video"),
+      }),
+    ]
+  );
+});
+
+test(`evaluate() fails an autoplaying <video> element that lasts more than 3
+      seconds, has audio, and has audio controls that aren't perceivable`, async (t) => {
+  const target = <video autoplay src="foo.mp4" />;
+
+  const controls = <button hidden>Toggle audio</button>;
+
+  const document = h.document([target, controls]);
+
+  t.deepEqual(
+    await evaluate(
+      R41,
+      { document },
+      oracle({
+        "is-above-duration-threshold": true,
+        "has-audio": true,
+        "audio-control-mechanism": Option.of(controls),
+      })
+    ),
+    [
+      failed(R41, target, {
+        1: Outcomes.HasNonPerceivablePauseMechanism("video"),
+      }),
+    ]
+  );
+});
+
+test(`evaluate() fails an autoplaying <video> element that lasts more than 3
+      seconds, has audio, and has audio controls with no accessible name`, async (t) => {
+  const target = <video autoplay src="foo.mp4" />;
+
+  const controls = <button />;
+
+  const document = h.document([target, controls]);
+
+  t.deepEqual(
+    await evaluate(
+      R41,
+      { document },
+      oracle({
+        "is-above-duration-threshold": true,
+        "has-audio": true,
+        "audio-control-mechanism": Option.of(controls),
+      })
+    ),
+    [
+      failed(R41, target, {
+        1: Outcomes.HasNonPerceivablePauseMechanism("video"),
+      }),
+    ]
+  );
+});

--- a/packages/alfa-rules/tsconfig.json
+++ b/packages/alfa-rules/tsconfig.json
@@ -205,6 +205,7 @@
     "test/sia-r42/rule.spec.tsx",
     "test/sia-r45/rule.spec.tsx",
     "test/sia-r46/rule.spec.tsx",
+    "test/sia-r49/rule.spec.tsx",
     "test/sia-r53/rule.spec.tsx",
     "test/sia-r54/rule.spec.tsx",
     "test/sia-r55/rule.spec.tsx",


### PR DESCRIPTION
- [ ] Follow up on DEV-12281.