### PR TITLE
Cache recursive computation in `isVisible`

### DIFF
--- a/packages/alfa-rules/src/common/predicate/is-visible.ts
+++ b/packages/alfa-rules/src/common/predicate/is-visible.ts
@@ -1,5 +1,7 @@
+import { Cache } from "@siteimprove/alfa-cache";
 import { Device } from "@siteimprove/alfa-device";
 import { Element, Text, Node } from "@siteimprove/alfa-dom";
+import { Option } from "@siteimprove/alfa-option";
 import { Predicate } from "@siteimprove/alfa-predicate";
 import { Refinement } from "@siteimprove/alfa-refinement";
 import { Context } from "@siteimprove/alfa-selector";
@@ -13,7 +15,7 @@ import {
   isTransparent,
 } from "../predicate";
 
-const { nor, not, or } = Predicate;
+const { nor, not, or, test } = Predicate;
 const { and } = Refinement;
 const { hasName, isElement } = Element;
 const { isText } = Text;
@@ -25,46 +27,68 @@ export function isVisible(device: Device, context?: Context): Predicate<Node> {
   return not(isInvisible(device, context));
 }
 
+const cache = Cache.empty<
+  Device,
+  Cache<Option<Context>, Cache<Node, boolean>>
+>();
+
 function isInvisible(device: Device, context?: Context): Predicate<Node> {
-  return or(
-    not(isRendered(device, context)),
-    isTransparent(device, context),
-    isClipped(device, context),
-    isOffscreen(device, context),
-    // Empty text
-    and(isText, (text) => text.data.trim() === ""),
-    // Text of size 0
-    and(
-      isText,
-      hasComputedStyle("font-size", (size) => size.value === 0, device, context)
-    ),
-    // Element with visibility != "visible"
-    and(
-      isElement,
-      hasComputedStyle(
-        "visibility",
-        (visibility) => visibility.value !== "visible",
-        device,
-        context
-      )
-    ),
-    // Most non-replaced elements with no visible children are not visible while
-    // replaced elements are assumed to be replaced by something visible. Some
-    // non-replaced elements are, however, visible even when empty.
-    and(
-      isElement,
-      and(
-        nor(isReplaced, isVisibleWhenEmpty, hasDimensions(device)),
-        (element) =>
-          element
-            .children({
-              nested: true,
-              flattened: true,
-            })
-            .every(isInvisible(device, context))
-      )
-    )
-  );
+  return (node) =>
+    cache
+      .get(device, Cache.empty)
+      .get(Option.from(context), Cache.empty)
+      .get(node, () =>
+        test(
+          or(
+            not(isRendered(device, context)),
+            isTransparent(device, context),
+            isClipped(device, context),
+            isOffscreen(device, context),
+            // Empty text
+            and(isText, (text) => text.data.trim() === ""),
+            // Text of size 0
+            and(
+              isText,
+              hasComputedStyle(
+                "font-size",
+                (size) => size.value === 0,
+                device,
+                context
+              )
+            ),
+            // Element with visibility != "visible"
+            and(
+              isElement,
+              hasComputedStyle(
+                "visibility",
+                (visibility) => visibility.value !== "visible",
+                device,
+                context
+              )
+            ),
+            // Most non-replaced elements with no visible children are not visible while
+            // replaced elements are assumed to be replaced by something visible. Some
+            // non-replaced elements are, however, visible even when empty.
+            and(
+              isElement,
+              and(
+                // If the element is replaced, visible when empty, or has set dimensions,
+                // it is assumed to be visible
+                nor(isReplaced, isVisibleWhenEmpty, hasDimensions(device)),
+                // otherwise, the element is invisible iff all its children are.
+                (element) =>
+                  element
+                    .children({
+                      nested: true,
+                      flattened: true,
+                    })
+                    .every(isInvisible(device, context))
+              )
+            )
+          ),
+          node
+        )
+      );
 }
 
 /**
@@ -73,6 +97,9 @@ function isInvisible(device: Device, context?: Context): Predicate<Node> {
  */
 const isVisibleWhenEmpty = hasName("textarea");
 
+/**
+ * Does the element have set dimensions?
+ */
 function hasDimensions(device: Device): Predicate<Element> {
   return and(
     ...(["width", "height"] as const).map((dimension) =>


### PR DESCRIPTION
Most sub-predicates were already cached, but the main one still does some extra computations that create recurrence down the DOM tree. Caching the top-level predicate to improve performance a bit.
