### PR TITLE
SIA-R83: Export diagnostic

### DIFF
--- a/packages/alfa-rules/src/sia-r83/rule.ts
+++ b/packages/alfa-rules/src/sia-r83/rule.ts
@@ -346,7 +346,7 @@ function isWrappingFlexContainer(device: Device): Predicate<Element> {
   };
 }
 
-class ClippingAncestors extends Diagnostic {
+export class ClippingAncestors extends Diagnostic {
   public static of(
     message: string,
     horizontal: Option<Element> = None,
@@ -398,7 +398,7 @@ class ClippingAncestors extends Diagnostic {
   }
 }
 
-namespace ClippingAncestors {
+export namespace ClippingAncestors {
   export interface JSON extends Diagnostic.JSON {
     horizontal: Option.JSON<Element>;
     vertical: Option.JSON<Element>;


### PR DESCRIPTION
So that it can be used for typing Dory's marshalling functions.
