### PR TITLE
Add additional `Thenable` helpers

### DIFF
--- a/docs/review/api/alfa-thenable.api.md
+++ b/docs/review/api/alfa-thenable.api.md
@@ -4,12 +4,42 @@
 
 ```ts
 
+import { Array as Array_2 } from '@siteimprove/alfa-array';
 import { Callback } from '@siteimprove/alfa-callback';
+import { Continuation } from '@siteimprove/alfa-continuation';
+import { Mapper } from '@siteimprove/alfa-mapper';
 
 // @public (undocumented)
 export interface Thenable<T, E = unknown> {
     // (undocumented)
     then(resolved: Callback<T>, rejected: Callback<E>): void;
+}
+
+// @public (undocumented)
+export namespace Thenable {
+    // (undocumented)
+    export function all<T, E = unknown>(...thenables: Array_2<Thenable<T, E>>): Thenable<Array_2<T>, E>;
+    // (undocumented)
+    export function any<T, E = unknown>(...thenables: Array_2<Thenable<T, E>>): Thenable<T, Array_2<E>>;
+    // (undocumented)
+    export function apply<T, U, E = unknown, F = E>(thenable: Thenable<T, E>, mapper: Thenable<Mapper<T, U>, F>): Thenable<U, E | F>;
+    // (undocumented)
+    export function defer<T, E = unknown>(continuation: Continuation<T, void, [reject: Callback<E>]>): Thenable<T, E>;
+    // (undocumented)
+    export function empty(): Thenable<void, never>;
+    // (undocumented)
+    export function flatMap<T, U, E = unknown, F = E>(thenable: Thenable<T, E>, mapper: Mapper<T, Thenable<U, F>>): Thenable<U, E | F>;
+    // (undocumented)
+    export function flatten<T, E = unknown, F = E>(thenable: Thenable<Thenable<T, F>, E>): Thenable<T, E | F>;
+    export function isThenable<T, E = unknown>(value: unknown): value is Thenable<T, E>;
+    // (undocumented)
+    export function map<T, U, E = unknown>(thenable: Thenable<T, E>, mapper: Mapper<T, U>): Thenable<U, E>;
+    // (undocumented)
+    export function race<T, E = unknown>(...thenables: Array_2<Thenable<T, E>>): Thenable<T, E>;
+    // (undocumented)
+    export function reject<E>(error: E): Thenable<never, E>;
+    // (undocumented)
+    export function resolve<T>(value: T): Thenable<T, never>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/alfa-thenable/package.json
+++ b/packages/alfa-thenable/package.json
@@ -18,7 +18,11 @@
     "src/**/*.d.ts"
   ],
   "dependencies": {
-    "@siteimprove/alfa-callback": "workspace:^0.22.7"
+    "@siteimprove/alfa-array": "workspace:^0.22.7",
+    "@siteimprove/alfa-callback": "workspace:^0.22.7",
+    "@siteimprove/alfa-continuation": "workspace:^0.22.7",
+    "@siteimprove/alfa-mapper": "workspace:^0.22.7",
+    "@siteimprove/alfa-refinement": "workspace:^0.22.7"
   },
   "devDependencies": {
     "@siteimprove/alfa-test": "workspace:^0.22.7"

--- a/packages/alfa-thenable/src/thenable.ts
+++ b/packages/alfa-thenable/src/thenable.ts
@@ -1,4 +1,10 @@
+import { Array } from "@siteimprove/alfa-array";
 import { Callback } from "@siteimprove/alfa-callback";
+import { Continuation } from "@siteimprove/alfa-continuation";
+import { Mapper } from "@siteimprove/alfa-mapper";
+import { Refinement } from "@siteimprove/alfa-refinement";
+
+const { isFunction, isObject } = Refinement;
 
 /**
  * @remarks
@@ -10,4 +16,162 @@ import { Callback } from "@siteimprove/alfa-callback";
  */
 export interface Thenable<T, E = unknown> {
   then(resolved: Callback<T>, rejected: Callback<E>): void;
+}
+
+/**
+ * @public
+ */
+export namespace Thenable {
+  /**
+   * Check if an unknown value implements the {@link (Thenable:interface)}
+   * interface.
+   */
+  export function isThenable<T, E = unknown>(
+    value: unknown
+  ): value is Thenable<T, E> {
+    return isObject(value) && isFunction(value.then);
+  }
+
+  export function empty(): Thenable<void, never> {
+    return resolve(undefined);
+  }
+
+  export function resolve<T>(value: T): Thenable<T, never> {
+    return defer((resolve) => {
+      resolve(value);
+    });
+  }
+
+  export function reject<E>(error: E): Thenable<never, E> {
+    return defer((resolve, reject) => {
+      reject(error);
+    });
+  }
+
+  export function defer<T, E = unknown>(
+    continuation: Continuation<T, void, [reject: Callback<E>]>
+  ): Thenable<T, E> {
+    return new (class Thenable {
+      then(resolve: Callback<T>, reject: Callback<E>) {
+        continuation(resolve, reject);
+      }
+    })();
+  }
+
+  export function map<T, U, E = unknown>(
+    thenable: Thenable<T, E>,
+    mapper: Mapper<T, U>
+  ): Thenable<U, E> {
+    return defer((resolved, rejected) => {
+      thenable.then((value) => resolved(mapper(value)), rejected);
+    });
+  }
+
+  export function apply<T, U, E = unknown, F = E>(
+    thenable: Thenable<T, E>,
+    mapper: Thenable<Mapper<T, U>, F>
+  ): Thenable<U, E | F> {
+    return flatMap(mapper, (mapper) => map(thenable, mapper));
+  }
+
+  export function flatMap<T, U, E = unknown, F = E>(
+    thenable: Thenable<T, E>,
+    mapper: Mapper<T, Thenable<U, F>>
+  ): Thenable<U, E | F> {
+    return defer((resolved, rejected) => {
+      thenable.then(
+        (value) => mapper(value).then(resolved, rejected),
+        rejected
+      );
+    });
+  }
+
+  export function flatten<T, E = unknown, F = E>(
+    thenable: Thenable<Thenable<T, F>, E>
+  ): Thenable<T, E | F> {
+    return flatMap(thenable, (thenable) => thenable);
+  }
+
+  export function all<T, E = unknown>(
+    ...thenables: Array<Thenable<T, E>>
+  ): Thenable<Array<T>, E> {
+    return defer((resolve, reject) => {
+      const values = Array.allocate<T>(thenables.length);
+
+      if (thenables.length === 0) {
+        return resolve(values);
+      }
+
+      let unsettled = thenables.length;
+
+      thenables.forEach((thenables, i) =>
+        thenables.then(
+          (value) => {
+            values[i] = value;
+
+            if (--unsettled === 0) {
+              resolve(values);
+            }
+          },
+          (error) => {
+            reject(error);
+          }
+        )
+      );
+    });
+  }
+
+  export function any<T, E = unknown>(
+    ...thenables: Array<Thenable<T, E>>
+  ): Thenable<T, Array<E>> {
+    return defer((resolve, reject) => {
+      const errors = Array.allocate<E>(thenables.length);
+
+      if (thenables.length === 0) {
+        return reject(errors);
+      }
+
+      let unsettled = thenables.length;
+
+      thenables.forEach((thenables, i) =>
+        thenables.then(
+          (value) => {
+            resolve(value);
+          },
+          (error) => {
+            errors[i] = error;
+
+            if (--unsettled === 0) {
+              reject(errors);
+            }
+          }
+        )
+      );
+    });
+  }
+
+  export function race<T, E = unknown>(
+    ...thenables: Array<Thenable<T, E>>
+  ): Thenable<T, E> {
+    return defer((resolve, reject) => {
+      let unsettled = true;
+
+      for (const thenable of thenables) {
+        thenable.then(
+          (value) => {
+            if (unsettled) {
+              unsettled = false;
+              resolve(value);
+            }
+          },
+          (error) => {
+            if (unsettled) {
+              unsettled = false;
+              reject(error);
+            }
+          }
+        );
+      }
+    });
+  }
 }

--- a/packages/alfa-thenable/test/thenable.spec.ts
+++ b/packages/alfa-thenable/test/thenable.spec.ts
@@ -3,26 +3,30 @@ import { test } from "@siteimprove/alfa-test";
 import { Thenable } from "../src/thenable";
 
 test("await a resolving thenable", async (t) => {
-  const foo: Thenable<number> = {
-    then(resolve) {
-      resolve(42);
-    },
-  };
-
-  t.equal(await foo, 42);
+  t.equal(await Thenable.resolve(42), 42);
 });
 
 test("await a rejecting thenable", async (t) => {
-  const foo: Thenable<number, string> = {
-    then(resolve, reject) {
-      reject("nope");
-    },
-  };
-
   try {
-    await foo;
+    await Thenable.reject("nope");
     t.fail();
   } catch (err) {
     t.equal(err, "nope");
   }
+});
+
+test(".map() applies a function to the value of a thenable", async (t) => {
+  t.equal(
+    await Thenable.map(Thenable.resolve(42), (x) => x.toString(10)),
+    "42"
+  );
+});
+
+test(".flatMap() applies a function to the value of a thenable and flattens the result", async (t) => {
+  t.equal(
+    await Thenable.flatMap(Thenable.resolve(42), (x) =>
+      Thenable.resolve(x.toString(10))
+    ),
+    "42"
+  );
 });

--- a/packages/alfa-thenable/tsconfig.json
+++ b/packages/alfa-thenable/tsconfig.json
@@ -4,7 +4,19 @@
   "files": ["src/index.ts", "src/thenable.ts", "test/thenable.spec.ts"],
   "references": [
     {
+      "path": "../alfa-array"
+    },
+    {
       "path": "../alfa-callback"
+    },
+    {
+      "path": "../alfa-continuation"
+    },
+    {
+      "path": "../alfa-mapper"
+    },
+    {
+      "path": "../alfa-refinement"
     },
     {
       "path": "../alfa-test"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2249,7 +2249,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@siteimprove/alfa-thenable@workspace:packages/alfa-thenable"
   dependencies:
+    "@siteimprove/alfa-array": "workspace:^0.22.7"
     "@siteimprove/alfa-callback": "workspace:^0.22.7"
+    "@siteimprove/alfa-continuation": "workspace:^0.22.7"
+    "@siteimprove/alfa-mapper": "workspace:^0.22.7"
+    "@siteimprove/alfa-refinement": "workspace:^0.22.7"
     "@siteimprove/alfa-test": "workspace:^0.22.7"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This pull request adds some additional helper functions for the `Thenable` type to maintain symmetry with `Promise` and `Future`. You might be wondering why we even have all these types as they can all seem like the same way to accomplish the same thing; asynchronous control flow.

The best way to reason about having 3 different types to achieve essentially the same thing is perhaps by comparing them to the `Iterable`, `Array`, and `Sequence` types as they have a lot in common:

- `Iterable` models sequences of values and `Thenable` models asynchronous control flow in a lazy, stack-unsafe manner by using the call stack. They provide excellent performance at the risk of blowing the stack.

- `Array` models sequences of values and `Promise` models asynchronous control flow in an eager, stack-safe manner by using the heap and task queue. They provide reasonable performance without risk of blowing the stack.

- `Sequence` models sequences of values and `Future` models asynchronous control flow in a lazy, stack-safe manner by using a trampoline and the task queue. They provide good performance without risk of blowing the stack.

Each type has its place and it's of course up to the programmer to pick the right tool for the job.