### PR TITLE
Map questions' uri to the expected answer type and register questions

### DIFF
--- a/docs/review/api/alfa-act.api.md
+++ b/docs/review/api/alfa-act.api.md
@@ -114,7 +114,7 @@ export type Interview<QUESTION, SUBJECT, CONTEXT, ANSWER, D extends number = 3> 
     [URI in keyof QUESTION]: Question<QUESTION[URI] extends [infer T, any] ? T : never, SUBJECT, CONTEXT, QUESTION[URI] extends [any, infer A] ? A : never, D extends -1 ? ANSWER : Interview<QUESTION, SUBJECT, CONTEXT, ANSWER, Depths[D]>, URI extends string ? URI : never>;
 }[keyof QUESTION];
 
-// @public
+// @public (undocumented)
 export namespace Interview {
     // (undocumented)
     export function conduct<INPUT, TARGET, QUESTION, SUBJECT, ANSWER>(interview: Interview<QUESTION, SUBJECT, TARGET, ANSWER>, rule: Rule<INPUT, TARGET, QUESTION, SUBJECT>, oracle: Oracle<INPUT, TARGET, QUESTION, SUBJECT>): Future<Option<ANSWER>>;

--- a/docs/review/api/alfa-act.api.md
+++ b/docs/review/api/alfa-act.api.md
@@ -109,21 +109,21 @@ export namespace Diagnostic {
 
 // Warning: (ae-forgotten-export) The symbol "Depths" needs to be exported by the entry point index.d.ts
 //
-// @public (undocumented)
+// @public
 export type Interview<QUESTION, SUBJECT, CONTEXT, ANSWER, D extends number = 3> = ANSWER | {
     [URI in keyof QUESTION]: Question<QUESTION[URI] extends [infer T, any] ? T : never, SUBJECT, CONTEXT, QUESTION[URI] extends [any, infer A] ? A : never, D extends -1 ? ANSWER : Interview<QUESTION, SUBJECT, CONTEXT, ANSWER, Depths[D]>, URI extends string ? URI : never>;
 }[keyof QUESTION];
 
-// @public (undocumented)
+// @public
 export namespace Interview {
     // (undocumented)
-    export function conduct<I, T, Q, S, A>(interview: Interview<Q, S, T, A>, rule: Rule<I, T, Q, S>, oracle: Oracle<I, T, Q, S>): Future<Option<A>>;
+    export function conduct<INPUT, TARGET, QUESTION, SUBJECT, ANSWER>(interview: Interview<QUESTION, SUBJECT, TARGET, ANSWER>, rule: Rule<INPUT, TARGET, QUESTION, SUBJECT>, oracle: Oracle<INPUT, TARGET, QUESTION, SUBJECT>): Future<Option<ANSWER>>;
 }
 
 // @public
-export type Oracle<INPUT, TARGET, QUESTION, SUBJECT> = <ANSWER>(rule: Rule<INPUT, TARGET, QUESTION, SUBJECT>, question: {
-    [URI in keyof QUESTION]: Question<QUESTION[URI] extends [infer T, any] ? T : never, SUBJECT, TARGET, QUESTION[URI] extends [any, infer A] ? A : never, ANSWER, URI extends string ? URI : never>;
-}[keyof QUESTION]) => Future<Option<ANSWER>>;
+export type Oracle<INPUT, TARGET, QUESTION, SUBJECT> = (rule: Rule<INPUT, TARGET, QUESTION, SUBJECT>, question: {
+    [URI in keyof QUESTION]: Question<QUESTION[URI] extends [infer T, any] ? T : never, SUBJECT, TARGET, QUESTION[URI] extends [any, infer A] ? A : never, unknown, URI extends string ? URI : never>;
+}[keyof QUESTION]) => Future<Option<QUESTION[keyof QUESTION] extends [any, infer A] ? A : never>>;
 
 // @public
 export abstract class Outcome<I, T, Q = never, S = T> implements Equatable, json.Serializable<Outcome.JSON>, earl.Serializable<Outcome.EARL>, sarif.Serializable<sarif.Result> {

--- a/docs/review/api/alfa-act.api.md
+++ b/docs/review/api/alfa-act.api.md
@@ -24,7 +24,7 @@ import { Sequence } from '@siteimprove/alfa-sequence';
 import { Serializable } from '@siteimprove/alfa-json';
 import { Thunk } from '@siteimprove/alfa-thunk';
 
-// @public (undocumented)
+// @public
 export class Audit<I, T = unknown, Q = never, S = T> {
     // (undocumented)
     evaluate(performance?: Performance<Audit.Event<I, T, Q, S>>): Future<Iterable_2<Outcome<I, T, Q, S>>>;
@@ -35,28 +35,28 @@ export class Audit<I, T = unknown, Q = never, S = T> {
 // @public (undocumented)
 export namespace Audit {
     // (undocumented)
-    export class Event<I, T, Q, S> implements Serializable<Event.JSON> {
+    export class Event<I, T, Q, S, N extends Event.Name = Event.Name> implements Serializable<Event.JSON<N>> {
         // (undocumented)
-        static end<I, T, Q, S>(rule: Rule<I, T, Q, S>): Event<I, T, Q, S>;
+        static end<I, T, Q, S>(rule: Rule<I, T, Q, S>): Event<I, T, Q, S, "end">;
         // (undocumented)
-        get name(): Event.Name;
+        get name(): N;
         // (undocumented)
-        static of<I, T, Q, S>(name: Event.Name, rule: Rule<I, T, Q, S>): Event<I, T, Q, S>;
+        static of<I, T, Q, S, N extends Event.Name>(name: N, rule: Rule<I, T, Q, S>): Event<I, T, Q, S, N>;
         // (undocumented)
         get rule(): Rule<I, T, Q, S>;
         // (undocumented)
-        static start<I, T, Q, S>(rule: Rule<I, T, Q, S>): Event<I, T, Q, S>;
+        static start<I, T, Q, S>(rule: Rule<I, T, Q, S>): Event<I, T, Q, S, "start">;
         // (undocumented)
-        toJSON(): Event.JSON;
+        toJSON(): Event.JSON<N>;
     }
     // (undocumented)
     export namespace Event {
         // (undocumented)
-        export interface JSON {
+        export interface JSON<N extends Name = Name> {
             // (undocumented)
             [key: string]: json.JSON;
             // (undocumented)
-            name: Name;
+            name: N;
             // (undocumented)
             rule: Rule.JSON;
         }
@@ -110,9 +110,9 @@ export namespace Diagnostic {
 // Warning: (ae-forgotten-export) The symbol "Depths" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export type Interview<Q, S, C, A, D extends number = 3> = A | {
-    [K in keyof Q]: Question<K, S, C, Q[K], D extends -1 ? A : Interview<Q, S, C, A, Depths[D]>>;
-}[keyof Q];
+export type Interview<QUESTION, SUBJECT, CONTEXT, ANSWER, D extends number = 3> = ANSWER | {
+    [URI in keyof QUESTION]: Question<QUESTION[URI] extends [infer T, any] ? T : never, SUBJECT, CONTEXT, QUESTION[URI] extends [any, infer A] ? A : never, D extends -1 ? ANSWER : Interview<QUESTION, SUBJECT, CONTEXT, ANSWER, Depths[D]>, URI extends string ? URI : never>;
+}[keyof QUESTION];
 
 // @public (undocumented)
 export namespace Interview {
@@ -120,12 +120,12 @@ export namespace Interview {
     export function conduct<I, T, Q, S, A>(interview: Interview<Q, S, T, A>, rule: Rule<I, T, Q, S>, oracle: Oracle<I, T, Q, S>): Future<Option<A>>;
 }
 
-// @public (undocumented)
-export type Oracle<I, T, Q, S> = <A>(rule: Rule<I, T, Q, S>, question: {
-    [K in keyof Q]: Question<K, S, T, Q[K], A>;
-}[keyof Q]) => Future<Option<A>>;
+// @public
+export type Oracle<INPUT, TARGET, QUESTION, SUBJECT> = <ANSWER>(rule: Rule<INPUT, TARGET, QUESTION, SUBJECT>, question: {
+    [URI in keyof QUESTION]: Question<QUESTION[URI] extends [infer T, any] ? T : never, SUBJECT, TARGET, QUESTION[URI] extends [any, infer A] ? A : never, ANSWER, URI extends string ? URI : never>;
+}[keyof QUESTION]) => Future<Option<ANSWER>>;
 
-// @public (undocumented)
+// @public
 export abstract class Outcome<I, T, Q = never, S = T> implements Equatable, json.Serializable<Outcome.JSON>, earl.Serializable<Outcome.EARL>, sarif.Serializable<sarif.Result> {
     protected constructor(rule: Rule<I, T, Q, S>);
     // (undocumented)
@@ -384,83 +384,83 @@ export namespace Outcome {
     }
 }
 
-// @public (undocumented)
-export class Question<Q, S, C, A, T = A, U extends string = string> implements Functor<T>, Applicative<T>, Monad<T>, Serializable<Question.JSON<Q, S, C>> {
-    protected constructor(type: Q, uri: U, message: string, subject: S, context: C, quester: Mapper<A, T>);
+// @public
+export class Question<TYPE, SUBJECT, CONTEXT, ANSWER, T = ANSWER, URI extends string = string> implements Functor<T>, Applicative<T>, Monad<T>, Serializable<Question.JSON<TYPE, SUBJECT, CONTEXT, URI>> {
+    protected constructor(type: TYPE, uri: URI, message: string, subject: SUBJECT, context: CONTEXT, quester: Mapper<ANSWER, T>);
     // (undocumented)
-    answer(answer: A): T;
+    answer(answer: ANSWER): T;
     // (undocumented)
-    answerIf(condition: boolean, answer: A): Question<Q, S, C, A, T, U>;
+    answerIf(condition: boolean, answer: ANSWER): Question<TYPE, SUBJECT, CONTEXT, ANSWER, T, URI>;
     // (undocumented)
-    answerIf(predicate: Predicate<S, [context: C]>, answer: A): Question<Q, S, C, A, T, U>;
+    answerIf(predicate: Predicate<SUBJECT, [context: CONTEXT]>, answer: ANSWER): Question<TYPE, SUBJECT, CONTEXT, ANSWER, T, URI>;
     // (undocumented)
-    answerIf(answer: Option<A>): Question<Q, S, C, A, T, U>;
+    answerIf(answer: Option<ANSWER>): Question<TYPE, SUBJECT, CONTEXT, ANSWER, T, URI>;
     // (undocumented)
-    answerIf(answer: Result<A, unknown>): Question<Q, S, C, A, T, U>;
+    answerIf(answer: Result<ANSWER, unknown>): Question<TYPE, SUBJECT, CONTEXT, ANSWER, T, URI>;
     // (undocumented)
-    apply<V>(mapper: Question<Q, S, C, A, Mapper<T, V>, U>): Question<Q, S, C, A, V, U>;
+    apply<U>(mapper: Question<TYPE, SUBJECT, CONTEXT, ANSWER, Mapper<T, U>, URI>): Question<TYPE, SUBJECT, CONTEXT, ANSWER, U, URI>;
     // (undocumented)
-    get context(): C;
+    get context(): CONTEXT;
     // (undocumented)
-    protected readonly _context: C;
+    protected readonly _context: CONTEXT;
     // (undocumented)
-    flatMap<V>(mapper: Mapper<T, Question<Q, S, C, A, V, U>>): Question<Q, S, C, A, V, U>;
+    flatMap<U>(mapper: Mapper<T, Question<TYPE, SUBJECT, CONTEXT, ANSWER, U, URI>>): Question<TYPE, SUBJECT, CONTEXT, ANSWER, U, URI>;
     // (undocumented)
-    flatten<Q, S, C, A, T>(this: Question<Q, S, C, A, Question<Q, S, C, A, T>>): Question<Q, S, C, A, T>;
+    flatten<TYPE, SUBJECT, CONTEXT, ANSWER, T>(this: Question<TYPE, SUBJECT, CONTEXT, ANSWER, Question<TYPE, SUBJECT, CONTEXT, ANSWER, T>>): Question<TYPE, SUBJECT, CONTEXT, ANSWER, T>;
     // (undocumented)
-    isRhetorical(): this is Question.Rhetorical<Q, S, C, A, T>;
+    isRhetorical(): this is Question.Rhetorical<TYPE, SUBJECT, CONTEXT, ANSWER, T>;
     // (undocumented)
-    map<V>(mapper: Mapper<T, V>): Question<Q, S, C, A, V, U>;
+    map<U>(mapper: Mapper<T, U>): Question<TYPE, SUBJECT, CONTEXT, ANSWER, U, URI>;
     // (undocumented)
     get message(): string;
     // (undocumented)
     protected readonly _message: string;
     // (undocumented)
-    static of<Q, S, C, A, U extends string = string>(type: Q, uri: U, message: string, subject: S, context: C): Question<Q, S, C, A, A, U>;
+    static of<TYPE, SUBJECT, CONTEXT, ANSWER, URI extends string = string>(type: TYPE, uri: URI, message: string, subject: SUBJECT, context: CONTEXT): Question<TYPE, SUBJECT, CONTEXT, ANSWER, ANSWER, URI>;
     // (undocumented)
-    protected readonly _quester: Mapper<A, T>;
+    protected readonly _quester: Mapper<ANSWER, T>;
     // (undocumented)
-    get subject(): S;
+    get subject(): SUBJECT;
     // (undocumented)
-    protected readonly _subject: S;
+    protected readonly _subject: SUBJECT;
     // (undocumented)
-    toJSON(): Question.JSON<Q, S, C, U>;
+    toJSON(): Question.JSON<TYPE, SUBJECT, CONTEXT, URI>;
     // (undocumented)
-    get type(): Q;
+    get type(): TYPE;
     // (undocumented)
-    protected readonly _type: Q;
+    protected readonly _type: TYPE;
     // (undocumented)
-    get uri(): U;
+    get uri(): URI;
     // (undocumented)
-    protected readonly _uri: U;
+    protected readonly _uri: URI;
 }
 
 // @public (undocumented)
 export namespace Question {
     // (undocumented)
-    export function isQuestion<Q, S, C, A, T = A, U extends string = string>(value: unknown): value is Question<Q, S, C, A, T, U>;
+    export function isQuestion<TYPE, SUBJECT, CONTEXT, ANSWER, T = ANSWER, URI extends string = string>(value: unknown): value is Question<TYPE, SUBJECT, CONTEXT, ANSWER, T, URI>;
     // (undocumented)
-    export interface JSON<Q, S, C, U extends string = string> {
+    export interface JSON<TYPE, SUBJECT, CONTEXT, URI extends string = string> {
         // (undocumented)
         [key: string]: json.JSON;
         // (undocumented)
-        context: Serializable.ToJSON<C>;
+        context: Serializable.ToJSON<CONTEXT>;
         // (undocumented)
         message: string;
         // (undocumented)
-        subject: Serializable.ToJSON<S>;
+        subject: Serializable.ToJSON<SUBJECT>;
         // (undocumented)
-        type: Serializable.ToJSON<Q>;
+        type: Serializable.ToJSON<TYPE>;
         // (undocumented)
-        uri: U;
+        uri: URI;
     }
     // @internal
-    export class Rhetorical<Q, S, C, A, T = A, U extends string = string> extends Question<Q, S, C, A, T, U> {
-        constructor(type: Q, uri: U, message: string, subject: S, context: C, answer: T);
+    export class Rhetorical<TYPE, SUBJECT, CONTEXT, ANSWER, T = ANSWER, URI extends string = string> extends Question<TYPE, SUBJECT, CONTEXT, ANSWER, T, URI> {
+        constructor(type: TYPE, uri: URI, message: string, subject: SUBJECT, context: CONTEXT, answer: T);
         // (undocumented)
         answer(): T;
         // (undocumented)
-        map<V>(mapper: Mapper<T, V>): Rhetorical<Q, S, C, A, V, U>;
+        map<U>(mapper: Mapper<T, U>): Rhetorical<TYPE, SUBJECT, CONTEXT, ANSWER, U, URI>;
     }
 }
 
@@ -503,7 +503,7 @@ export namespace Requirement {
     }
 }
 
-// @public (undocumented)
+// @public
 export abstract class Rule<I = unknown, T = unknown, Q = never, S = T> implements Equatable, json.Serializable<Rule.JSON>, earl.Serializable<Rule.EARL>, sarif.Serializable<sarif.ReportingDescriptor> {
     protected constructor(uri: string, requirements: Array_2<Requirement>, tags: Array_2<Tag>, evaluator: Rule.Evaluate<I, T, Q, S>);
     // (undocumented)

--- a/docs/review/api/alfa-rules.api.md
+++ b/docs/review/api/alfa-rules.api.md
@@ -27,19 +27,19 @@ import { Text } from '@siteimprove/alfa-dom';
 const _default: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_10: Rule.Atomic<Page, Attribute, never, Attribute>;
+const _default_10: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_11: Rule.Atomic<Page, Element, never, Element>;
+const _default_11: Rule.Atomic<Page, Attribute, never, Attribute>;
 
 // @public (undocumented)
 const _default_12: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_13: Rule.Atomic<Page, Attribute, never, Attribute>;
+const _default_13: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_14: Rule.Atomic<Page, Element, never, Element>;
+const _default_14: Rule.Atomic<Page, Attribute, never, Attribute>;
 
 // @public (undocumented)
 const _default_15: Rule.Atomic<Page, Element, never, Element>;
@@ -51,19 +51,19 @@ const _default_16: Rule.Atomic<Page, Element, never, Element>;
 const _default_17: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_18: Rule.Atomic<Page, Group<Element>, Question, Group<Element>>;
+const _default_18: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_19: Rule.Atomic<Page, Element, never, Element>;
+const _default_19: Rule.Atomic<Page, Group<Element>, Question.Metadata, Group<Element>>;
 
 // @public (undocumented)
-const _default_2: Rule.Atomic<Page, Document, Question, Element>;
+const _default_2: Rule.Atomic<Page, Document, Question.Metadata, Element>;
 
 // @public (undocumented)
 const _default_20: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_21: Rule.Atomic<Page, Attribute, never, Attribute>;
+const _default_21: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
 const _default_22: Rule.Atomic<Page, Attribute, never, Attribute>;
@@ -75,73 +75,73 @@ const _default_23: Rule.Atomic<Page, Attribute, never, Attribute>;
 const _default_24: Rule.Atomic<Page, Attribute, never, Attribute>;
 
 // @public (undocumented)
-const _default_25: Rule.Atomic<Page, Element, Question, Element>;
+const _default_25: Rule.Atomic<Page, Attribute, never, Attribute>;
 
 // @public (undocumented)
-const _default_26: Rule.Atomic<Page, Element, Question, Element>;
+const _default_26: Rule.Atomic<Page, Element, Question.Metadata, Element>;
 
 // @public (undocumented)
-const _default_27: Rule.Atomic<Page, Element, Question, Element>;
+const _default_27: Rule.Atomic<Page, Element, Question.Metadata, Element>;
 
 // @public (undocumented)
-const _default_28: Rule.Atomic<Page, Element, Question, Element>;
+const _default_28: Rule.Atomic<Page, Element, Question.Metadata, Element>;
 
 // @public (undocumented)
-const _default_29: Rule.Atomic<Page, Element, Question, Element>;
+const _default_29: Rule.Atomic<Page, Element, Question.Metadata, Element>;
 
 // @public (undocumented)
-const _default_3: Rule.Atomic<Page, Document, Question, Document>;
+const _default_3: Rule.Atomic<Page, Element, Question.Metadata, Node>;
 
 // @public (undocumented)
-const _default_30: Rule.Composite<Page, Element, Question, Element>;
+const _default_30: Rule.Atomic<Page, Element, Question.Metadata, Element>;
 
 // @public (undocumented)
-const _default_31: Rule.Atomic<Page, Element, never, Element>;
+const _default_31: Rule.Composite<Page, Element, Question.Metadata, Element>;
 
 // @public (undocumented)
-const _default_32: Rule.Atomic<Page, Element, Question, Element>;
+const _default_32: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_33: Rule.Composite<Page, Element, Question, Element>;
+const _default_33: Rule.Atomic<Page, Element, Question.Metadata, Element>;
 
 // @public (undocumented)
-const _default_34: Rule.Atomic<Page, Element, Question, Element>;
+const _default_34: Rule.Composite<Page, Element, Question.Metadata, Element>;
 
 // @public (undocumented)
-const _default_35: Rule.Atomic<Page, Element, Question, Element>;
+const _default_35: Rule.Atomic<Page, Element, Question.Metadata, Element>;
 
 // @public (undocumented)
-const _default_36: Rule.Atomic<Page, Element, Question, Element>;
+const _default_36: Rule.Atomic<Page, Element, Question.Metadata, Element>;
 
 // @public (undocumented)
-const _default_37: Rule.Atomic<Page, Element, Question, Element>;
+const _default_37: Rule.Atomic<Page, Element, Question.Metadata, Element>;
 
 // @public (undocumented)
-const _default_38: Rule.Composite<Page, Element, Question, Element>;
+const _default_38: Rule.Atomic<Page, Element, Question.Metadata, Element>;
 
 // @public (undocumented)
-const _default_39: Rule.Atomic<Page, Element, Question, Element>;
+const _default_39: Rule.Composite<Page, Element, Question.Metadata, Element>;
 
 // @public (undocumented)
-const _default_4: Rule.Atomic<Page, Document, never, Document>;
+const _default_4: Rule.Atomic<Page, Document, Question.Metadata, Document>;
 
 // @public (undocumented)
-const _default_40: Rule.Composite<Page, Element, Question, Element>;
+const _default_40: Rule.Atomic<Page, Element, Question.Metadata, Element>;
 
 // @public (undocumented)
-const _default_41: Rule.Composite<Page, Element, Question, Element>;
+const _default_41: Rule.Composite<Page, Element, Question.Metadata, Element>;
 
 // @public (undocumented)
-const _default_42: Rule.Atomic<Page, Element, Question, Element>;
+const _default_42: Rule.Composite<Page, Element, Question.Metadata, Element>;
 
 // @public (undocumented)
-const _default_43: Rule.Atomic<Page, Element, never, Element>;
+const _default_43: Rule.Atomic<Page, Element, Question.Metadata, Element>;
 
 // @public (undocumented)
-const _default_44: Rule.Atomic<Page, Group<Element>, Question, Group<Element>>;
+const _default_44: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_45: Rule.Atomic<Page, Element, never, Element>;
+const _default_45: Rule.Atomic<Page, Group<Element>, Question.Metadata, Group<Element>>;
 
 // @public (undocumented)
 const _default_46: Rule.Atomic<Page, Element, never, Element>;
@@ -150,55 +150,55 @@ const _default_46: Rule.Atomic<Page, Element, never, Element>;
 const _default_47: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_48: Rule.Atomic<Page, Attribute, never, Attribute>;
+const _default_48: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_49: Rule.Atomic<Page, Element, never, Element>;
+const _default_49: Rule.Atomic<Page, Attribute, never, Attribute>;
 
 // @public (undocumented)
-const _default_5: Rule.Atomic<Page, Element, never, Element>;
+const _default_5: Rule.Atomic<Page, Document, never, Document>;
 
 // @public (undocumented)
 const _default_50: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_51: Rule.Atomic<Page, Element, Question, Element>;
+const _default_51: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_52: Rule.Atomic<Page, Element, Question, Element>;
+const _default_52: Rule.Atomic<Page, Element, Question.Metadata, Element>;
 
 // @public (undocumented)
-const _default_53: Rule.Composite<Page, Element, Question, Element>;
+const _default_53: Rule.Atomic<Page, Element, Question.Metadata, Element>;
 
 // @public (undocumented)
-const _default_54: Rule.Atomic<Page, Element, never, Element>;
+const _default_54: Rule.Composite<Page, Element, Question.Metadata, Element>;
 
 // @public (undocumented)
 const _default_55: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_56: Rule.Atomic<Page, Group<Element>, Question, Group<Element>>;
+const _default_56: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_57: Rule.Atomic<Page, Group<Element>, never, Group<Element>>;
+const _default_57: Rule.Atomic<Page, Group<Element>, Question.Metadata, Group<Element>>;
 
 // @public (undocumented)
-const _default_58: Rule.Atomic<Page, Text, never, Text>;
+const _default_58: Rule.Atomic<Page, Group<Element>, never, Group<Element>>;
 
 // @public (undocumented)
-const _default_59: Rule.Atomic<Page, Document, never, Document>;
+const _default_59: Rule.Atomic<Page, Text, never, Text>;
 
 // @public (undocumented)
 const _default_6: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_60: Rule.Atomic<Page, Element, never, Element>;
+const _default_60: Rule.Atomic<Page, Document, never, Document>;
 
 // @public (undocumented)
-const _default_61: Rule.Atomic<Page, Document, never, Document>;
+const _default_61: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_62: Rule.Atomic<Page, Element, never, Element>;
+const _default_62: Rule.Atomic<Page, Document, never, Document>;
 
 // @public (undocumented)
 const _default_63: Rule.Atomic<Page, Element, never, Element>;
@@ -207,28 +207,28 @@ const _default_63: Rule.Atomic<Page, Element, never, Element>;
 const _default_64: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_65: Rule.Atomic<Page, Element, Question, Element>;
+const _default_65: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_66: Rule.Atomic<Page, Text, Question, Text>;
+const _default_66: Rule.Atomic<Page, Element, Question.Metadata, Element>;
 
 // @public (undocumented)
-const _default_67: Rule.Atomic<Page, Element, never, Element>;
+const _default_67: Rule.Atomic<Page, Text, Question.Metadata, Text>;
 
 // @public (undocumented)
 const _default_68: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_69: Rule.Atomic<Page, Text, Question, Text>;
+const _default_69: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
 const _default_7: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_70: Rule.Atomic<Page, Document, never, Document>;
+const _default_70: Rule.Atomic<Page, Text, Question.Metadata, Text>;
 
 // @public (undocumented)
-const _default_71: Rule.Atomic<Page, Element, never, Element>;
+const _default_71: Rule.Atomic<Page, Document, never, Document>;
 
 // @public (undocumented)
 const _default_72: Rule.Atomic<Page, Element, never, Element>;
@@ -255,16 +255,16 @@ const _default_78: Rule.Atomic<Page, Element, never, Element>;
 const _default_79: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_8: Rule.Atomic<Page, Attribute, never, Attribute>;
+const _default_8: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
 const _default_80: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_81: Rule.Atomic<Page, Group<Element>, Question, Group<Element>>;
+const _default_81: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_82: Rule.Atomic<Page, Element, Question, Node>;
+const _default_82: Rule.Atomic<Page, Group<Element>, Question.Metadata, Group<Element>>;
 
 // @public (undocumented)
 const _default_83: Rule.Atomic<Page, Text, never, Text>;
@@ -279,7 +279,7 @@ const _default_85: Rule.Atomic<Page, Element, never, Element>;
 const _default_86: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_87: Rule.Atomic<Page, Document, Question, Document>;
+const _default_87: Rule.Atomic<Page, Document, Question.Metadata, Document>;
 
 // @public (undocumented)
 const _default_88: Rule.Atomic<Page, Element, never, Element>;
@@ -288,7 +288,7 @@ const _default_88: Rule.Atomic<Page, Element, never, Element>;
 const _default_89: Rule.Atomic<Page, Element, never, Element>;
 
 // @public (undocumented)
-const _default_9: Rule.Atomic<Page, Element, never, Element>;
+const _default_9: Rule.Atomic<Page, Attribute, never, Attribute>;
 
 // @public (undocumented)
 const _default_90: Rule.Atomic<Page, Element, never, Element>;
@@ -309,7 +309,8 @@ declare namespace experimentalRules {
     export {
         _default as ER62,
         _default_2 as ER87,
-        _default_3 as R109
+        _default_3 as R82,
+        _default_4 as R109
     }
 }
 export { experimentalRules }
@@ -363,27 +364,171 @@ export namespace Group {
 }
 
 // @public (undocumented)
-export interface Question {
-    // (undocumented)
-    "color[]": Iterable<RGB>;
-    // (undocumented)
-    "node[]": Iterable<Node>;
-    // (undocumented)
-    boolean: boolean;
-    // (undocumented)
-    color: Option<RGB>;
-    // (undocumented)
-    node: Option<Node>;
-    // (undocumented)
-    string: string;
-}
-
-// @public (undocumented)
 export namespace Question {
+    export type Data = typeof Data & Record<Uri, {
+        readonly type: keyof Type;
+        readonly message: string;
+    }>;
+    export type Metadata = {
+        [K in Uri]: [Data[K]["type"], Type[Data[K]["type"]]];
+    };
     // (undocumented)
-    export function of<Q extends keyof Question, S, U extends string = string>(type: Q, uri: U, message: string, subject: S): act.Question<Q, S, S, Question[Q], Question[Q], U>;
+    export function of<S, U extends Uri = Uri>(uri: U, subject: S, message?: string): act.Question<Data[U]["type"], S, S, Type[Data[U]["type"]], Type[Data[U]["type"]], U>;
     // (undocumented)
-    export function of<Q extends keyof Question, S, C, U extends string = string>(type: Q, uri: U, message: string, subject: S, context: C): act.Question<Q, S, C, Question[Q], Question[Q], U>;
+    export function of<S, C, U extends Uri = Uri>(uri: U, subject: S, context: C, message?: string): act.Question<Data[U]["type"], S, C, Type[Data[U]["type"]], Type[Data[U]["type"]], U>;
+    export interface Type {
+        // (undocumented)
+        "color[]": Iterable<RGB>;
+        // (undocumented)
+        "node[]": Iterable<Node>;
+        // (undocumented)
+        boolean: boolean;
+        // (undocumented)
+        node: Option<Node>;
+        // (undocumented)
+        string: string;
+    }
+    export type Uri = keyof typeof Data;
+    const // (undocumented)
+    Data: {
+        readonly "reference-equivalent-resources": {
+            readonly type: "boolean";
+            readonly message: "Do the [links/iframe] [resolve to/reference] equivalent resources?";
+        };
+        readonly "has-audio": {
+            readonly type: "boolean";
+            readonly message: "Does the `<video>` element have audio?";
+        };
+        readonly "has-audio-track": {
+            readonly type: "boolean";
+            readonly message: "Does the `<video>` element have an audio track that describes its\n            visual information?";
+        };
+        readonly "has-captions": {
+            readonly type: "boolean";
+            readonly message: "Does the `<video>` element have captions?";
+        };
+        readonly "has-description": {
+            readonly type: "boolean";
+            readonly message: "Is the visual information of the [audio/video] available through its\n            audio or a separate audio description track?";
+        };
+        readonly "is-audio-streaming": {
+            readonly type: "boolean";
+            readonly message: "Is the `<audio>` element streaming?";
+        };
+        readonly "is-playing": {
+            readonly type: "boolean";
+            readonly message: "Is the `<audio>` element currently playing?";
+        };
+        readonly "is-video-streaming": {
+            readonly type: "boolean";
+            readonly message: "Is the `<video>` element streaming?";
+        };
+        readonly label: {
+            readonly type: "node";
+            readonly message: "Where is the text that labels the [audio/video] element as a video alternative?";
+        };
+        readonly "play-button": {
+            readonly type: "node";
+            readonly message: "Where is the button that controls playback of the `<audio>`\n                    element?";
+        };
+        readonly "text-alternative": {
+            readonly type: "node";
+            readonly message: "Where is the text alternative of the [audio/video] element?";
+        };
+        readonly "track-describes-video": {
+            readonly type: "boolean";
+            readonly message: "Does at least 1 track describe the visual information of the `<video>`\n      element, either in the language of the `<video>` element or the language\n      of the page?";
+        };
+        readonly transcript: {
+            readonly type: "node";
+            readonly message: "Where is the transcript of the [audio/video] element?";
+        };
+        readonly "transcript-link": {
+            readonly type: "node";
+            readonly message: "Where is the link pointing to the transcript of the [audio/video]\n                  element?";
+        };
+        readonly "transcript-perceivable": {
+            readonly type: "boolean";
+            readonly message: "Is the transcript of the [audio/video] element perceivable?";
+        };
+        readonly "name-describes-purpose": {
+            readonly type: "boolean";
+            readonly message: "Does the accessible name of the `<(target.name]>` element\n            describe its purpose?";
+        };
+        readonly "audio-control-mechanism": {
+            readonly type: "node";
+            readonly message: "Where is the mechanism that can pause or stop the audio of the\n            `<[target.name]>` element?";
+        };
+        readonly "is-above-duration-threshold": {
+            readonly type: "boolean";
+            readonly message: "Does the `<[element.name]>` element have a duration of more\n              than 3 seconds?";
+        };
+        readonly "is-below-audio-duration-threshold": {
+            readonly type: "boolean";
+            readonly message: "Does the `<[target.name]>` element have a total audio duration\n            of less than 3 seconds?";
+        };
+        readonly "is-content-equivalent": {
+            readonly type: "boolean";
+            readonly message: "Do these [role] landmarks have the same or equivalent content?";
+        };
+        readonly "has-focus-indicator": {
+            readonly type: "boolean";
+            readonly message: "Does the element have a visible focus indicator?";
+        };
+        readonly "background-colors": {
+            readonly type: "color[]";
+            readonly message: "What are the background colors of the text node?";
+        };
+        readonly "foreground-colors": {
+            readonly type: "color[]";
+            readonly message: "What are the foreground colors of the text node?";
+        };
+        readonly "first-tabbable-is-internal-link": {
+            readonly type: "boolean";
+            readonly message: "Is the first tabbable element of the document an internal link?";
+        };
+        readonly "first-tabbable-is-visible": {
+            readonly type: "boolean";
+            readonly message: "Is the first tabbable element of the document visible if it's focused?";
+        };
+        readonly "first-tabbable-reference": {
+            readonly type: "node";
+            readonly message: "Where in the document does the first tabbable element point?";
+        };
+        readonly "first-tabbable-reference-is-main": {
+            readonly type: "boolean";
+            readonly message: "Does the first tabbable element of the document point to the main content?";
+        };
+        readonly "error-indicators": {
+            readonly type: "node[]";
+            readonly message: "Where are the error indicators, if any, for the form field?";
+        };
+        readonly "error-indicator-describes-resolution": {
+            readonly type: "boolean";
+            readonly message: "Does the error indicator describe, in text, the cause of the error or how\n      to resolve it?";
+        };
+        readonly "error-indicator-identifies-form-field": {
+            readonly type: "boolean";
+            readonly message: "Does the error indicator identify, in text, the form field it relates to?";
+        };
+        readonly "internal-reference": {
+            readonly type: "node";
+            readonly message: "Where in the document does this element point?";
+        };
+        readonly "is-start-of-main": {
+            readonly type: "boolean";
+            readonly message: "Is this element at the start of the main content of the document?";
+        };
+        readonly "is-visible-when-focused": {
+            readonly type: "boolean";
+            readonly message: "Is this element visible when it's focused?";
+        };
+        readonly "document-language": {
+            readonly type: "string";
+            readonly message: "What is the main language of the document?";
+        };
+    };
+        {};
 }
 
 // @public (undocumented)

--- a/docs/review/api/alfa-rules.api.md
+++ b/docs/review/api/alfa-rules.api.md
@@ -365,6 +365,7 @@ export namespace Group {
 
 // @public (undocumented)
 export namespace Question {
+    // (undocumented)
     export type Data = typeof Data & Record<Uri, {
         readonly type: keyof Type;
         readonly message: string;
@@ -388,6 +389,7 @@ export namespace Question {
         // (undocumented)
         string: string;
     }
+    // (undocumented)
     export type Uri = keyof typeof Data;
     const // (undocumented)
     Data: {

--- a/packages/alfa-act/src/audit.ts
+++ b/packages/alfa-act/src/audit.ts
@@ -14,6 +14,10 @@ import { Rule } from "./rule";
 
 /**
  * @public
+ * * I: type of Input for rules
+ * * T: possible types of test targets
+ * * Q: questions' metadata type
+ * * S: possible types of questions' subject.
  */
 export class Audit<I, T = unknown, Q = never, S = T> {
   public static of<I, T = unknown, Q = never, S = T>(
@@ -62,31 +66,37 @@ export class Audit<I, T = unknown, Q = never, S = T> {
  * @public
  */
 export namespace Audit {
-  export class Event<I, T, Q, S> implements Serializable<Event.JSON> {
-    public static of<I, T, Q, S>(
-      name: Event.Name,
+  export class Event<I, T, Q, S, N extends Event.Name = Event.Name>
+    implements Serializable<Event.JSON<N>>
+  {
+    public static of<I, T, Q, S, N extends Event.Name>(
+      name: N,
       rule: Rule<I, T, Q, S>
-    ): Event<I, T, Q, S> {
+    ): Event<I, T, Q, S, N> {
       return new Event(name, rule);
     }
 
-    public static start<I, T, Q, S>(rule: Rule<I, T, Q, S>): Event<I, T, Q, S> {
+    public static start<I, T, Q, S>(
+      rule: Rule<I, T, Q, S>
+    ): Event<I, T, Q, S, "start"> {
       return new Event("start", rule);
     }
 
-    public static end<I, T, Q, S>(rule: Rule<I, T, Q, S>): Event<I, T, Q, S> {
+    public static end<I, T, Q, S>(
+      rule: Rule<I, T, Q, S>
+    ): Event<I, T, Q, S, "end"> {
       return new Event("end", rule);
     }
 
-    private readonly _name: Event.Name;
+    private readonly _name: N;
     private readonly _rule: Rule<I, T, Q, S>;
 
-    private constructor(event: Event.Name, rule: Rule<I, T, Q, S>) {
+    private constructor(event: N, rule: Rule<I, T, Q, S>) {
       this._name = event;
       this._rule = rule;
     }
 
-    public get name(): Event.Name {
+    public get name(): N {
       return this._name;
     }
 
@@ -94,7 +104,7 @@ export namespace Audit {
       return this._rule;
     }
 
-    public toJSON(): Event.JSON {
+    public toJSON(): Event.JSON<N> {
       return {
         name: this._name,
         rule: this._rule.toJSON(),
@@ -105,9 +115,9 @@ export namespace Audit {
   export namespace Event {
     export type Name = "start" | "end";
 
-    export interface JSON {
+    export interface JSON<N extends Name = Name> {
       [key: string]: json.JSON;
-      name: Name;
+      name: N;
       rule: Rule.JSON;
     }
   }

--- a/packages/alfa-act/src/interview.ts
+++ b/packages/alfa-act/src/interview.ts
@@ -75,7 +75,9 @@ export namespace Interview {
       if (interview.isRhetorical()) {
         answer = Future.now(Option.of(interview.answer()));
       } else {
-        answer = oracle(rule, interview);
+        answer = oracle(rule, interview).map((option) =>
+          option.map((answer) => interview.answer(answer))
+        );
       }
 
       return answer.flatMap((answer) =>

--- a/packages/alfa-act/src/interview.ts
+++ b/packages/alfa-act/src/interview.ts
@@ -18,7 +18,7 @@ type Depths = [-1, 0, 1, 2];
 /**
  * @public
  *
- * An Interview is either a direct ANSWER, or a question whose ultimately going
+ * An Interview is either a direct ANSWER; or a question who is ultimately going
  * to produce one, possibly through more questions (aka, an Interview).
  *
  * The QUESTION type maps questions' URI to the expected type of answer, both as
@@ -48,20 +48,19 @@ export type Interview<
 
 /**
  * @public
- *
- * To conduct an interview:
- * * if it is an answer, just send it back;
- * * if it is a rhetorical question, fetch its answer and recursively conduct
- *   an interview on it;
- * * if it is a true question, ask it to the oracle and recursively conduct an
- *   interview on the result.
- *
- * Oracles must return Options, to have the possibility to not answer a given
- * question (by returning None).
- * Oracles must return Futures, because the full interview process is essentially
- * async (e.g., asking through a CLI).
  */
 export namespace Interview {
+  //   To conduct an interview:
+  // * if it is an answer, just send it back;
+  // * if it is a rhetorical question, fetch its answer and recursively conduct
+  //   an interview on it;
+  // * if it is a true question, ask it to the oracle and recursively conduct an
+  //   interview on the result.
+  //
+  // Oracles must return Options, to have the possibility to not answer a given
+  // question (by returning None).
+  // Oracles must return Futures, because the full interview process is essentially
+  // async (e.g., asking through a CLI).
   export function conduct<INPUT, TARGET, QUESTION, SUBJECT, ANSWER>(
     // Questions' contexts are guaranteed to be (potential) test target of
     // the rule.
@@ -76,7 +75,8 @@ export namespace Interview {
         answer = Future.now(Option.of(interview.answer()));
       } else {
         answer = oracle(rule, interview).map((option) =>
-          option.map((answer) => interview.answer(answer))
+          // need to bind due to eta-contraction losing `this`.
+          option.map(interview.answer.bind(interview))
         );
       }
 

--- a/packages/alfa-act/src/interview.ts
+++ b/packages/alfa-act/src/interview.ts
@@ -18,17 +18,26 @@ type Depths = [-1, 0, 1, 2];
 /**
  * @public
  */
-export type Interview<Q, S, C, A, D extends number = 3> =
-  | A
+export type Interview<
+  QUESTION,
+  SUBJECT,
+  CONTEXT,
+  ANSWER,
+  D extends number = 3
+> =
+  | ANSWER
   | {
-      [K in keyof Q]: Question<
-        K,
-        S,
-        C,
-        Q[K],
-        D extends -1 ? A : Interview<Q, S, C, A, Depths[D]>
+      [URI in keyof QUESTION]: Question<
+        QUESTION[URI] extends [infer T, any] ? T : never,
+        SUBJECT,
+        CONTEXT,
+        QUESTION[URI] extends [any, infer A] ? A : never,
+        D extends -1
+          ? ANSWER
+          : Interview<QUESTION, SUBJECT, CONTEXT, ANSWER, Depths[D]>,
+        URI extends string ? URI : never
       >;
-    }[keyof Q];
+    }[keyof QUESTION];
 
 /**
  * @public

--- a/packages/alfa-act/src/oracle.ts
+++ b/packages/alfa-act/src/oracle.ts
@@ -5,16 +5,44 @@ import { Question } from "./question";
 import { Rule } from "./rule";
 
 /**
- * @public
- * * I: type of Input for rules
- * * T: possible types of test targets
- * * Q: questions' metadata type; has the shape {URI: [T, type]} where
- *      URI is the question URI, T a representation of the expected return
- *      type, and type the actual return type.
- *      e.g. { "q1": ["boolean", boolean]}
- * * S: possible types of questions' subject.
+ * The type of question's metadata.
+ * * URI: unique identifier
+ * * TYPE: a Javascript manipulable representation of the expected answer type
+ * * ANSWER: the expected answer type
+ *
+ * Example:
+ *   {
+ *     "q1": ["boolean", boolean],
+ *     "q2": ["number?", number | undefined],
+ *   }
  */
-export type Oracle<I, T, Q, S> = <A>(
-  rule: Rule<I, T, Q, S>,
-  question: { [K in keyof Q]: Question<K, S, T, Q[K], A> }[keyof Q]
-) => Future<Option<A>>;
+type Metadata<URI extends string, TYPE, ANSWER> = Record<URI, [TYPE, ANSWER]>;
+
+/**
+ * @public
+ * * INPUT: type of Input for rules
+ * * TARGET: possible types of test targets
+ * * QUESTION: questions' metadata type; has the shape {URI: [T, A]} where
+ *             URI is the question URI, T a representation of the expected return
+ *             type, and A the actual return type.
+ *             Example:
+ *             {
+ *               "q1": ["boolean", boolean],
+ *               "q2": ["number?", number | undefined],
+ *             }
+ * * SUBJECT: possible types of questions' subject.
+ * * ANSWER: transformed type of questions' answer.
+ */
+export type Oracle<INPUT, TARGET, QUESTION, SUBJECT> = <ANSWER>(
+  rule: Rule<INPUT, TARGET, QUESTION, SUBJECT>,
+  question: {
+    [URI in keyof QUESTION]: Question<
+      QUESTION[URI] extends [infer T, any] ? T : never,
+      SUBJECT,
+      TARGET,
+      QUESTION[URI] extends [any, infer A] ? A : never,
+      ANSWER,
+      URI extends string ? URI : never
+    >;
+  }[keyof QUESTION]
+) => Future<Option<ANSWER>>;

--- a/packages/alfa-act/src/oracle.ts
+++ b/packages/alfa-act/src/oracle.ts
@@ -6,6 +6,13 @@ import { Rule } from "./rule";
 
 /**
  * @public
+ * * I: type of Input for rules
+ * * T: possible types of test targets
+ * * Q: questions' metadata type; has the shape {URI: [T, type]} where
+ *      URI is the question URI, T a representation of the expected return
+ *      type, and type the actual return type.
+ *      e.g. { "q1": ["boolean", boolean]}
+ * * S: possible types of questions' subject.
  */
 export type Oracle<I, T, Q, S> = <A>(
   rule: Rule<I, T, Q, S>,

--- a/packages/alfa-act/src/oracle.ts
+++ b/packages/alfa-act/src/oracle.ts
@@ -15,7 +15,7 @@ import { Rule } from "./rule";
  *               "q2": ["number?", number | undefined],
  *             \}
  */
-export type Oracle<INPUT, TARGET, QUESTION, SUBJECT> = <ANSWER>(
+export type Oracle<INPUT, TARGET, QUESTION, SUBJECT> = (
   rule: Rule<INPUT, TARGET, QUESTION, SUBJECT>,
   question: {
     [URI in keyof QUESTION]: Question<
@@ -23,8 +23,10 @@ export type Oracle<INPUT, TARGET, QUESTION, SUBJECT> = <ANSWER>(
       SUBJECT,
       TARGET,
       QUESTION[URI] extends [any, infer A] ? A : never,
-      ANSWER,
+      unknown,
       URI extends string ? URI : never
     >;
   }[keyof QUESTION]
-) => Future<Option<ANSWER>>;
+) => Future<
+  Option<QUESTION[keyof QUESTION] extends [any, infer A] ? A : never>
+>;

--- a/packages/alfa-act/src/oracle.ts
+++ b/packages/alfa-act/src/oracle.ts
@@ -5,31 +5,17 @@ import { Question } from "./question";
 import { Rule } from "./rule";
 
 /**
- * The type of question's metadata.
- * * URI: unique identifier
- * * TYPE: a Javascript manipulable representation of the expected answer type
- * * ANSWER: the expected answer type
- *
- * Example:
- *   {
- *     "q1": ["boolean", boolean],
- *     "q2": ["number?", number | undefined],
- *   }
- */
-type Metadata<URI extends string, TYPE, ANSWER> = Record<URI, [TYPE, ANSWER]>;
-
-/**
  * @public
  * * INPUT: type of Input for rules
  * * TARGET: possible types of test targets
- * * QUESTION: questions' metadata type; has the shape {URI: [T, A]} where
+ * * QUESTION: questions' metadata type; has the shape \{ URI: [T, A] \} where
  *             URI is the question URI, T a representation of the expected return
  *             type, and A the actual return type.
  *             Example:
- *             {
+ *             \{
  *               "q1": ["boolean", boolean],
  *               "q2": ["number?", number | undefined],
- *             }
+ *             \}
  * * SUBJECT: possible types of questions' subject.
  * * ANSWER: transformed type of questions' answer.
  */

--- a/packages/alfa-act/src/oracle.ts
+++ b/packages/alfa-act/src/oracle.ts
@@ -6,8 +6,6 @@ import { Rule } from "./rule";
 
 /**
  * @public
- * * INPUT: type of Input for rules
- * * TARGET: possible types of test targets
  * * QUESTION: questions' metadata type; has the shape \{ URI: [T, A] \} where
  *             URI is the question URI, T a representation of the expected return
  *             type, and A the actual return type.
@@ -16,8 +14,6 @@ import { Rule } from "./rule";
  *               "q1": ["boolean", boolean],
  *               "q2": ["number?", number | undefined],
  *             \}
- * * SUBJECT: possible types of questions' subject.
- * * ANSWER: transformed type of questions' answer.
  */
 export type Oracle<INPUT, TARGET, QUESTION, SUBJECT> = <ANSWER>(
   rule: Rule<INPUT, TARGET, QUESTION, SUBJECT>,

--- a/packages/alfa-act/src/outcome.ts
+++ b/packages/alfa-act/src/outcome.ts
@@ -14,6 +14,10 @@ import { Rule } from "./rule";
 
 /**
  * @public
+ * I: type of Input for the associated rule
+ * T: type of the rule's test target
+ * Q: questions' metadata type
+ * S: possible types of questions' subject.
  */
 export abstract class Outcome<I, T, Q = never, S = T>
   implements

--- a/packages/alfa-act/src/rule.ts
+++ b/packages/alfa-act/src/rule.ts
@@ -25,6 +25,10 @@ const { flatMap, flatten, reduce } = Iterable;
 
 /**
  * @public
+ * * I: type of Input for the rule
+ * * T: type of the test targets
+ * * Q: questions' metadata type
+ * * S: possible types of questions' subject.
  */
 export abstract class Rule<I = unknown, T = unknown, Q = never, S = T>
   implements

--- a/packages/alfa-assert/test/asserter.spec.ts
+++ b/packages/alfa-assert/test/asserter.spec.ts
@@ -44,7 +44,7 @@ test("#expect() allows to reject cantTell outcomes", async (t) => {
 
 test("#expect() accepts an oracle", async (t) => {
   const { expect } = Asserter.of([Pass("pass"), CantTell("maybe")], [], {
-    oracle: (_, question) => Future.now(Option.of(question.answer(true))),
+    oracle: (_, question) => Future.now(Option.of(true)),
   });
 
   const result = await expect("foo").to.be.accessible();

--- a/packages/alfa-assert/test/fixture/rule.ts
+++ b/packages/alfa-assert/test/fixture/rule.ts
@@ -40,7 +40,7 @@ export const Fail = (uri: string) =>
   });
 
 export const CantTell = (uri: string) =>
-  Rule.Atomic.of<string, string, { boolean: boolean }>({
+  Rule.Atomic.of<string, string, { "is-passed": ["boolean", boolean] }>({
     uri,
 
     evaluate(input) {
@@ -50,13 +50,13 @@ export const CantTell = (uri: string) =>
         },
 
         expectations(target) {
-          const isPassed = Question.of<"boolean", string, string, boolean>(
+          const isPassed = Question.of<
             "boolean",
-            "is-passed",
-            "Does the rule pass?",
-            target,
-            target
-          );
+            string,
+            string,
+            boolean,
+            "is-passed"
+          >("boolean", "is-passed", "Does the rule pass?", target, target);
           return {
             1: isPassed.map((passed) =>
               passed

--- a/packages/alfa-rules/src/common/applicability/audio.ts
+++ b/packages/alfa-rules/src/common/applicability/audio.ts
@@ -16,7 +16,7 @@ export function audio(
   document: Document,
   device: Device,
   options: audio.Options = {}
-): Iterable<Interview<Question, Element, Element, Option<Element>>> {
+): Iterable<Interview<Question.Type, Element, Element, Option<Element>>> {
   return document
     .descendants({ flattened: true, nested: true })
     .filter(isElement)

--- a/packages/alfa-rules/src/common/applicability/audio.ts
+++ b/packages/alfa-rules/src/common/applicability/audio.ts
@@ -28,29 +28,13 @@ export function audio(
       )
     )
     .map((element) =>
-      Question.of(
-        "boolean",
-        "is-audio-streaming",
-        `Is the \`<audio>\` element streaming?`,
-        element
-      ).map((isStreaming) =>
+      Question.of("is-audio-streaming", element).map((isStreaming) =>
         isStreaming
           ? None
-          : Question.of(
-              "boolean",
-              "is-playing",
-              `Is the \`<audio>\` element currently playing?`,
-              element
-            ).map((isPlaying) =>
+          : Question.of("is-playing", element).map((isPlaying) =>
               isPlaying
                 ? Option.of(element)
-                : Question.of(
-                    "node",
-                    "play-button",
-                    `Where is the button that controls playback of the \`<audio>\`
-                    element?`,
-                    element
-                  ).map((playButton) =>
+                : Question.of("play-button", element).map((playButton) =>
                     playButton.some(
                       and(Element.isElement, isPerceivable(device))
                     )

--- a/packages/alfa-rules/src/common/applicability/audio.ts
+++ b/packages/alfa-rules/src/common/applicability/audio.ts
@@ -16,7 +16,7 @@ export function audio(
   document: Document,
   device: Device,
   options: audio.Options = {}
-): Iterable<Interview<Question.Type, Element, Element, Option<Element>>> {
+): Iterable<Interview<Question.Metadata, Element, Element, Option<Element>>> {
   return document
     .descendants({ flattened: true, nested: true })
     .filter(isElement)

--- a/packages/alfa-rules/src/common/applicability/video.ts
+++ b/packages/alfa-rules/src/common/applicability/video.ts
@@ -15,7 +15,7 @@ export function video(
   document: Document,
   device: Device,
   options: video.Options = {}
-): Iterable<Interview<Question.Type, Element, Element, Option<Element>>> {
+): Iterable<Interview<Question.Metadata, Element, Element, Option<Element>>> {
   const { audio, track } = options;
 
   return document

--- a/packages/alfa-rules/src/common/applicability/video.ts
+++ b/packages/alfa-rules/src/common/applicability/video.ts
@@ -15,7 +15,7 @@ export function video(
   document: Document,
   device: Device,
   options: video.Options = {}
-): Iterable<Interview<Question, Element, Element, Option<Element>>> {
+): Iterable<Interview<Question.Type, Element, Element, Option<Element>>> {
   const { audio, track } = options;
 
   return document

--- a/packages/alfa-rules/src/common/applicability/video.ts
+++ b/packages/alfa-rules/src/common/applicability/video.ts
@@ -57,23 +57,13 @@ export function video(
       )
     )
     .map((element) =>
-      Question.of(
-        "boolean",
-        "is-video-streaming",
-        `Is the \`<video>\` element streaming?`,
-        element
-      ).map((isStreaming) => {
+      Question.of("is-video-streaming", element).map((isStreaming) => {
         if (isStreaming) {
           return None;
         }
 
         if (audio !== undefined) {
-          return Question.of(
-            "boolean",
-            "has-audio",
-            `Does the \`<video>\` element have audio?`,
-            element
-          ).map((hasAudio) =>
+          return Question.of("has-audio", element).map((hasAudio) =>
             audio.has === hasAudio ? Option.of(element) : None
           );
         }

--- a/packages/alfa-rules/src/common/expectation/media-text-alternative.ts
+++ b/packages/alfa-rules/src/common/expectation/media-text-alternative.ts
@@ -13,8 +13,22 @@ import { Question } from "../question";
 import { Diagnostic } from "@siteimprove/alfa-act";
 
 function mediaTextAlternative(
-  alt: act.Question<"node", Element, Element, Option<Node>>,
-  label: act.Question<"node", Element, Element, Option<Node>>,
+  alt: act.Question<
+    "node",
+    Element,
+    Element,
+    Option<Node>,
+    Option<Node>,
+    "text-alternative"
+  >,
+  label: act.Question<
+    "node",
+    Element,
+    Element,
+    Option<Node>,
+    Option<Node>,
+    "label"
+  >,
   device: Device,
   kind: "<audio>" | "<video>"
 ) {

--- a/packages/alfa-rules/src/common/expectation/media-text-alternative.ts
+++ b/packages/alfa-rules/src/common/expectation/media-text-alternative.ts
@@ -49,17 +49,15 @@ function mediaTextAlternative(
 // keeping the next two functions separate because question should be split in two at some point.
 export function audioTextAlternative(target: Element, device: Device) {
   const alt = Question.of(
-    "node",
     "text-alternative",
-    `Where is the text alternative of the \`<audio>\` element?`,
-    target
+    target,
+    `Where is the text alternative of the \`<audio>\` element?`
   );
 
   const label = Question.of(
-    "node",
     "label",
-    `Where is the text that labels the \`<audio>\` element as a video alternative?`,
-    target
+    target,
+    `Where is the text that labels the \`<audio>\` element as a video alternative?`
   );
 
   return mediaTextAlternative(alt, label, device, "<video>");
@@ -67,17 +65,15 @@ export function audioTextAlternative(target: Element, device: Device) {
 
 export function videoTextAlternative(target: Element, device: Device) {
   const alt = Question.of(
-    "node",
     "text-alternative",
-    `Where is the text alternative of the \`<video>\` element?`,
-    target
+    target,
+    `Where is the text alternative of the \`<video>\` element?`
   );
 
   const label = Question.of(
-    "node",
     "label",
-    `Where is the text that labels the \`<video>\` element as a video alternative?`,
-    target
+    target,
+    `Where is the text that labels the \`<video>\` element as a video alternative?`
   );
 
   return mediaTextAlternative(alt, label, device, "<video>");

--- a/packages/alfa-rules/src/common/expectation/video-description-track-accurate.ts
+++ b/packages/alfa-rules/src/common/expectation/video-description-track-accurate.ts
@@ -8,14 +8,7 @@ import { expectation } from "../expectation";
 
 export function videoDescriptionTrackAccurate(target: Element) {
   return {
-    1: Question.of(
-      "boolean",
-      "track-describes-video",
-      `Does at least 1 track describe the visual information of the \`<video>\`
-      element, either in the language of the \`<video>\` element or the language
-      of the page?`,
-      target
-    ).map((trackDescribesVideo) =>
+    1: Question.of("track-describes-video", target).map((trackDescribesVideo) =>
       expectation(
         trackDescribesVideo,
         () => Outcomes.HasDescriptionTrack,

--- a/packages/alfa-rules/src/common/question.ts
+++ b/packages/alfa-rules/src/common/question.ts
@@ -28,12 +28,10 @@ export namespace Question {
     [K in Uri]: [Data[K]["type"], Type[Data[K]["type"]]];
   };
 
-  /**
-   * Since Data is declared `as const`, `typeof Data` is a readonly type with the
-   * actual keys as string literal types (rather than the generic string).
-   * The intersection with the generic Record ensures that if Data is not
-   * correctly filled, Question.of won't properly type.
-   */
+  // Since Data is declared `as const`, `typeof Data` is a readonly type with the
+  // actual keys as string literal types (rather than the generic string).
+  // The intersection with the generic Record ensures that if Data is not
+  // correctly filled, Question.of won't properly type.
   type Data = typeof Data &
     Record<
       Uri,
@@ -43,9 +41,10 @@ export namespace Question {
       }
     >;
 
-  /**
-   * The list of all registered URIs.
-   */
+  // The list of all registered URIs.
+  // It is needed to have it as a separate type to break circularity in building
+  // the type Data; but it shouldn't be exported and `keyof Metadata` should be
+  // preferred, to keep `Metadata` as the only source of question knowledge.
   type Uri = keyof typeof Data;
 
   export function of<S, U extends Uri = Uri>(

--- a/packages/alfa-rules/src/common/question.ts
+++ b/packages/alfa-rules/src/common/question.ts
@@ -20,53 +20,59 @@ export interface Question {
  * @public
  */
 export namespace Question {
-  export function of<S, U extends URI = URI>(
+  export function of<S, U extends Uri = Uri>(
     uri: U,
-    message: string,
-    subject: S
+    subject: S,
+    message?: string
   ): act.Question<
-    DATA[U]["type"],
+    Data[U]["type"],
     S,
     S,
-    Question[DATA[U]["type"]],
-    Question[DATA[U]["type"]],
+    Question[Data[U]["type"]],
+    Question[Data[U]["type"]],
     U
   >;
 
-  export function of<S, C, U extends URI = URI>(
+  export function of<S, C, U extends Uri = Uri>(
     uri: U,
-    message: string,
     subject: S,
-    context: C
+    context: C,
+    message?: string
   ): act.Question<
-    DATA[U]["type"],
+    Data[U]["type"],
     S,
     C,
-    Question[DATA[U]["type"]],
-    Question[DATA[U]["type"]],
+    Question[Data[U]["type"]],
+    Question[Data[U]["type"]],
     U
   >;
 
-  export function of<S, U extends URI = URI>(
+  export function of<S, U extends Uri = Uri>(
     uri: U,
-    message: string,
     subject: S,
-    context: S = subject
+    contextOrMessage?: S | string,
+    message?: string
   ): act.Question<
-    DATA[U]["type"],
+    Data[U]["type"],
     S,
     S,
-    Question[DATA[U]["type"]],
-    Question[DATA[U]["type"]],
+    Question[Data[U]["type"]],
+    Question[Data[U]["type"]],
     U
   > {
-    return act.Question.of(
-      QuestionData[uri].type,
-      uri,
-      message,
-      subject,
-      context
-    );
+    let context: S = subject;
+    if (
+      // We assume that no context will be a string.
+      // Since contexts are guaranteed to be test targets, this is OK. They are
+      // more likely to be text nodes that the actual text in it.
+      typeof contextOrMessage === "string"
+    ) {
+      message = contextOrMessage;
+    } else {
+      context = contextOrMessage ?? subject;
+      message = message ?? Data[uri].message;
+    }
+    return act.Question.of(Data[uri].type, uri, message, subject, context);
   }
 
   type QuestionInfo = {
@@ -76,14 +82,170 @@ export namespace Question {
 
   // If a question data is poorly filled, the intersection reduces to never
   // and `of` doesn't type correctly.
-  type DATA = typeof QuestionData & Record<URI, QuestionInfo>;
+  export type Data = typeof Data & Record<Uri, QuestionInfo>;
 
-  type URI = "first-tabbable-reference-is-main";
+  export type Uri = keyof typeof Data;
 
-  const QuestionData = {
+  const Data = {
+    // R15, R41, R81
+    "reference-equivalent-resources": {
+      type: "boolean",
+      message: `Do the [links/iframe] [resolve to/reference] equivalent resources?`,
+    },
+    // media rules (R27 [R22, R31], R30 [R23, R29], R35 [R26, R32, R33, R34],
+    //              R37 [R25, R31, R36], R38 [R24, R25, R31, R36], R50 [R48, R49])
+    "has-audio": {
+      type: "boolean",
+      message: `Does the \`<video>\` element have audio?`,
+    },
+    "has-audio-track": {
+      type: "boolean",
+      message: `Does the \`<video>\` element have an audio track that describes its
+            visual information?`,
+    },
+    "has-captions": {
+      type: "boolean",
+      message: `Does the \`<video>\` element have captions?`,
+    },
+    "has-description": {
+      type: "boolean",
+      message: `Is the visual information of the [audio/video] available through its
+            audio or a separate audio description track?`,
+    },
+    "is-audio-streaming": {
+      type: "boolean",
+      message: `Is the \`<audio>\` element streaming?`,
+    },
+    "is-playing": {
+      type: "boolean",
+      message: `Is the \`<audio>\` element currently playing?`,
+    },
+    "is-video-streaming": {
+      type: "boolean",
+      message: `Is the \`<video>\` element streaming?`,
+    },
+    label: {
+      type: "node",
+      message: `Where is the text that labels the [audio/video] element as a video alternative?`,
+    },
+    "play-button": {
+      type: "node",
+      message: `Where is the button that controls playback of the \`<audio>\`
+                    element?`,
+    },
+    "text-alternative": {
+      type: "node",
+      message: `Where is the text alternative of the [audio/video] element?`,
+    },
+    "track-describes-video": {
+      type: "boolean",
+      message: `Does at least 1 track describe the visual information of the \`<video>\`
+      element, either in the language of the \`<video>\` element or the language
+      of the page?`,
+    },
+    transcript: {
+      type: "node",
+      message: `Where is the transcript of the [audio/video] element?`,
+    },
+    "transcript-link": {
+      type: "node",
+      message: `Where is the link pointing to the transcript of the [audio/video]
+                  element?`,
+    },
+    "transcript-perceivable": {
+      type: "boolean",
+      message: `Is the transcript of the [audio/video] element perceivable?`,
+    },
+    // R39
+    "name-describes-purpose": {
+      type: "boolean",
+      message: `Does the accessible name of the \`<(target.name]>\` element
+            describe its purpose?`,
+    },
+    // R50 [R48, R49]
+    "audio-control-mechanism": {
+      type: "node",
+      message: `Where is the mechanism that can pause or stop the audio of the
+            \`<[target.name]>\` element?`,
+    },
+    "is-above-duration-threshold": {
+      type: "boolean",
+      message: `Does the \`<[element.name]>\` element have a duration of more
+              than 3 seconds?`,
+    },
+    "is-below-audio-duration-threshold": {
+      type: "boolean",
+      message: `Does the \`<[target.name]>\` element have a total audio duration
+            of less than 3 seconds?`,
+    },
+    // R55
+    "is-content-equivalent": {
+      type: "boolean",
+      message: `Do these [role] landmarks have the same or equivalent content?`,
+    },
+    // R65
+    "has-focus-indicator": {
+      type: "boolean",
+      message: `Does the element have a visible focus indicator?`,
+    },
+    // R66, R69
+    "background-colors": {
+      type: "color[]",
+      message: "What are the background colors of the text node?",
+    },
+    "foreground-colors": {
+      type: "color[]",
+      message: "What are the foreground colors of the text node?",
+    },
+    // R87
+    "first-tabbable-is-internal-link": {
+      type: "boolean",
+      message: `Is the first tabbable element of the document an internal link?`,
+    },
+    "first-tabbable-is-visible": {
+      type: "boolean",
+      message: `Is the first tabbable element of the document visible if it's focused?`,
+    },
+    "first-tabbable-reference": {
+      type: "node",
+      message: `Where in the document does the first tabbable element point?`,
+    },
     "first-tabbable-reference-is-main": {
       type: "boolean",
       message: `Does the first tabbable element of the document point to the main content?`,
+    },
+    // R82 (experimental)
+    "error-indicators": {
+      type: "node[]",
+      message: `Where are the error indicators, if any, for the form field?`,
+    },
+    "error-indicator-describes-resolution": {
+      type: "boolean",
+      message: `Does the error indicator describe, in text, the cause of the error or how
+      to resolve it?`,
+    },
+    "error-indicator-identifies-form-field": {
+      type: "boolean",
+      message:
+        "Does the error indicator identify, in text, the form field it relates to?",
+    },
+    // ER87 (experimental)
+    "internal-reference": {
+      type: "node",
+      message: `Where in the document does this element point?`,
+    },
+    "is-start-of-main": {
+      type: "boolean",
+      message: `Is this element at the start of the main content of the document?`,
+    },
+    "is-visible-when-focused": {
+      type: "boolean",
+      message: `Is this element visible when it's focused?`,
+    },
+    // R109 (experimental)
+    "document-language": {
+      type: "string",
+      message: "What is the main language of the document?",
     },
   } as const;
 }

--- a/packages/alfa-rules/src/common/question.ts
+++ b/packages/alfa-rules/src/common/question.ts
@@ -9,14 +9,12 @@ import * as act from "@siteimprove/alfa-act";
  */
 export namespace Question {
   /**
-   * @public
    * Maps the `type` parameter of questions to the expected type of the answer.
    */
-  export interface Type {
+  interface Type {
     boolean: boolean;
     node: Option<Node>;
     "node[]": Iterable<Node>;
-    color: Option<RGB>;
     "color[]": Iterable<RGB>;
     string: string;
   }
@@ -49,16 +47,6 @@ export namespace Question {
    * The list of all registered URIs.
    */
   type Uri = keyof typeof Data;
-
-  // function foo<U extends Uri = Uri>(
-  //   uri: U,
-  //   type: Metadata[U][0],
-  //   answer: Metadata[U][1]
-  // ): void {}
-  //
-  // foo("has-audio", "boolean", true);
-  // foo("has-audio", "boolean", "true");
-  // foo("has-audio", "node", "true");
 
   export function of<S, U extends Uri = Uri>(
     uri: U,

--- a/packages/alfa-rules/src/common/question.ts
+++ b/packages/alfa-rules/src/common/question.ts
@@ -20,28 +20,70 @@ export interface Question {
  * @public
  */
 export namespace Question {
-  export function of<Q extends keyof Question, S, U extends string = string>(
-    type: Q,
+  export function of<S, U extends URI = URI>(
     uri: U,
     message: string,
     subject: S
-  ): act.Question<Q, S, S, Question[Q], Question[Q], U>;
+  ): act.Question<
+    DATA[U]["type"],
+    S,
+    S,
+    Question[DATA[U]["type"]],
+    Question[DATA[U]["type"]],
+    U
+  >;
 
-  export function of<Q extends keyof Question, S, C, U extends string = string>(
-    type: Q,
+  export function of<S, C, U extends URI = URI>(
     uri: U,
     message: string,
     subject: S,
     context: C
-  ): act.Question<Q, S, C, Question[Q], Question[Q], U>;
+  ): act.Question<
+    DATA[U]["type"],
+    S,
+    C,
+    Question[DATA[U]["type"]],
+    Question[DATA[U]["type"]],
+    U
+  >;
 
-  export function of<Q extends keyof Question, S, U extends string = string>(
-    type: Q,
+  export function of<S, U extends URI = URI>(
     uri: U,
     message: string,
     subject: S,
     context: S = subject
-  ): act.Question<Q, S, S, Question[Q], Question[Q], U> {
-    return act.Question.of(type, uri, message, subject, context);
+  ): act.Question<
+    DATA[U]["type"],
+    S,
+    S,
+    Question[DATA[U]["type"]],
+    Question[DATA[U]["type"]],
+    U
+  > {
+    return act.Question.of(
+      QuestionData[uri].type,
+      uri,
+      message,
+      subject,
+      context
+    );
   }
+
+  type QuestionInfo = {
+    readonly type: keyof Question;
+    readonly message: string;
+  };
+
+  // If a question data is poorly filled, the intersection reduces to never
+  // and `of` doesn't type correctly.
+  type DATA = typeof QuestionData & Record<URI, QuestionInfo>;
+
+  type URI = "first-tabbable-reference-is-main";
+
+  const QuestionData = {
+    "first-tabbable-reference-is-main": {
+      type: "boolean",
+      message: `Does the first tabbable element of the document point to the main content?`,
+    },
+  } as const;
 }

--- a/packages/alfa-rules/src/common/question.ts
+++ b/packages/alfa-rules/src/common/question.ts
@@ -112,6 +112,7 @@ export namespace Question {
     // media rules (R27 [R22, R31], R30 [R23, R29], R35 [R26, R32, R33, R34],
     //              R37 [R25, R31, R36], R38 [R24, R25, R31, R36], R50 [R48, R49])
     "has-audio": {
+      // Also used in R50 [R48, R49]
       type: "boolean",
       message: `Does the \`<video>\` element have audio?`,
     },

--- a/packages/alfa-rules/src/common/question.ts
+++ b/packages/alfa-rules/src/common/question.ts
@@ -7,19 +7,33 @@ import * as act from "@siteimprove/alfa-act";
 /**
  * @public
  */
-export interface Question {
-  boolean: boolean;
-  node: Option<Node>;
-  "node[]": Iterable<Node>;
-  color: Option<RGB>;
-  "color[]": Iterable<RGB>;
-  string: string;
-}
-
-/**
- * @public
- */
 export namespace Question {
+  /**
+   * @public
+   * Maps the `type` parameter of question to the expected type of the answer.
+   */
+  export interface Type {
+    boolean: boolean;
+    node: Option<Node>;
+    "node[]": Iterable<Node>;
+    color: Option<RGB>;
+    "color[]": Iterable<RGB>;
+    string: string;
+  }
+
+  // If a question data is poorly filled, the intersection reduces to never
+  // and `of` doesn't type correctly.
+  type Data = typeof Data &
+    Record<
+      Uri,
+      {
+        readonly type: keyof Type;
+        readonly message: string;
+      }
+    >;
+
+  type Uri = keyof typeof Data;
+
   export function of<S, U extends Uri = Uri>(
     uri: U,
     subject: S,
@@ -28,8 +42,8 @@ export namespace Question {
     Data[U]["type"],
     S,
     S,
-    Question[Data[U]["type"]],
-    Question[Data[U]["type"]],
+    Type[Data[U]["type"]],
+    Type[Data[U]["type"]],
     U
   >;
 
@@ -42,8 +56,8 @@ export namespace Question {
     Data[U]["type"],
     S,
     C,
-    Question[Data[U]["type"]],
-    Question[Data[U]["type"]],
+    Type[Data[U]["type"]],
+    Type[Data[U]["type"]],
     U
   >;
 
@@ -56,8 +70,8 @@ export namespace Question {
     Data[U]["type"],
     S,
     S,
-    Question[Data[U]["type"]],
-    Question[Data[U]["type"]],
+    Type[Data[U]["type"]],
+    Type[Data[U]["type"]],
     U
   > {
     let context: S = subject;
@@ -74,17 +88,6 @@ export namespace Question {
     }
     return act.Question.of(Data[uri].type, uri, message, subject, context);
   }
-
-  type QuestionInfo = {
-    readonly type: keyof Question;
-    readonly message: string;
-  };
-
-  // If a question data is poorly filled, the intersection reduces to never
-  // and `of` doesn't type correctly.
-  export type Data = typeof Data & Record<Uri, QuestionInfo>;
-
-  export type Uri = keyof typeof Data;
 
   const Data = {
     // R15, R41, R81

--- a/packages/alfa-rules/src/common/question.ts
+++ b/packages/alfa-rules/src/common/question.ts
@@ -10,7 +10,7 @@ import * as act from "@siteimprove/alfa-act";
 export namespace Question {
   /**
    * @public
-   * Maps the `type` parameter of question to the expected type of the answer.
+   * Maps the `type` parameter of questions to the expected type of the answer.
    */
   export interface Type {
     boolean: boolean;
@@ -21,8 +21,21 @@ export namespace Question {
     string: string;
   }
 
-  // If a question data is poorly filled, the intersection reduces to never
-  // and `of` doesn't type correctly.
+  /**
+   * @public
+   * Maps the `uri` parameter of questions to their `type` parameter and the
+   * expected type of answers.
+   */
+  export type Metadata = {
+    [K in Uri]: [Data[K]["type"], Type[Data[K]["type"]]];
+  };
+
+  /**
+   * Since Data is declared `as const`, `typeof Data` is a readonly type with the
+   * actual keys as string literal types (rather than the generic string).
+   * The intersection with the generic Record ensures that if Data is not
+   * correctly filled, Question.of won't properly type.
+   */
   type Data = typeof Data &
     Record<
       Uri,
@@ -32,7 +45,20 @@ export namespace Question {
       }
     >;
 
+  /**
+   * The list of all registered URIs.
+   */
   type Uri = keyof typeof Data;
+
+  // function foo<U extends Uri = Uri>(
+  //   uri: U,
+  //   type: Metadata[U][0],
+  //   answer: Metadata[U][1]
+  // ): void {}
+  //
+  // foo("has-audio", "boolean", true);
+  // foo("has-audio", "boolean", "true");
+  // foo("has-audio", "node", "true");
 
   export function of<S, U extends Uri = Uri>(
     uri: U,

--- a/packages/alfa-rules/src/experimental.ts
+++ b/packages/alfa-rules/src/experimental.ts
@@ -1,3 +1,4 @@
 export { default as ER62 } from "./sia-er62/rule";
 export { default as ER87 } from "./sia-er87/rule";
+export { default as R82 } from "./sia-r82/rule";
 export { default as R109 } from "./sia-r109/rule";

--- a/packages/alfa-rules/src/rules.ts
+++ b/packages/alfa-rules/src/rules.ts
@@ -76,7 +76,6 @@ export { default as R78 } from "./sia-r78/rule";
 export { default as R79 } from "./sia-r79/rule";
 export { default as R80 } from "./sia-r80/rule";
 export { default as R81 } from "./sia-r81/rule";
-export { default as R82 } from "./sia-r82/rule";
 export { default as R83 } from "./sia-r83/rule";
 export { default as R84 } from "./sia-r84/rule";
 export { default as R85 } from "./sia-r85/rule";

--- a/packages/alfa-rules/src/sia-er87/rule.ts
+++ b/packages/alfa-rules/src/sia-er87/rule.ts
@@ -35,7 +35,7 @@ const { and } = Refinement;
  * this needs changes in the Page Report to be able to highlight an element
  * different from the test target.
  */
-export default Rule.Atomic.of<Page, Document, Question, Element>({
+export default Rule.Atomic.of<Page, Document, Question.Type, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r87#experimental",
   requirements: [Technique.of("G1")],
   tags: [Scope.Page, Stability.Experimental],
@@ -62,7 +62,7 @@ export default Rule.Atomic.of<Page, Document, Question, Element>({
         function isAtTheStartOfMain(
           reference: Node
         ): Interview<
-          Question,
+          Question.Type,
           Element,
           Document,
           Option.Maybe<Result<Diagnostic, Diagnostic>>
@@ -98,7 +98,7 @@ export default Rule.Atomic.of<Page, Document, Question, Element>({
         }
 
         function isSkipLink(): Interview<
-          Question,
+          Question.Type,
           Element,
           Document,
           Option.Maybe<Result<Diagnostic>>

--- a/packages/alfa-rules/src/sia-er87/rule.ts
+++ b/packages/alfa-rules/src/sia-er87/rule.ts
@@ -33,7 +33,7 @@ const { and } = Refinement;
  * destination once it's been identified as a link).
  * This needs changes in Dory, Nemo, and likely databases to be stored;
  * this needs changes in the Page Report to be able to highlight an element
- * different than the test target.
+ * different from the test target.
  */
 export default Rule.Atomic.of<Page, Document, Question, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r87#experimental",
@@ -77,9 +77,7 @@ export default Rule.Atomic.of<Page, Document, Question, Element>({
           }
 
           const askIsMain = Question.of(
-            "boolean",
             "is-start-of-main",
-            `Is this element at the start of the main content of the document?`,
             destination.get(),
             target
           );
@@ -106,9 +104,7 @@ export default Rule.Atomic.of<Page, Document, Question, Element>({
           Option.Maybe<Result<Diagnostic>>
         > {
           const askReference = Question.of(
-            "node",
             "internal-reference",
-            `Where in the document does this element point?`,
             element,
             target
           );
@@ -149,9 +145,7 @@ export default Rule.Atomic.of<Page, Document, Question, Element>({
         }
 
         const askIsVisible = Question.of(
-          "boolean",
           "is-visible-when-focused",
-          `Is this element visible when it's focused?`,
           element,
           target
         );

--- a/packages/alfa-rules/src/sia-er87/rule.ts
+++ b/packages/alfa-rules/src/sia-er87/rule.ts
@@ -35,7 +35,7 @@ const { and } = Refinement;
  * this needs changes in the Page Report to be able to highlight an element
  * different from the test target.
  */
-export default Rule.Atomic.of<Page, Document, Question.Type, Element>({
+export default Rule.Atomic.of<Page, Document, Question.Metadata, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r87#experimental",
   requirements: [Technique.of("G1")],
   tags: [Scope.Page, Stability.Experimental],
@@ -62,7 +62,7 @@ export default Rule.Atomic.of<Page, Document, Question.Type, Element>({
         function isAtTheStartOfMain(
           reference: Node
         ): Interview<
-          Question.Type,
+          Question.Metadata,
           Element,
           Document,
           Option.Maybe<Result<Diagnostic, Diagnostic>>
@@ -98,7 +98,7 @@ export default Rule.Atomic.of<Page, Document, Question.Type, Element>({
         }
 
         function isSkipLink(): Interview<
-          Question.Type,
+          Question.Metadata,
           Element,
           Document,
           Option.Maybe<Result<Diagnostic>>

--- a/packages/alfa-rules/src/sia-r109/rule.ts
+++ b/packages/alfa-rules/src/sia-r109/rule.ts
@@ -21,7 +21,7 @@ const { and } = Refinement;
  * the `lang` attribute. This is not a nice experience for the end user and
  * shouldn't be used until backend can automatically determine the answer.
  */
-export default Rule.Atomic.of<Page, Document, Question.Type>({
+export default Rule.Atomic.of<Page, Document, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r109",
   requirements: [Criterion.of("3.1.1"), Technique.of("H57")],
   tags: [Scope.Page, Stability.Experimental],

--- a/packages/alfa-rules/src/sia-r109/rule.ts
+++ b/packages/alfa-rules/src/sia-r109/rule.ts
@@ -21,7 +21,7 @@ const { and } = Refinement;
  * the `lang` attribute. This is not a nice experience for the end user and
  * shouldn't be used until backend can automatically determine the answer.
  */
-export default Rule.Atomic.of<Page, Document, Question>({
+export default Rule.Atomic.of<Page, Document, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r109",
   requirements: [Criterion.of("3.1.1"), Technique.of("H57")],
   tags: [Scope.Page, Stability.Experimental],

--- a/packages/alfa-rules/src/sia-r109/rule.ts
+++ b/packages/alfa-rules/src/sia-r109/rule.ts
@@ -51,12 +51,7 @@ export default Rule.Atomic.of<Page, Document, Question>({
 
       expectations(target) {
         return {
-          1: Question.of(
-            "string",
-            "document-language",
-            "What is the main language of the document?",
-            target
-          ).map((language) =>
+          1: Question.of("document-language", target).map((language) =>
             Language.parse(language).mapOrElse(
               (naturalLanguage) =>
                 expectation(

--- a/packages/alfa-rules/src/sia-r15/rule.ts
+++ b/packages/alfa-rules/src/sia-r15/rule.ts
@@ -22,7 +22,7 @@ import { Question } from "../common/question";
 const { isElement, hasName, hasNamespace } = Element;
 const { and, not } = Predicate;
 
-export default Rule.Atomic.of<Page, Group<Element>, Question.Type>({
+export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r15",
   requirements: [Criterion.of("4.1.2")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r15/rule.ts
+++ b/packages/alfa-rules/src/sia-r15/rule.ts
@@ -64,10 +64,9 @@ export default Rule.Atomic.of<Page, Group<Element>, Question>({
             () => Outcomes.EmbedSameResources,
             () =>
               Question.of(
-                "boolean",
                 "reference-equivalent-resources",
-                "Do the <iframe> elements embed equivalent resources?",
-                target
+                target,
+                "Do the <iframe> elements embed equivalent resources?"
               ).map((embedEquivalentResources) =>
                 expectation(
                   embedEquivalentResources,

--- a/packages/alfa-rules/src/sia-r15/rule.ts
+++ b/packages/alfa-rules/src/sia-r15/rule.ts
@@ -22,7 +22,7 @@ import { Question } from "../common/question";
 const { isElement, hasName, hasNamespace } = Element;
 const { and, not } = Predicate;
 
-export default Rule.Atomic.of<Page, Group<Element>, Question>({
+export default Rule.Atomic.of<Page, Group<Element>, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r15",
   requirements: [Criterion.of("4.1.2")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r22/rule.ts
+++ b/packages/alfa-rules/src/sia-r22/rule.ts
@@ -11,7 +11,7 @@ import { expectation } from "../common/expectation";
 import { Question } from "../common/question";
 import { Scope } from "../tags";
 
-export default Rule.Atomic.of<Page, Element, Question.Type>({
+export default Rule.Atomic.of<Page, Element, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r22",
   requirements: [Technique.of("G87"), Technique.of("G93"), Technique.of("H95")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r22/rule.ts
+++ b/packages/alfa-rules/src/sia-r22/rule.ts
@@ -11,7 +11,7 @@ import { expectation } from "../common/expectation";
 import { Question } from "../common/question";
 import { Scope } from "../tags";
 
-export default Rule.Atomic.of<Page, Element, Question>({
+export default Rule.Atomic.of<Page, Element, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r22",
   requirements: [Technique.of("G87"), Technique.of("G93"), Technique.of("H95")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r22/rule.ts
+++ b/packages/alfa-rules/src/sia-r22/rule.ts
@@ -23,12 +23,7 @@ export default Rule.Atomic.of<Page, Element, Question>({
 
       expectations(target) {
         return {
-          1: Question.of(
-            "boolean",
-            "has-captions",
-            `Does the \`<video>\` element have captions?`,
-            target
-          ).map((hasCaptions) =>
+          1: Question.of("has-captions", target).map((hasCaptions) =>
             expectation(
               hasCaptions,
               () => Outcomes.HasCaptions,

--- a/packages/alfa-rules/src/sia-r23/rule.ts
+++ b/packages/alfa-rules/src/sia-r23/rule.ts
@@ -28,18 +28,16 @@ export default Rule.Atomic.of<Page, Element, Question>({
       expectations(target) {
         return {
           1: Question.of(
-            "node",
             "transcript",
-            `Where is the transcript of the \`<audio>\` element?`,
-            target
+            target,
+            `Where is the transcript of the \`<audio>\` element?`
           ).map((transcript) => {
             if (transcript.isNone()) {
               return Question.of(
-                "node",
                 "transcript-link",
+                target,
                 `Where is the link pointing to the transcript of the \`<audio>\`
-                element?`,
-                target
+                element?`
               ).map((transcriptLink) => {
                 if (transcriptLink.isNone()) {
                   return Option.of(Outcomes.HasNoTranscript);
@@ -54,10 +52,9 @@ export default Rule.Atomic.of<Page, Element, Question>({
                 }
 
                 return Question.of(
-                  "boolean",
                   "transcript-perceivable",
-                  `Is the transcript of the \`<audio>\` element perceivable?`,
-                  target
+                  target,
+                  `Is the transcript of the \`<audio>\` element perceivable?`
                 ).map((isPerceivable) =>
                   expectation(
                     isPerceivable,

--- a/packages/alfa-rules/src/sia-r23/rule.ts
+++ b/packages/alfa-rules/src/sia-r23/rule.ts
@@ -16,7 +16,7 @@ import { Scope } from "../tags";
 
 const { and } = Predicate;
 
-export default Rule.Atomic.of<Page, Element, Question.Type>({
+export default Rule.Atomic.of<Page, Element, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r23",
   tags: [Scope.Component],
   evaluate({ document, device }) {

--- a/packages/alfa-rules/src/sia-r23/rule.ts
+++ b/packages/alfa-rules/src/sia-r23/rule.ts
@@ -16,7 +16,7 @@ import { Scope } from "../tags";
 
 const { and } = Predicate;
 
-export default Rule.Atomic.of<Page, Element, Question>({
+export default Rule.Atomic.of<Page, Element, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r23",
   tags: [Scope.Component],
   evaluate({ document, device }) {

--- a/packages/alfa-rules/src/sia-r24/rule.ts
+++ b/packages/alfa-rules/src/sia-r24/rule.ts
@@ -24,21 +24,19 @@ export default Rule.Atomic.of<Page, Element, Question>({
       expectations(target) {
         return {
           1: Question.of(
-            "node",
             "transcript",
-            `Where is the transcript of the \`<video>\` element?`,
-            target
+            target,
+            `Where is the transcript of the \`<video>\` element?`
           ).map((transcript) =>
             expectation(
               transcript.isSome(),
               () => Outcomes.HasTranscript,
               () =>
                 Question.of(
-                  "node",
                   "transcript-link",
+                  target,
                   `Where is the link pointing to the transcript of the \`<video>\`
-                  element?`,
-                  target
+                  element?`
                 ).map((transcriptLink) =>
                   expectation(
                     transcriptLink.isSome(),

--- a/packages/alfa-rules/src/sia-r24/rule.ts
+++ b/packages/alfa-rules/src/sia-r24/rule.ts
@@ -11,7 +11,7 @@ import { expectation } from "../common/expectation";
 import { Question } from "../common/question";
 import { Scope } from "../tags";
 
-export default Rule.Atomic.of<Page, Element, Question.Type>({
+export default Rule.Atomic.of<Page, Element, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r24",
   requirements: [Criterion.of("1.2.8"), Technique.of("G69")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r24/rule.ts
+++ b/packages/alfa-rules/src/sia-r24/rule.ts
@@ -11,7 +11,7 @@ import { expectation } from "../common/expectation";
 import { Question } from "../common/question";
 import { Scope } from "../tags";
 
-export default Rule.Atomic.of<Page, Element, Question>({
+export default Rule.Atomic.of<Page, Element, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r24",
   requirements: [Criterion.of("1.2.8"), Technique.of("G69")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r25/rule.ts
+++ b/packages/alfa-rules/src/sia-r25/rule.ts
@@ -11,7 +11,7 @@ import { expectation } from "../common/expectation";
 import { Question } from "../common/question";
 import { Scope } from "../tags";
 
-export default Rule.Atomic.of<Page, Element, Question>({
+export default Rule.Atomic.of<Page, Element, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r25",
   requirements: [Technique.of("G8"), Technique.of("G78"), Technique.of("G173")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r25/rule.ts
+++ b/packages/alfa-rules/src/sia-r25/rule.ts
@@ -24,11 +24,10 @@ export default Rule.Atomic.of<Page, Element, Question>({
       expectations(target) {
         return {
           1: Question.of(
-            "boolean",
             "has-description",
+            target,
             `Is the visual information of the \`<video>\` available through its
-            audio or a separate audio description track?`,
-            target
+            audio or a separate audio description track?`
           ).map((hasAudio) =>
             expectation(
               hasAudio,

--- a/packages/alfa-rules/src/sia-r25/rule.ts
+++ b/packages/alfa-rules/src/sia-r25/rule.ts
@@ -11,7 +11,7 @@ import { expectation } from "../common/expectation";
 import { Question } from "../common/question";
 import { Scope } from "../tags";
 
-export default Rule.Atomic.of<Page, Element, Question.Type>({
+export default Rule.Atomic.of<Page, Element, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r25",
   requirements: [Technique.of("G8"), Technique.of("G78"), Technique.of("G173")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r26/rule.ts
+++ b/packages/alfa-rules/src/sia-r26/rule.ts
@@ -9,7 +9,7 @@ import { videoTextAlternative } from "../common/expectation/media-text-alternati
 import { Question } from "../common/question";
 import { Scope } from "../tags";
 
-export default Rule.Atomic.of<Page, Element, Question.Type>({
+export default Rule.Atomic.of<Page, Element, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r26",
   tags: [Scope.Component],
   evaluate({ device, document }) {

--- a/packages/alfa-rules/src/sia-r26/rule.ts
+++ b/packages/alfa-rules/src/sia-r26/rule.ts
@@ -9,7 +9,7 @@ import { videoTextAlternative } from "../common/expectation/media-text-alternati
 import { Question } from "../common/question";
 import { Scope } from "../tags";
 
-export default Rule.Atomic.of<Page, Element, Question>({
+export default Rule.Atomic.of<Page, Element, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r26",
   tags: [Scope.Component],
   evaluate({ device, document }) {

--- a/packages/alfa-rules/src/sia-r27/rule.ts
+++ b/packages/alfa-rules/src/sia-r27/rule.ts
@@ -14,7 +14,7 @@ import R22 from "../sia-r22/rule";
 import R31 from "../sia-r31/rule";
 import { Scope } from "../tags";
 
-export default Rule.Composite.of<Page, Element, Question.Type>({
+export default Rule.Composite.of<Page, Element, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r27",
   requirements: [
     Criterion.of("1.2.2"),

--- a/packages/alfa-rules/src/sia-r27/rule.ts
+++ b/packages/alfa-rules/src/sia-r27/rule.ts
@@ -14,7 +14,7 @@ import R22 from "../sia-r22/rule";
 import R31 from "../sia-r31/rule";
 import { Scope } from "../tags";
 
-export default Rule.Composite.of<Page, Element, Question>({
+export default Rule.Composite.of<Page, Element, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r27",
   requirements: [
     Criterion.of("1.2.2"),

--- a/packages/alfa-rules/src/sia-r29/rule.ts
+++ b/packages/alfa-rules/src/sia-r29/rule.ts
@@ -9,7 +9,7 @@ import { audioTextAlternative } from "../common/expectation/media-text-alternati
 import { Question } from "../common/question";
 import { Scope } from "../tags";
 
-export default Rule.Atomic.of<Page, Element, Question>({
+export default Rule.Atomic.of<Page, Element, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r29",
   tags: [Scope.Component],
   evaluate({ device, document }) {

--- a/packages/alfa-rules/src/sia-r29/rule.ts
+++ b/packages/alfa-rules/src/sia-r29/rule.ts
@@ -9,7 +9,7 @@ import { audioTextAlternative } from "../common/expectation/media-text-alternati
 import { Question } from "../common/question";
 import { Scope } from "../tags";
 
-export default Rule.Atomic.of<Page, Element, Question.Type>({
+export default Rule.Atomic.of<Page, Element, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r29",
   tags: [Scope.Component],
   evaluate({ device, document }) {

--- a/packages/alfa-rules/src/sia-r30/rule.ts
+++ b/packages/alfa-rules/src/sia-r30/rule.ts
@@ -14,7 +14,7 @@ import R23 from "../sia-r23/rule";
 import R29 from "../sia-r29/rule";
 import { Scope } from "../tags";
 
-export default Rule.Composite.of<Page, Element, Question.Type>({
+export default Rule.Composite.of<Page, Element, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r30",
   requirements: [Criterion.of("1.2.1"), Technique.of("G158")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r30/rule.ts
+++ b/packages/alfa-rules/src/sia-r30/rule.ts
@@ -14,7 +14,7 @@ import R23 from "../sia-r23/rule";
 import R29 from "../sia-r29/rule";
 import { Scope } from "../tags";
 
-export default Rule.Composite.of<Page, Element, Question>({
+export default Rule.Composite.of<Page, Element, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r30",
   requirements: [Criterion.of("1.2.1"), Technique.of("G158")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r31/rule.ts
+++ b/packages/alfa-rules/src/sia-r31/rule.ts
@@ -9,7 +9,7 @@ import { videoTextAlternative } from "../common/expectation/media-text-alternati
 import { Question } from "../common/question";
 import { Scope } from "../tags";
 
-export default Rule.Atomic.of<Page, Element, Question>({
+export default Rule.Atomic.of<Page, Element, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r31",
   tags: [Scope.Component],
   evaluate({ device, document }) {

--- a/packages/alfa-rules/src/sia-r31/rule.ts
+++ b/packages/alfa-rules/src/sia-r31/rule.ts
@@ -9,7 +9,7 @@ import { videoTextAlternative } from "../common/expectation/media-text-alternati
 import { Question } from "../common/question";
 import { Scope } from "../tags";
 
-export default Rule.Atomic.of<Page, Element, Question.Type>({
+export default Rule.Atomic.of<Page, Element, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r31",
   tags: [Scope.Component],
   evaluate({ device, document }) {

--- a/packages/alfa-rules/src/sia-r32/rule.ts
+++ b/packages/alfa-rules/src/sia-r32/rule.ts
@@ -11,7 +11,7 @@ import { expectation } from "../common/expectation";
 import { Question } from "../common/question";
 import { Scope } from "../tags";
 
-export default Rule.Atomic.of<Page, Element, Question>({
+export default Rule.Atomic.of<Page, Element, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r32",
   requirements: [Technique.of("G166")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r32/rule.ts
+++ b/packages/alfa-rules/src/sia-r32/rule.ts
@@ -11,7 +11,7 @@ import { expectation } from "../common/expectation";
 import { Question } from "../common/question";
 import { Scope } from "../tags";
 
-export default Rule.Atomic.of<Page, Element, Question.Type>({
+export default Rule.Atomic.of<Page, Element, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r32",
   requirements: [Technique.of("G166")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r32/rule.ts
+++ b/packages/alfa-rules/src/sia-r32/rule.ts
@@ -23,13 +23,7 @@ export default Rule.Atomic.of<Page, Element, Question>({
 
       expectations(target) {
         return {
-          1: Question.of(
-            "boolean",
-            "has-audio-track",
-            `Does the \`<video>\` element have an audio track that describes its
-            visual information?`,
-            target
-          ).map((hasAudioTrack) =>
+          1: Question.of("has-audio-track", target).map((hasAudioTrack) =>
             expectation(
               hasAudioTrack,
               () => Outcomes.HasDescriptiveAudio,

--- a/packages/alfa-rules/src/sia-r33/rule.ts
+++ b/packages/alfa-rules/src/sia-r33/rule.ts
@@ -24,20 +24,18 @@ export default Rule.Atomic.of<Page, Element, Question>({
       expectations(target) {
         return {
           1: Question.of(
-            "node",
             "transcript",
-            `Where is the transcript of the \`<video>\` element?`,
-            target
+            target,
+            `Where is the transcript of the \`<video>\` element?`
           ).map((transcript) =>
             expectation(
               transcript.isSome(),
               () => Outcomes.HasTranscript,
               () =>
                 Question.of(
-                  "node",
                   "transcript-link",
-                  `Where is the link pointing to the transcript of the \`<video>\` element?`,
-                  target
+                  target,
+                  `Where is the link pointing to the transcript of the \`<video>\` element?`
                 ).map((transcriptLink) =>
                   expectation(
                     transcriptLink.isSome(),

--- a/packages/alfa-rules/src/sia-r33/rule.ts
+++ b/packages/alfa-rules/src/sia-r33/rule.ts
@@ -11,7 +11,7 @@ import { expectation } from "../common/expectation";
 import { Question } from "../common/question";
 import { Scope } from "../tags";
 
-export default Rule.Atomic.of<Page, Element, Question>({
+export default Rule.Atomic.of<Page, Element, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r33",
   requirements: [Technique.of("G159")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r33/rule.ts
+++ b/packages/alfa-rules/src/sia-r33/rule.ts
@@ -11,7 +11,7 @@ import { expectation } from "../common/expectation";
 import { Question } from "../common/question";
 import { Scope } from "../tags";
 
-export default Rule.Atomic.of<Page, Element, Question.Type>({
+export default Rule.Atomic.of<Page, Element, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r33",
   requirements: [Technique.of("G159")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r34/rule.ts
+++ b/packages/alfa-rules/src/sia-r34/rule.ts
@@ -10,7 +10,7 @@ import { videoDescriptionTrackAccurate } from "../common/expectation/video-descr
 import { Question } from "../common/question";
 import { Scope } from "../tags";
 
-export default Rule.Atomic.of<Page, Element, Question.Type>({
+export default Rule.Atomic.of<Page, Element, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r34",
   requirements: [Technique.of("H96")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r34/rule.ts
+++ b/packages/alfa-rules/src/sia-r34/rule.ts
@@ -10,7 +10,7 @@ import { videoDescriptionTrackAccurate } from "../common/expectation/video-descr
 import { Question } from "../common/question";
 import { Scope } from "../tags";
 
-export default Rule.Atomic.of<Page, Element, Question>({
+export default Rule.Atomic.of<Page, Element, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r34",
   requirements: [Technique.of("H96")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r35/rule.ts
+++ b/packages/alfa-rules/src/sia-r35/rule.ts
@@ -16,7 +16,7 @@ import R33 from "../sia-r33/rule";
 import R34 from "../sia-r34/rule";
 import { Scope } from "../tags";
 
-export default Rule.Composite.of<Page, Element, Question.Type>({
+export default Rule.Composite.of<Page, Element, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r35",
   requirements: [
     Criterion.of("1.2.1"),

--- a/packages/alfa-rules/src/sia-r35/rule.ts
+++ b/packages/alfa-rules/src/sia-r35/rule.ts
@@ -16,7 +16,7 @@ import R33 from "../sia-r33/rule";
 import R34 from "../sia-r34/rule";
 import { Scope } from "../tags";
 
-export default Rule.Composite.of<Page, Element, Question>({
+export default Rule.Composite.of<Page, Element, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r35",
   requirements: [
     Criterion.of("1.2.1"),

--- a/packages/alfa-rules/src/sia-r36/rule.ts
+++ b/packages/alfa-rules/src/sia-r36/rule.ts
@@ -10,7 +10,7 @@ import { videoDescriptionTrackAccurate } from "../common/expectation/video-descr
 import { Question } from "../common/question";
 import { Scope } from "../tags";
 
-export default Rule.Atomic.of<Page, Element, Question.Type>({
+export default Rule.Atomic.of<Page, Element, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r36",
   requirements: [Technique.of("G78"), Technique.of("H96")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r36/rule.ts
+++ b/packages/alfa-rules/src/sia-r36/rule.ts
@@ -10,7 +10,7 @@ import { videoDescriptionTrackAccurate } from "../common/expectation/video-descr
 import { Question } from "../common/question";
 import { Scope } from "../tags";
 
-export default Rule.Atomic.of<Page, Element, Question>({
+export default Rule.Atomic.of<Page, Element, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r36",
   requirements: [Technique.of("G78"), Technique.of("H96")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r37/rule.ts
+++ b/packages/alfa-rules/src/sia-r37/rule.ts
@@ -15,7 +15,7 @@ import R31 from "../sia-r31/rule";
 import R36 from "../sia-r36/rule";
 import { Scope } from "../tags";
 
-export default Rule.Composite.of<Page, Element, Question>({
+export default Rule.Composite.of<Page, Element, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r37",
   requirements: [
     Criterion.of("1.2.5"),

--- a/packages/alfa-rules/src/sia-r37/rule.ts
+++ b/packages/alfa-rules/src/sia-r37/rule.ts
@@ -15,7 +15,7 @@ import R31 from "../sia-r31/rule";
 import R36 from "../sia-r36/rule";
 import { Scope } from "../tags";
 
-export default Rule.Composite.of<Page, Element, Question.Type>({
+export default Rule.Composite.of<Page, Element, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r37",
   requirements: [
     Criterion.of("1.2.5"),

--- a/packages/alfa-rules/src/sia-r38/rule.ts
+++ b/packages/alfa-rules/src/sia-r38/rule.ts
@@ -16,7 +16,7 @@ import R31 from "../sia-r31/rule";
 import R36 from "../sia-r36/rule";
 import { Scope } from "../tags";
 
-export default Rule.Composite.of<Page, Element, Question.Type>({
+export default Rule.Composite.of<Page, Element, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r38",
   requirements: [
     Criterion.of("1.2.3"),

--- a/packages/alfa-rules/src/sia-r38/rule.ts
+++ b/packages/alfa-rules/src/sia-r38/rule.ts
@@ -16,7 +16,7 @@ import R31 from "../sia-r31/rule";
 import R36 from "../sia-r36/rule";
 import { Scope } from "../tags";
 
-export default Rule.Composite.of<Page, Element, Question>({
+export default Rule.Composite.of<Page, Element, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r38",
   requirements: [
     Criterion.of("1.2.3"),

--- a/packages/alfa-rules/src/sia-r39/rule.ts
+++ b/packages/alfa-rules/src/sia-r39/rule.ts
@@ -15,7 +15,7 @@ import { Scope } from "../tags";
 const { isElement, hasInputType, hasName, hasNamespace } = Element;
 const { and, or, not, test } = Predicate;
 
-export default Rule.Atomic.of<Page, Element, Question.Type>({
+export default Rule.Atomic.of<Page, Element, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r39",
   requirements: [
     Criterion.of("1.1.1"),

--- a/packages/alfa-rules/src/sia-r39/rule.ts
+++ b/packages/alfa-rules/src/sia-r39/rule.ts
@@ -15,7 +15,7 @@ import { Scope } from "../tags";
 const { isElement, hasInputType, hasName, hasNamespace } = Element;
 const { and, or, not, test } = Predicate;
 
-export default Rule.Atomic.of<Page, Element, Question>({
+export default Rule.Atomic.of<Page, Element, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r39",
   requirements: [
     Criterion.of("1.1.1"),

--- a/packages/alfa-rules/src/sia-r39/rule.ts
+++ b/packages/alfa-rules/src/sia-r39/rule.ts
@@ -54,11 +54,10 @@ export default Rule.Atomic.of<Page, Element, Question>({
       expectations(target) {
         return {
           1: Question.of(
-            "boolean",
             "name-describes-purpose",
+            target,
             `Does the accessible name of the \`<${target.name}>\` element
-            describe its purpose?`,
-            target
+            describe its purpose?`
           ).map((nameDescribesPurpose) =>
             expectation(
               nameDescribesPurpose,

--- a/packages/alfa-rules/src/sia-r41/rule.ts
+++ b/packages/alfa-rules/src/sia-r41/rule.ts
@@ -23,7 +23,7 @@ import { Scope } from "../tags";
 const { isElement, hasNamespace } = Element;
 const { and, not } = Predicate;
 
-export default Rule.Atomic.of<Page, Group<Element>, Question>({
+export default Rule.Atomic.of<Page, Group<Element>, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r41",
   requirements: [Criterion.of("2.4.9")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r41/rule.ts
+++ b/packages/alfa-rules/src/sia-r41/rule.ts
@@ -23,7 +23,7 @@ import { Scope } from "../tags";
 const { isElement, hasNamespace } = Element;
 const { and, not } = Predicate;
 
-export default Rule.Atomic.of<Page, Group<Element>, Question.Type>({
+export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r41",
   requirements: [Criterion.of("2.4.9")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r41/rule.ts
+++ b/packages/alfa-rules/src/sia-r41/rule.ts
@@ -71,10 +71,9 @@ export default Rule.Atomic.of<Page, Group<Element>, Question>({
             () => Outcomes.ResolveSameResource,
             () =>
               Question.of(
-                "boolean",
                 "reference-equivalent-resources",
-                `Do the links resolve to equivalent resources?`,
-                target
+                target,
+                `Do the links resolve to equivalent resources?`
               ).map((embedEquivalentResources) =>
                 expectation(
                   embedEquivalentResources,

--- a/packages/alfa-rules/src/sia-r48/rule.ts
+++ b/packages/alfa-rules/src/sia-r48/rule.ts
@@ -42,11 +42,10 @@ export default Rule.Atomic.of<Page, Element, Question>({
           )
           .map((element) => {
             const isAboveDurationThreshold = Question.of(
-              "boolean",
               "is-above-duration-threshold",
+              element,
               `Does the \`<${element.name}>\` element have a duration of more
-              than 3 seconds?`,
-              element
+              than 3 seconds?`
             ).map((isAboveDurationThreshold) =>
               isAboveDurationThreshold ? Option.of(element) : None
             );
@@ -55,10 +54,9 @@ export default Rule.Atomic.of<Page, Element, Question>({
               return isAboveDurationThreshold;
             } else {
               return Question.of(
-                "boolean",
                 "has-audio",
-                `Does the \`<${element.name}>\` element contain audio?`,
-                element
+                element,
+                `Does the \`<${element.name}>\` element contain audio?`
               ).map((hasAudio) => (hasAudio ? isAboveDurationThreshold : None));
             }
           });
@@ -67,11 +65,10 @@ export default Rule.Atomic.of<Page, Element, Question>({
       expectations(target) {
         return {
           1: Question.of(
-            "boolean",
             "is-below-audio-duration-threshold",
+            target,
             `Does the \`<${target.name}>\` element have a total audio duration
-            of less than 3 seconds?`,
-            target
+            of less than 3 seconds?`
           ).map((isBelowAudioDurationThreshold) =>
             expectation(
               isBelowAudioDurationThreshold,

--- a/packages/alfa-rules/src/sia-r48/rule.ts
+++ b/packages/alfa-rules/src/sia-r48/rule.ts
@@ -18,7 +18,7 @@ const { isElement, hasName, hasNamespace } = Element;
 const { or, nor } = Predicate;
 const { and } = Refinement;
 
-export default Rule.Atomic.of<Page, Element, Question>({
+export default Rule.Atomic.of<Page, Element, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r48",
   requirements: [Technique.of("G60")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r48/rule.ts
+++ b/packages/alfa-rules/src/sia-r48/rule.ts
@@ -18,7 +18,7 @@ const { isElement, hasName, hasNamespace } = Element;
 const { or, nor } = Predicate;
 const { and } = Refinement;
 
-export default Rule.Atomic.of<Page, Element, Question.Type>({
+export default Rule.Atomic.of<Page, Element, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r48",
   requirements: [Technique.of("G60")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r49/rule.ts
+++ b/packages/alfa-rules/src/sia-r49/rule.ts
@@ -47,11 +47,10 @@ export default Rule.Atomic.of<Page, Element, Question>({
           )
           .map((element) => {
             const isAboveDurationThreshold = Question.of(
-              "boolean",
               "is-above-duration-threshold",
+              element,
               `Does the \`<${element.name}>\` element have a duration of more
-              than 3 seconds?`,
-              element
+              than 3 seconds?`
             ).map((isAboveDurationThreshold) =>
               isAboveDurationThreshold ? Option.of(element) : None
             );
@@ -60,10 +59,9 @@ export default Rule.Atomic.of<Page, Element, Question>({
               return isAboveDurationThreshold;
             } else {
               return Question.of(
-                "boolean",
                 "has-audio",
-                `Does the \`<${element.name}>\` element contain audio?`,
-                element
+                element,
+                `Does the \`<${element.name}>\` element contain audio?`
               ).map((hasAudio) => (hasAudio ? isAboveDurationThreshold : None));
             }
           });
@@ -72,11 +70,10 @@ export default Rule.Atomic.of<Page, Element, Question>({
       expectations(target) {
         return {
           1: Question.of(
-            "node",
             "audio-control-mechanism",
+            target,
             `Where is the mechanism that can pause or stop the audio of the
-            \`<${target.name}>\` element?`,
-            target
+            \`<${target.name}>\` element?`
           )
             // If the applicable <video> or <audio> element uses native controls
             // we assume that the mechanism is the element itself.

--- a/packages/alfa-rules/src/sia-r49/rule.ts
+++ b/packages/alfa-rules/src/sia-r49/rule.ts
@@ -23,7 +23,7 @@ const { isElement, hasName, hasNamespace } = Element;
 const { or, nor, equals } = Predicate;
 const { and } = Refinement;
 
-export default Rule.Atomic.of<Page, Element, Question>({
+export default Rule.Atomic.of<Page, Element, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r49",
   requirements: [Technique.of("G170")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r49/rule.ts
+++ b/packages/alfa-rules/src/sia-r49/rule.ts
@@ -23,7 +23,7 @@ const { isElement, hasName, hasNamespace } = Element;
 const { or, nor, equals } = Predicate;
 const { and } = Refinement;
 
-export default Rule.Atomic.of<Page, Element, Question.Type>({
+export default Rule.Atomic.of<Page, Element, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r49",
   requirements: [Technique.of("G170")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r50/rule.ts
+++ b/packages/alfa-rules/src/sia-r50/rule.ts
@@ -14,7 +14,7 @@ import R48 from "../sia-r48/rule";
 import R49 from "../sia-r49/rule";
 import { Scope } from "../tags";
 
-export default Rule.Composite.of<Page, Element, Question, Element>({
+export default Rule.Composite.of<Page, Element, Question.Type, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r50",
   requirements: [
     Criterion.of("1.4.2"),

--- a/packages/alfa-rules/src/sia-r50/rule.ts
+++ b/packages/alfa-rules/src/sia-r50/rule.ts
@@ -14,7 +14,7 @@ import R48 from "../sia-r48/rule";
 import R49 from "../sia-r49/rule";
 import { Scope } from "../tags";
 
-export default Rule.Composite.of<Page, Element, Question.Type, Element>({
+export default Rule.Composite.of<Page, Element, Question.Metadata, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r50",
   requirements: [
     Criterion.of("1.4.2"),

--- a/packages/alfa-rules/src/sia-r55/rule.ts
+++ b/packages/alfa-rules/src/sia-r55/rule.ts
@@ -17,7 +17,7 @@ import { Scope } from "../tags";
 const { and, equals, not } = Predicate;
 const { hasNamespace } = Element;
 
-export default Rule.Atomic.of<Page, Group<Element>, Question.Type>({
+export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r55",
   tags: [Scope.Component],
   evaluate({ device, document }) {

--- a/packages/alfa-rules/src/sia-r55/rule.ts
+++ b/packages/alfa-rules/src/sia-r55/rule.ts
@@ -17,7 +17,7 @@ import { Scope } from "../tags";
 const { and, equals, not } = Predicate;
 const { hasNamespace } = Element;
 
-export default Rule.Atomic.of<Page, Group<Element>, Question>({
+export default Rule.Atomic.of<Page, Group<Element>, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r55",
   tags: [Scope.Component],
   evaluate({ device, document }) {

--- a/packages/alfa-rules/src/sia-r55/rule.ts
+++ b/packages/alfa-rules/src/sia-r55/rule.ts
@@ -61,10 +61,9 @@ export default Rule.Atomic.of<Page, Group<Element>, Question>({
           .name;
 
         const sameResource = Question.of(
-          "boolean",
           "is-content-equivalent",
-          `Do these ${role} landmarks have the same or equivalent content?`,
-          target
+          target,
+          `Do these ${role} landmarks have the same or equivalent content?`
         );
 
         return {

--- a/packages/alfa-rules/src/sia-r65/rule.ts
+++ b/packages/alfa-rules/src/sia-r65/rule.ts
@@ -26,7 +26,7 @@ const { isElement } = Element;
 const { isKeyword } = Keyword;
 const { or, test, xor } = Predicate;
 
-export default Rule.Atomic.of<Page, Element, Question.Type>({
+export default Rule.Atomic.of<Page, Element, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r65",
   requirements: [Criterion.of("2.4.7")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r65/rule.ts
+++ b/packages/alfa-rules/src/sia-r65/rule.ts
@@ -26,7 +26,7 @@ const { isElement } = Element;
 const { isKeyword } = Keyword;
 const { or, test, xor } = Predicate;
 
-export default Rule.Atomic.of<Page, Element, Question>({
+export default Rule.Atomic.of<Page, Element, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r65",
   requirements: [Criterion.of("2.4.7")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r65/rule.ts
+++ b/packages/alfa-rules/src/sia-r65/rule.ts
@@ -46,12 +46,7 @@ export default Rule.Atomic.of<Page, Element, Question>({
       },
 
       expectations(target) {
-        const askFocusIndicator = Question.of(
-          "boolean",
-          "has-focus-indicator",
-          `Does the element have a visible focus indicator?`,
-          target
-        );
+        const askFocusIndicator = Question.of("has-focus-indicator", target);
 
         return {
           1: askFocusIndicator

--- a/packages/alfa-rules/src/sia-r66/rule.ts
+++ b/packages/alfa-rules/src/sia-r66/rule.ts
@@ -70,19 +70,9 @@ export default Rule.Atomic.of<Page, Text, Question>({
       },
 
       expectations(target) {
-        const foregrounds = Question.of(
-          "color[]",
-          "foreground-colors",
-          "What are the foreground colors of the text node?",
-          target
-        );
+        const foregrounds = Question.of("foreground-colors", target);
 
-        const backgrounds = Question.of(
-          "color[]",
-          "background-colors",
-          "What are the background colors of the text node?",
-          target
-        );
+        const backgrounds = Question.of("background-colors", target);
 
         const result = foregrounds.map((foregrounds) =>
           backgrounds.map((backgrounds) => {

--- a/packages/alfa-rules/src/sia-r66/rule.ts
+++ b/packages/alfa-rules/src/sia-r66/rule.ts
@@ -31,7 +31,7 @@ const { max } = Math;
 const { isElement } = Element;
 const { isText } = Text;
 
-export default Rule.Atomic.of<Page, Text, Question.Type>({
+export default Rule.Atomic.of<Page, Text, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r66",
   requirements: [Criterion.of("1.4.6")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r66/rule.ts
+++ b/packages/alfa-rules/src/sia-r66/rule.ts
@@ -31,7 +31,7 @@ const { max } = Math;
 const { isElement } = Element;
 const { isText } = Text;
 
-export default Rule.Atomic.of<Page, Text, Question>({
+export default Rule.Atomic.of<Page, Text, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r66",
   requirements: [Criterion.of("1.4.6")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r69/rule.ts
+++ b/packages/alfa-rules/src/sia-r69/rule.ts
@@ -32,7 +32,7 @@ const { max } = Math;
 const { isElement } = Element;
 const { isText } = Text;
 
-export default Rule.Atomic.of<Page, Text, Question>({
+export default Rule.Atomic.of<Page, Text, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r69",
   requirements: [Criterion.of("1.4.3"), Criterion.of("1.4.6")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r69/rule.ts
+++ b/packages/alfa-rules/src/sia-r69/rule.ts
@@ -1,4 +1,5 @@
 import { Rule } from "@siteimprove/alfa-act";
+import { RGB } from "@siteimprove/alfa-css";
 import { Element, Text, Namespace, Node } from "@siteimprove/alfa-dom";
 import { Iterable } from "@siteimprove/alfa-iterable";
 import { Predicate } from "@siteimprove/alfa-predicate";
@@ -70,19 +71,9 @@ export default Rule.Atomic.of<Page, Text, Question>({
       },
 
       expectations(target) {
-        const foregrounds = Question.of(
-          "color[]",
-          "foreground-colors",
-          "What are the foreground colors of the text node?",
-          target
-        );
+        const foregrounds = Question.of("foreground-colors", target);
 
-        const backgrounds = Question.of(
-          "color[]",
-          "background-colors",
-          "What are the background colors of the text node?",
-          target
-        );
+        const backgrounds = Question.of("background-colors", target);
 
         const result = foregrounds.map((foregrounds) =>
           backgrounds.map((backgrounds) => {

--- a/packages/alfa-rules/src/sia-r69/rule.ts
+++ b/packages/alfa-rules/src/sia-r69/rule.ts
@@ -32,7 +32,7 @@ const { max } = Math;
 const { isElement } = Element;
 const { isText } = Text;
 
-export default Rule.Atomic.of<Page, Text, Question.Type>({
+export default Rule.Atomic.of<Page, Text, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r69",
   requirements: [Criterion.of("1.4.3"), Criterion.of("1.4.6")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r81/rule.ts
+++ b/packages/alfa-rules/src/sia-r81/rule.ts
@@ -76,10 +76,9 @@ export default Rule.Atomic.of<Page, Group<Element>, Question>({
             () => Outcomes.ResolveSameResource,
             () =>
               Question.of(
-                "boolean",
                 "reference-equivalent-resources",
-                `Do the links resolve to equivalent resources?`,
-                target
+                target,
+                `Do the links resolve to equivalent resources?`
               ).map((embedEquivalentResources) =>
                 expectation(
                   embedEquivalentResources,

--- a/packages/alfa-rules/src/sia-r81/rule.ts
+++ b/packages/alfa-rules/src/sia-r81/rule.ts
@@ -27,7 +27,7 @@ import { Scope } from "../tags";
 const { isElement, hasName, hasNamespace, hasId } = Element;
 const { and, not, equals } = Predicate;
 
-export default Rule.Atomic.of<Page, Group<Element>, Question>({
+export default Rule.Atomic.of<Page, Group<Element>, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r81",
   requirements: [Criterion.of("2.4.4"), Criterion.of("2.4.9")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r81/rule.ts
+++ b/packages/alfa-rules/src/sia-r81/rule.ts
@@ -27,7 +27,7 @@ import { Scope } from "../tags";
 const { isElement, hasName, hasNamespace, hasId } = Element;
 const { and, not, equals } = Predicate;
 
-export default Rule.Atomic.of<Page, Group<Element>, Question.Type>({
+export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r81",
   requirements: [Criterion.of("2.4.4"), Criterion.of("2.4.9")],
   tags: [Scope.Component],

--- a/packages/alfa-rules/src/sia-r82/rule.ts
+++ b/packages/alfa-rules/src/sia-r82/rule.ts
@@ -11,15 +11,23 @@ import { expectation } from "../common/expectation";
 import { hasRole, isPerceivable } from "../common/predicate";
 
 import { Question } from "../common/question";
-import { Scope } from "../tags";
+import { Scope, Stability } from "../tags";
 
 const { isElement, hasNamespace } = Element;
 const { and, test } = Predicate;
 
+/**
+ * R82 ask questions whose subject is not the target of the rule.
+ * The context of the question is still the test target, but the
+ * subjects can be various other elements.
+ * This needs changes in Dory, Nemo, and likely databases to be stored;
+ * this needs changes in the Page Report to be able to highlight an element
+ * different from the test target.
+ */
 export default Rule.Atomic.of<Page, Element, Question, Node>({
   uri: "https://alfa.siteimprove.com/rules/sia-r82",
   requirements: [Criterion.of("3.3.1")],
-  tags: [Scope.Component],
+  tags: [Scope.Component, Stability.Experimental],
   evaluate({ device, document }) {
     return {
       applicability() {
@@ -48,12 +56,9 @@ export default Rule.Atomic.of<Page, Element, Question, Node>({
       },
 
       expectations(target) {
-        const indicators = Question.of(
-          "node[]",
-          "error-indicators",
-          `Where are the error indicators, if any, for the form field?`,
-          target
-        ).map((indicators) => [...indicators]);
+        const indicators = Question.of("error-indicators", target).map(
+          (indicators) => [...indicators]
+        );
 
         return {
           1: indicators.map((indicators) =>
@@ -146,9 +151,7 @@ function identifiesTarget(
   }
 
   return Question.of(
-    "boolean",
     "error-indicator-identifies-form-field",
-    "Does the error indicator identify, in text, the form field it relates to?",
     indicator,
     target
   ).map((isIdentified) => {
@@ -177,10 +180,7 @@ function describesResolution(
   }
 
   return Question.of(
-    "boolean",
     "error-indicator-describes-resolution",
-    `Does the error indicator describe, in text, the cause of the error or how
-    to resolve it?`,
     indicator,
     target
   ).map((isDescribed) => {

--- a/packages/alfa-rules/src/sia-r82/rule.ts
+++ b/packages/alfa-rules/src/sia-r82/rule.ts
@@ -24,7 +24,7 @@ const { and, test } = Predicate;
  * this needs changes in the Page Report to be able to highlight an element
  * different from the test target.
  */
-export default Rule.Atomic.of<Page, Element, Question, Node>({
+export default Rule.Atomic.of<Page, Element, Question.Type, Node>({
   uri: "https://alfa.siteimprove.com/rules/sia-r82",
   requirements: [Criterion.of("3.3.1")],
   tags: [Scope.Component, Stability.Experimental],
@@ -143,7 +143,7 @@ function identifiesTarget(
   indicators: Array<Node>,
   error: Err<Diagnostic>,
   device: Device
-): Interview<Question, Node, Element, Result<Diagnostic>> {
+): Interview<Question.Type, Node, Element, Result<Diagnostic>> {
   const indicator = indicators[0];
 
   if (indicator === undefined) {
@@ -172,7 +172,7 @@ function describesResolution(
   indicators: Array<Node>,
   error: Err<Diagnostic>,
   device: Device
-): Interview<Question, Node, Element, Result<Diagnostic>> {
+): Interview<Question.Type, Node, Element, Result<Diagnostic>> {
   const indicator = indicators[0];
 
   if (indicator === undefined) {

--- a/packages/alfa-rules/src/sia-r82/rule.ts
+++ b/packages/alfa-rules/src/sia-r82/rule.ts
@@ -24,7 +24,7 @@ const { and, test } = Predicate;
  * this needs changes in the Page Report to be able to highlight an element
  * different from the test target.
  */
-export default Rule.Atomic.of<Page, Element, Question.Type, Node>({
+export default Rule.Atomic.of<Page, Element, Question.Metadata, Node>({
   uri: "https://alfa.siteimprove.com/rules/sia-r82",
   requirements: [Criterion.of("3.3.1")],
   tags: [Scope.Component, Stability.Experimental],
@@ -143,7 +143,7 @@ function identifiesTarget(
   indicators: Array<Node>,
   error: Err<Diagnostic>,
   device: Device
-): Interview<Question.Type, Node, Element, Result<Diagnostic>> {
+): Interview<Question.Metadata, Node, Element, Result<Diagnostic>> {
   const indicator = indicators[0];
 
   if (indicator === undefined) {
@@ -172,7 +172,7 @@ function describesResolution(
   indicators: Array<Node>,
   error: Err<Diagnostic>,
   device: Device
-): Interview<Question.Type, Node, Element, Result<Diagnostic>> {
+): Interview<Question.Metadata, Node, Element, Result<Diagnostic>> {
   const indicator = indicators[0];
 
   if (indicator === undefined) {

--- a/packages/alfa-rules/src/sia-r87/rule.ts
+++ b/packages/alfa-rules/src/sia-r87/rule.ts
@@ -28,7 +28,7 @@ const { hasName, isElement } = Element;
 const { fold } = Predicate;
 const { and } = Refinement;
 
-export default Rule.Atomic.of<Page, Document, Question.Type>({
+export default Rule.Atomic.of<Page, Document, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r87",
   requirements: [Technique.of("G1")],
   tags: [Scope.Page],
@@ -94,7 +94,7 @@ export default Rule.Atomic.of<Page, Document, Question.Type>({
         function isAtTheStartOfMain(
           reference: Option<Node>
         ): Interview<
-          Question.Type,
+          Question.Metadata,
           Document,
           Document,
           Option.Maybe<Result<Diagnostic, Diagnostic>>
@@ -114,7 +114,7 @@ export default Rule.Atomic.of<Page, Document, Question.Type>({
         }
 
         function isSkipLink(): Interview<
-          Question.Type,
+          Question.Metadata,
           Document,
           Document,
           Option.Maybe<Result<Diagnostic>>

--- a/packages/alfa-rules/src/sia-r87/rule.ts
+++ b/packages/alfa-rules/src/sia-r87/rule.ts
@@ -28,7 +28,7 @@ const { hasName, isElement } = Element;
 const { fold } = Predicate;
 const { and } = Refinement;
 
-export default Rule.Atomic.of<Page, Document, Question>({
+export default Rule.Atomic.of<Page, Document, Question.Type>({
   uri: "https://alfa.siteimprove.com/rules/sia-r87",
   requirements: [Technique.of("G1")],
   tags: [Scope.Page],
@@ -94,7 +94,7 @@ export default Rule.Atomic.of<Page, Document, Question>({
         function isAtTheStartOfMain(
           reference: Option<Node>
         ): Interview<
-          Question,
+          Question.Type,
           Document,
           Document,
           Option.Maybe<Result<Diagnostic, Diagnostic>>
@@ -114,7 +114,7 @@ export default Rule.Atomic.of<Page, Document, Question>({
         }
 
         function isSkipLink(): Interview<
-          Question,
+          Question.Type,
           Document,
           Document,
           Option.Maybe<Result<Diagnostic>>

--- a/packages/alfa-rules/src/sia-r87/rule.ts
+++ b/packages/alfa-rules/src/sia-r87/rule.ts
@@ -78,32 +78,18 @@ export default Rule.Atomic.of<Page, Document, Question>({
           .filter(and(isElement, hasRole(device, "main")));
 
         const askIsMain = Question.of(
-          "boolean",
           "first-tabbable-reference-is-main",
-          `Does the first tabbable element of the document point to the main content?`,
           target
         );
 
         const askIsInteralLink = Question.of(
-          "boolean",
           "first-tabbable-is-internal-link",
-          `Is the first tabbable element of the document an internal link?`,
           target
         );
 
-        const askReference = Question.of(
-          "node",
-          "first-tabbable-reference",
-          `Where in the document does the first tabbable element point?`,
-          target
-        );
+        const askReference = Question.of("first-tabbable-reference", target);
 
-        const askIsVisible = Question.of(
-          "boolean",
-          "first-tabbable-is-visible",
-          `Is the first tabbable element of the document visible if it's focused?`,
-          target
-        );
+        const askIsVisible = Question.of("first-tabbable-is-visible", target);
 
         function isAtTheStartOfMain(
           reference: Option<Node>

--- a/packages/alfa-rules/test/common/oracle.ts
+++ b/packages/alfa-rules/test/common/oracle.ts
@@ -4,7 +4,14 @@ import { None, Option } from "@siteimprove/alfa-option";
 
 import { Question } from "../../src/common/question";
 
-function wrapper<TYPE, SUBJECT, CONTEXT, ANSWER, T, URI extends string>(
+function wrapper<
+  TYPE,
+  SUBJECT,
+  CONTEXT,
+  ANSWER,
+  T,
+  URI extends keyof Question.Metadata
+>(
   question: act.Question<TYPE, SUBJECT, CONTEXT, ANSWER, T, URI>,
   answer: ANSWER
 ): Future<Option<ANSWER>> {

--- a/packages/alfa-rules/test/common/oracle.ts
+++ b/packages/alfa-rules/test/common/oracle.ts
@@ -21,6 +21,8 @@ function wrapper<A, T>(
 
 const dontKnow = Future.now(None);
 
+type Uri = keyof Question.Metadata;
+
 export function oracle<I, T, S>(answers: {
   [uri: string]: Question.Type[keyof Question.Type];
 }): act.Oracle<I, T, Question.Type, S> {

--- a/packages/alfa-rules/test/common/oracle.ts
+++ b/packages/alfa-rules/test/common/oracle.ts
@@ -1,64 +1,50 @@
 import * as act from "@siteimprove/alfa-act";
-import { RGB } from "@siteimprove/alfa-css";
-import { Node } from "@siteimprove/alfa-dom";
 import { Future } from "@siteimprove/alfa-future";
-import { Iterable } from "@siteimprove/alfa-iterable";
 import { None, Option } from "@siteimprove/alfa-option";
-import { Refinement } from "@siteimprove/alfa-refinement";
 
 import { Question } from "../../src/common/question";
 
-const { isIterable } = Iterable;
-const { isOption } = Option;
-const { isBoolean, isString } = Refinement;
-
-function wrapper<A, T>(
-  question: act.Question<unknown, unknown, unknown, A, T, string>,
-  answer: A
+function wrapper<TYPE, SUBJECT, CONTEXT, ANSWER, T, URI extends string>(
+  question: act.Question<TYPE, SUBJECT, CONTEXT, ANSWER, T, URI>,
+  answer: ANSWER
 ): Future<Option<T>> {
   return Future.now(Option.of(question.answer(answer)));
 }
 
 const dontKnow = Future.now(None);
 
-type Uri = keyof Question.Metadata;
-
-export function oracle<I, T, S>(answers: {
-  [uri: string]: Question.Type[keyof Question.Type];
-}): act.Oracle<I, T, Question.Type, S> {
+export function oracle<I, T, S>(
+  answers: Partial<{
+    [URI in keyof Question.Metadata]: Question.Metadata[URI][1];
+  }>
+): act.Oracle<I, T, Question.Metadata, S> {
   return (rule, question) => {
-    const answer = answers[question.uri];
+    // Check if we do have an answer for this question.
+    if (answers[question.uri] === undefined) {
+      return dontKnow;
+    }
 
     // * We use a switch with no default case to ensure exhaustive matching at
-    //   the type level.
-    // * We need to check the type of `answer` because there is no link between
-    //   URI and type, so `answers` cannot be better typed that with the union
-    //   of all possible types.
-    // * We can't pre-compute `wrapper` because narrowing the type of `answer`
-    //   won't narrow the type of the wrapped answer.
-    // * We could have a better wrapper, taking the refinement as an argument,
-    //   and doing all the work. However, `isOption<Node>` is not callable as
-    //   is; `isOption` is not narrowing enough; and eta-expanding it breaks
-    //   the narrowing. So we'd need a new refinement to only be an
-    //   eta-expanded `isOption<Node>`, which is a bit overkill.
+    //   the type level. This also fails type checking if a Question.Type is
+    //   not used by any question.
+    // * We can't pre-compute `wrapper` or even `answers[question.uri]` because
+    //   we first need to narrow by question type to ensure the answer has the
+    //   expected type.
     switch (question.type) {
       case "boolean":
-        return isBoolean(answer) ? wrapper(question, answer) : dontKnow;
+        return wrapper(question, answers[question.uri]!);
 
       case "node":
-        return isOption<Node>(answer) ? wrapper(question, answer) : dontKnow;
+        return wrapper(question, answers[question.uri]!);
 
       case "node[]":
-        return isIterable<Node>(answer) ? wrapper(question, answer) : dontKnow;
-
-      case "color":
-        return isOption<RGB>(answer) ? wrapper(question, answer) : dontKnow;
+        return wrapper(question, answers[question.uri]!);
 
       case "color[]":
-        return isIterable<RGB>(answer) ? wrapper(question, answer) : dontKnow;
+        return wrapper(question, answers[question.uri]!);
 
       case "string":
-        return isString(answer) ? wrapper(question, answer) : dontKnow;
+        return wrapper(question, answers[question.uri]!);
     }
   };
 }

--- a/packages/alfa-rules/test/common/oracle.ts
+++ b/packages/alfa-rules/test/common/oracle.ts
@@ -7,8 +7,8 @@ import { Question } from "../../src/common/question";
 function wrapper<TYPE, SUBJECT, CONTEXT, ANSWER, T, URI extends string>(
   question: act.Question<TYPE, SUBJECT, CONTEXT, ANSWER, T, URI>,
   answer: ANSWER
-): Future<Option<T>> {
-  return Future.now(Option.of(question.answer(answer)));
+): Future<Option<ANSWER>> {
+  return Future.now(Option.of(answer));
 }
 
 const dontKnow = Future.now(None);
@@ -30,6 +30,7 @@ export function oracle<I, T, S>(
     // * We can't pre-compute `wrapper` or even `answers[question.uri]` because
     //   we first need to narrow by question type to ensure the answer has the
     //   expected type.
+    // * Thanks to the initial test, we know that answers[question.uri] exists.
     switch (question.type) {
       case "boolean":
         return wrapper(question, answers[question.uri]!);

--- a/packages/alfa-rules/test/common/oracle.ts
+++ b/packages/alfa-rules/test/common/oracle.ts
@@ -22,8 +22,8 @@ function wrapper<A, T>(
 const dontKnow = Future.now(None);
 
 export function oracle<I, T, S>(answers: {
-  [uri: string]: Question[keyof Question];
-}): act.Oracle<I, T, Question, S> {
+  [uri: string]: Question.Type[keyof Question.Type];
+}): act.Oracle<I, T, Question.Type, S> {
   return (rule, question) => {
     const answer = answers[question.uri];
 

--- a/packages/alfa-rules/test/sia-r38/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r38/rule.spec.tsx
@@ -29,8 +29,8 @@ test("evaluate() passes when some atomic rules are passing", async (t) => {
         transcript: None,
         "transcript-link": None,
         "has-description": true,
-        "text-alternative": false,
-        label: false,
+        "text-alternative": None,
+        label: None,
         "track-describes-video": true,
       })
     ),


### PR DESCRIPTION
Resolves #1018 

---
Questions have a `type` parameter which is used to link the question to its expected answer type in a programmatic way. Notably, this ensures type safety in Oracles by making sure that a question expecting a `boolean` answer (`question.type === "boolean"`) will indeed get it (by case analysis on `question.type` and narrowing on `answer`).

To ensure this stays true, `Rule` (and most `alfa-act` classes) have a generic "question shape" type variable which is instantiated by  interfaces like:
```javascript
interface Question {
  boolean: boolean;
  "node[]": Iterable<Node>;
  …
}
```

With this PR, the type of questions is also linked to their URI. That is, two questions with the same URI must now have the same `type` and therefore expect the same type for answers. Since the URI is supposed to identify questions, it makes no sense to have the "same" question (same URI) expecting sometimes a boolean and sometimes a node.

While the `type` parameter of questions becomes a bit redundant, it is nonetheless kept as a programmatic way to find the expected type of answer. While it is not possible to branch code on the `ANSWER` type variable of a Question; it is possible to do so on `question.type`. Oracles can use that to ensure type safety when answering questions.

Thus, the "question shape" generic now looks like:
```javascript
interface Question {
  "question1": ["boolean", boolean];
  "question2": ["boolean", boolean];
  "question3": ["node[]", Iterable<Node>];
…
}
```
Note that using string litterals, who are the same as their type, makes this manipulation possible.

---
As a consequence and to be able to build the question shape generic, Questions now need to be registered by their URI before being used in rules.

This also let questions register a default message and ease a bit building of questions in rules. However, since the message is now optional, the order of parameters has been changed.

---
`Interview.conduct` now wraps answers in `question.answer`; therefore Oracles don't need to do it.
This allows to get rid of the free type variable in Oracles.

---
Small changes:
* SIA-R82 is now marked and exported as Experimental.
* Give explicit name to type variables in `alfa-act` + some doc.
* Remove the `"color"` type of questions, which was not used.