### PR TITLE
Add function to create a WCAG `Criterion` from its URI

### DIFF
--- a/packages/alfa-wcag/src/criterion.ts
+++ b/packages/alfa-wcag/src/criterion.ts
@@ -1,5 +1,6 @@
 import { Requirement } from "@siteimprove/alfa-act";
 import { Branched } from "@siteimprove/alfa-branched";
+import { None, Option } from "@siteimprove/alfa-option";
 
 import { Criteria } from "./criterion/data";
 
@@ -223,5 +224,17 @@ export namespace Criterion {
 
   export function isCriterion(value: unknown): value is Criterion {
     return value instanceof Criterion;
+  }
+
+  export function fromURI(uri: string): Option<Criterion> {
+    for (const [chapter, value] of Object.entries(Criteria)) {
+      for (const version of value.versions) {
+        if (version[1].uri === uri) {
+          return Option.of(Criterion.of(chapter as Criterion.Chapter));
+        }
+      }
+    }
+
+    return None;
   }
 }

--- a/packages/alfa-wcag/src/criterion.ts
+++ b/packages/alfa-wcag/src/criterion.ts
@@ -230,7 +230,7 @@ export namespace Criterion {
     for (const [chapter, value] of Object.entries(Criteria)) {
       for (const version of value.versions) {
         if (version[1].uri === uri) {
-          return Option.of(Criterion.of(chapter as Criterion.Chapter));
+          return Option.of(Criterion.of(chapter as Chapter));
         }
       }
     }


### PR DESCRIPTION
Usage:
```javascript
import { Conformance, Criterion } from "@siteimprove/alfa-wcag";

const contrast = Criterion.fromURI(
  "https://www.w3.org/TR/WCAG/#contrast-minimum"
).get();

console.log(Conformance.isA()(contrast)); // false
console.log(Conformance.isAA()(contrast));  // true
console.log(Conformance.isAAA()(contrast));  // true
```