### PR TITLE
Devtools improvements

### DIFF
--- a/docs/review/api/alfa-assert.api.md
+++ b/docs/review/api/alfa-assert.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { Future } from '@siteimprove/alfa-future';
+import { Oracle } from '@siteimprove/alfa-act';
 import { Outcome } from '@siteimprove/alfa-act';
 import { Predicate } from '@siteimprove/alfa-predicate';
 import { Result } from '@siteimprove/alfa-result';
@@ -42,6 +43,8 @@ export namespace Assertion {
     // (undocumented)
     export interface Options<I, T, Q, S> {
         readonly filter?: Predicate<Outcome.Failed<I, T, Q, S>>;
+        readonly filterCantTell?: Predicate<Outcome.CantTell<I, T, Q, S>>;
+        readonly oracle?: Oracle<I, T, Q, S>;
     }
 }
 

--- a/packages/alfa-assert/src/assertion.ts
+++ b/packages/alfa-assert/src/assertion.ts
@@ -66,10 +66,10 @@ export class Assertion<I, T, Q, S> {
     return Audit.of<I, T, Q, S>(this._input, this._rules, oracle)
       .evaluate()
       .flatMap((outcomes) => {
-        // Since we need to go through `outcomes` twice, we can't keep it As
+        // Since we need to go through `outcomes` twice, we can't keep it as
         // an Iterable which self-destruct on reading.
         // We also assume there will be few suspicious outcomes and therefore
-        // filtering them once likely save time
+        // filtering them once likely saves time
         const suspicious = Sequence.from(outcomes).filter(
           or(Outcome.isFailed, Outcome.isCantTell)
         );
@@ -130,14 +130,13 @@ export class Assertion<I, T, Q, S> {
 export namespace Assertion {
   export interface Options<I, T, Q, S> {
     /**
-     * Predicate for filtering out outcomes that should count towards an
-     * assertion failure.; only failed outcomes matching this filter will be
-     * reported.
+     * Predicate for filtering outcomes that should count towards an assertion
+     * failure.; only failed outcomes matching this filter will be reported.
      * If left unset, all failed outcomes will be reported
      */
     readonly filter?: Predicate<Outcome.Failed<I, T, Q, S>>;
     /**
-     * Filter cantTell outcome.
+     * Predicate for filtering cantTell outcome.
      * If left unset, no cantTell outcome will be reported.
      */
     readonly filterCantTell?: Predicate<Outcome.CantTell<I, T, Q, S>>;

--- a/packages/alfa-assert/src/assertion.ts
+++ b/packages/alfa-assert/src/assertion.ts
@@ -1,5 +1,6 @@
-import { Audit, Outcome, Rule } from "@siteimprove/alfa-act";
+import { Audit, Oracle, Outcome, Rule } from "@siteimprove/alfa-act";
 import { Future } from "@siteimprove/alfa-future";
+import { None } from "@siteimprove/alfa-option";
 import { Predicate } from "@siteimprove/alfa-predicate";
 import { Result, Err } from "@siteimprove/alfa-result";
 
@@ -49,9 +50,11 @@ export class Assertion<I, T, Q, S> {
   }
 
   public accessible(): Future<Result<string>> {
-    const { filter = () => true } = { ...this._options };
+    const { filter = () => true, oracle = () => Future.now(None) } = {
+      ...this._options,
+    };
 
-    return Audit.of<I, T, Q, S>(this._input, this._rules)
+    return Audit.of<I, T, Q, S>(this._input, this._rules, oracle)
       .evaluate()
       .flatMap((outcomes) => {
         const failures = [...outcomes].filter(
@@ -102,5 +105,6 @@ export namespace Assertion {
      * assertion failure.
      */
     readonly filter?: Predicate<Outcome.Failed<I, T, Q, S>>;
+    readonly oracle?: Oracle<I, T, Q, S>;
   }
 }

--- a/packages/alfa-assert/test/asserter.spec.ts
+++ b/packages/alfa-assert/test/asserter.spec.ts
@@ -1,4 +1,3 @@
-import { Oracle } from "@siteimprove/alfa-act";
 import { Future } from "@siteimprove/alfa-future";
 import { Option } from "@siteimprove/alfa-option";
 import { test } from "@siteimprove/alfa-test";
@@ -33,15 +32,22 @@ test("#expect() allows filtering of failed outcomes", async (t) => {
   t.equal(result.isOk(), true);
 });
 
-// test("#expect() accepts an oracle", async (t) => {
-//   const oracle: Oracle<string, string, { boolean: boolean }, string> = <A>() =>
-//     Future.now(Option.of(true as unknown as A));
-//
-//   const { expect } = Asserter.of([Pass("pass"), CantTell("maybe")], [], {
-//     oracle,
-//   });
-//
-//   const result = await expect("foo").to.be.accessible();
-//
-//   t.equal(result.isOk(), true);
-// });
+test("#expect() allows to reject cantTell outcomes", async (t) => {
+  const { expect } = Asserter.of([Pass("pass"), CantTell("maybe")], [], {
+    filterCantTell: () => true,
+  });
+
+  const result = await expect("foo").to.be.accessible();
+
+  t.equal(result.isErr(), true);
+});
+
+test("#expect() accepts an oracle", async (t) => {
+  const { expect } = Asserter.of([Pass("pass"), CantTell("maybe")], [], {
+    oracle: (_, question) => Future.now(Option.of(question.answer(true))),
+  });
+
+  const result = await expect("foo").to.be.accessible();
+
+  t.equal(result.isOk(), true);
+});

--- a/packages/alfa-assert/test/asserter.spec.ts
+++ b/packages/alfa-assert/test/asserter.spec.ts
@@ -1,11 +1,14 @@
+import { Oracle } from "@siteimprove/alfa-act";
+import { Future } from "@siteimprove/alfa-future";
+import { Option } from "@siteimprove/alfa-option";
 import { test } from "@siteimprove/alfa-test";
 
 import { Asserter } from "../src/asserter";
 
-import { Pass, Fail } from "./fixture/rule";
+import { CantTell, Fail, Pass } from "./fixture/rule";
 
 test("#expect() returns an ok when no rules fail", async (t) => {
-  const { expect } = Asserter.of([Pass]);
+  const { expect } = Asserter.of([Pass("pass")]);
 
   const result = await expect("foo").to.be.accessible();
 
@@ -13,9 +16,32 @@ test("#expect() returns an ok when no rules fail", async (t) => {
 });
 
 test("#expect() returns an error when a rule fails", async (t) => {
-  const { expect } = Asserter.of([Pass, Fail]);
+  const { expect } = Asserter.of([Pass("pass"), Fail("fail")]);
 
   const result = await expect("foo").to.be.accessible();
 
   t.equal(result.isErr(), true);
 });
+
+test("#expect() allows filtering of failed outcomes", async (t) => {
+  const { expect } = Asserter.of([Pass("pass"), Fail("good")], [], {
+    filter: (outcome) => outcome.rule.uri !== "good",
+  });
+
+  const result = await expect("foo").to.be.accessible();
+
+  t.equal(result.isOk(), true);
+});
+
+// test("#expect() accepts an oracle", async (t) => {
+//   const oracle: Oracle<string, string, { boolean: boolean }, string> = <A>() =>
+//     Future.now(Option.of(true as unknown as A));
+//
+//   const { expect } = Asserter.of([Pass("pass"), CantTell("maybe")], [], {
+//     oracle,
+//   });
+//
+//   const result = await expect("foo").to.be.accessible();
+//
+//   t.equal(result.isOk(), true);
+// });

--- a/packages/alfa-assert/test/fixture/rule.ts
+++ b/packages/alfa-assert/test/fixture/rule.ts
@@ -1,38 +1,70 @@
-import { Diagnostic, Rule } from "@siteimprove/alfa-act";
+import { Diagnostic, Question, Rule } from "@siteimprove/alfa-act";
 import { Result, Err } from "@siteimprove/alfa-result";
 
-export const Pass = Rule.Atomic.of<string, string>({
-  uri: "pass",
+export const Pass = (uri: string) =>
+  Rule.Atomic.of<string, string>({
+    uri,
 
-  evaluate(input) {
-    return {
-      applicability() {
-        return [input];
-      },
+    evaluate(input) {
+      return {
+        applicability() {
+          return [input];
+        },
 
-      expectations() {
-        return {
-          1: Result.of(Diagnostic.of("Success!")),
-        };
-      },
-    };
-  },
-});
+        expectations() {
+          return {
+            1: Result.of(Diagnostic.of("Success!")),
+          };
+        },
+      };
+    },
+  });
 
-export const Fail = Rule.Atomic.of<string, string>({
-  uri: "fail",
+export const Fail = (uri: string) =>
+  Rule.Atomic.of<string, string>({
+    uri,
 
-  evaluate(input) {
-    return {
-      applicability() {
-        return [input];
-      },
+    evaluate(input) {
+      return {
+        applicability() {
+          return [input];
+        },
 
-      expectations() {
-        return {
-          1: Err.of(Diagnostic.of("Failure!")),
-        };
-      },
-    };
-  },
-});
+        expectations() {
+          return {
+            1: Err.of(Diagnostic.of("Failure!")),
+          };
+        },
+      };
+    },
+  });
+
+export const CantTell = (uri: string) =>
+  Rule.Atomic.of<string, string, { boolean: boolean }>({
+    uri,
+
+    evaluate(input) {
+      return {
+        applicability() {
+          return [input];
+        },
+
+        expectations(target) {
+          const isPassed = Question.of<"boolean", string, string, boolean>(
+            "boolean",
+            "is-passed",
+            "Does the rule pass?",
+            target,
+            target
+          );
+          return {
+            1: isPassed.map((passed) =>
+              passed
+                ? Result.of(Diagnostic.of("Success!"))
+                : Err.of(Diagnostic.of("Failure!"))
+            ),
+          };
+        },
+      };
+    },
+  });


### PR DESCRIPTION
Resolves #1012 

Assertions now accept an oracle, and a way to filter out irrelevant `cantTell` outcomes (default is to remove all `cantTell` outcomes and keep all `failed` ones).