### PR TITLE
Serialise `path` in DOM Nodes JSON

### DIFF
--- a/docs/review/api/alfa-dom.api.md
+++ b/docs/review/api/alfa-dom.api.md
@@ -17,7 +17,7 @@ import { Serializable } from '@siteimprove/alfa-json';
 import { Trampoline } from '@siteimprove/alfa-trampoline';
 
 // @public (undocumented)
-export class Attribute extends Node {
+export class Attribute<N extends string = string> extends Node {
     // @internal (undocumented)
     _attachOwner(owner: Element): boolean;
     // @internal (undocumented)
@@ -29,11 +29,11 @@ export class Attribute extends Node {
     // (undocumented)
     isBoolean(): boolean;
     // (undocumented)
-    get name(): string;
+    get name(): N | Lowercase<N>;
     // (undocumented)
     get namespace(): Option<Namespace>;
     // (undocumented)
-    static of(namespace: Option<Namespace>, prefix: Option<string>, name: string, value: string): Attribute;
+    static of<N extends string = string>(namespace: Option<Namespace>, prefix: Option<string>, name: N, value: string): Attribute<N>;
     // (undocumented)
     get owner(): Option<Element>;
     // (undocumented)
@@ -43,7 +43,7 @@ export class Attribute extends Node {
     // (undocumented)
     get qualifiedName(): string;
     // (undocumented)
-    toJSON(): Attribute.JSON;
+    toJSON(): Attribute.JSON<N>;
     // (undocumented)
     tokens(separator?: string | RegExp): Sequence<string>;
     // (undocumented)
@@ -55,21 +55,19 @@ export class Attribute extends Node {
 // @public (undocumented)
 export namespace Attribute {
     // @internal
-    export function foldCase(name: string, owner: Option<Element>): string;
+    export function foldCase<N extends string = string>(name: N, owner: Option<Element>): N | Lowercase<N>;
     // @internal (undocumented)
-    export function fromAttribute(attribute: JSON): Trampoline<Attribute>;
+    export function fromAttribute<N extends string = string>(attribute: JSON<N>): Trampoline<Attribute<N>>;
     // (undocumented)
     export function isAttribute(value: unknown): value is Attribute;
     // (undocumented)
-    export interface JSON extends Node.JSON {
+    export interface JSON<N extends string = string> extends Node.JSON<"attribute"> {
         // (undocumented)
-        name: string;
+        name: N;
         // (undocumented)
         namespace: string | null;
         // (undocumented)
         prefix: string | null;
-        // (undocumented)
-        type: "attribute";
         // (undocumented)
         value: string;
     }
@@ -132,11 +130,9 @@ export namespace Comment {
     // (undocumented)
     export function isComment(value: unknown): value is Comment;
     // (undocumented)
-    export interface JSON extends Node.JSON {
+    export interface JSON extends Node.JSON<"comment"> {
         // (undocumented)
         data: string;
-        // (undocumented)
-        type: "comment";
     }
 }
 
@@ -234,18 +230,16 @@ export namespace Document {
     // (undocumented)
     export function isDocument(value: unknown): value is Document;
     // (undocumented)
-    export interface JSON extends Node.JSON {
+    export interface JSON extends Node.JSON<"document"> {
         // (undocumented)
         children: Array<Node.JSON>;
         // (undocumented)
         style: Array<Sheet.JSON>;
-        // (undocumented)
-        type: "document";
     }
 }
 
 // @public (undocumented)
-export class Element extends Node implements Slot, Slotable {
+export class Element<N extends string = string> extends Node implements Slot, Slotable {
     // (undocumented)
     assignedNodes(): Iterable_2<Slotable>;
     // (undocumented)
@@ -255,9 +249,9 @@ export class Element extends Node implements Slot, Slotable {
     // @internal (undocumented)
     _attachShadow(shadow: Shadow): boolean;
     // (undocumented)
-    attribute(name: string): Option<Attribute>;
+    attribute<A extends string = string>(name: A): Option<Attribute<A>>;
     // (undocumented)
-    attribute(predicate: Predicate<Attribute>): Option<Attribute>;
+    attribute<A extends string = string>(predicate: Predicate<Attribute<A>>): Option<Attribute<A>>;
     // (undocumented)
     get attributes(): Sequence<Attribute>;
     // (undocumented)
@@ -271,11 +265,11 @@ export class Element extends Node implements Slot, Slotable {
     // (undocumented)
     isVoid(): boolean;
     // (undocumented)
-    get name(): string;
+    get name(): N;
     // (undocumented)
     get namespace(): Option<Namespace>;
     // (undocumented)
-    static of(namespace: Option<Namespace>, prefix: Option<string>, name: string, attributes?: Iterable_2<Attribute>, children?: Iterable_2<Node>, style?: Option<Block>): Element;
+    static of<N extends string = string>(namespace: Option<Namespace>, prefix: Option<string>, name: N, attributes?: Iterable_2<Attribute>, children?: Iterable_2<Node>, style?: Option<Block>): Element<N>;
     // (undocumented)
     parent(options?: Node.Traversal): Option<Node>;
     // (undocumented)
@@ -291,7 +285,7 @@ export class Element extends Node implements Slot, Slotable {
     // (undocumented)
     tabIndex(): Option<number>;
     // (undocumented)
-    toJSON(): Element.JSON;
+    toJSON(): Element.JSON<N>;
     // (undocumented)
     toString(): string;
 }
@@ -299,11 +293,11 @@ export class Element extends Node implements Slot, Slotable {
 // @public (undocumented)
 export namespace Element {
     // @internal (undocumented)
-    export function fromElement(json: JSON): Trampoline<Element>;
+    export function fromElement<N extends string = string>(json: JSON<N>): Trampoline<Element<N>>;
     // (undocumented)
     export function isElement(value: unknown): value is Element;
     // (undocumented)
-    export interface JSON extends Node.JSON {
+    export interface JSON<N extends string = string> extends Node.JSON<"element"> {
         // (undocumented)
         attributes: Array<Attribute.JSON>;
         // (undocumented)
@@ -311,7 +305,7 @@ export namespace Element {
         // (undocumented)
         content: Document.JSON | null;
         // (undocumented)
-        name: string;
+        name: N;
         // (undocumented)
         namespace: string | null;
         // (undocumented)
@@ -320,8 +314,6 @@ export namespace Element {
         shadow: Shadow.JSON | null;
         // (undocumented)
         style: Block.JSON | null;
-        // (undocumented)
-        type: "element";
     }
     const // Warning: (ae-forgotten-export) The symbol "predicate" needs to be exported by the entry point index.d.ts
     //
@@ -390,11 +382,9 @@ export namespace Fragment {
     // (undocumented)
     export function isFragment(value: unknown): value is Fragment;
     // (undocumented)
-    export interface JSON extends Node.JSON {
+    export interface JSON extends Node.JSON<"fragment"> {
         // (undocumented)
         children: Array<Node.JSON>;
-        // (undocumented)
-        type: "fragment";
     }
 }
 
@@ -423,12 +413,12 @@ export namespace GroupingRule {
 }
 
 // @public (undocumented)
-export function h(name: string, attributes?: Array<Attribute> | Record<string, string | boolean>, children?: Array<Node | string>, style?: Array<Declaration> | Record<string, string>): Element;
+export function h<N extends string = string>(name: N, attributes?: Array<Attribute> | Record<string, string | boolean>, children?: Array<Node | string>, style?: Array<Declaration> | Record<string, string>): Element<N>;
 
 // @public (undocumented)
 export namespace h {
     // (undocumented)
-    export function attribute(name: string, value: string): Attribute;
+    export function attribute<N extends string = string>(name: N, value: string): Attribute<N>;
     // (undocumented)
     export function block(declarations: Array<Declaration> | Record<string, string>): Block;
     // (undocumented)
@@ -436,7 +426,7 @@ export namespace h {
     // (undocumented)
     export function document(children: Array<Node | string>, style?: Array<Sheet>): Document;
     // (undocumented)
-    export function element(name: string, attributes?: Array<Attribute> | Record<string, string | boolean>, children?: Array<Node | string>, style?: Array<Declaration> | Record<string, string>): Element;
+    export function element<N extends string = string>(name: N, attributes?: Array<Attribute> | Record<string, string | boolean>, children?: Array<Node | string>, style?: Array<Declaration> | Record<string, string>): Element<N>;
     // (undocumented)
     export function fragment(children: Array<Node | string>): Fragment;
     // (undocumented)
@@ -465,7 +455,7 @@ export namespace h {
     // (undocumented)
     export function text(data: string): Text;
     // (undocumented)
-    export function type(name: string, publicId?: string, systemId?: string): Type;
+    export function type<N extends string = string>(name: N, publicId?: string, systemId?: string): Type<N>;
 }
 
 // @public (undocumented)
@@ -483,16 +473,16 @@ function hasInputType(predicate: Predicate<InputType>): Predicate<Element>;
 function hasInputType(inputType: InputType, ...rest: Array<InputType>): Predicate<Element>;
 
 // @public (undocumented)
-function hasName(predicate: Predicate<string>): Predicate<Attribute>;
+function hasName<N extends string = string>(predicate: Refinement<string, N>): Refinement<Attribute, Attribute<N>>;
 
 // @public (undocumented)
-function hasName(name: string, ...rest: Array<string>): Predicate<Attribute>;
+function hasName<N extends string = string>(name: N, ...rest: Array<N>): Refinement<Attribute, Attribute<N>>;
 
 // @public (undocumented)
-function hasName_2(predicate: Predicate<string>): Predicate<Element>;
+function hasName_2<N extends string = string>(predicate: Refinement<string, N>): Refinement<Element, Element<N>>;
 
 // @public (undocumented)
-function hasName_2(name: string, ...rest: Array<string>): Predicate<Element>;
+function hasName_2<N extends string = string>(name: N, ...rest: Array<N>): Refinement<Element, Element<N>>;
 
 // @public (undocumented)
 function hasNamespace(predicate: Predicate<Namespace>): Predicate<Element>;
@@ -550,7 +540,7 @@ function isEditingHost(element: Element): boolean;
 function isSuggestedFocusable(element: Element): boolean;
 
 // @public (undocumented)
-export function jsx(name: string, properties?: jsx.Properties | null, ...children: jsx.Children): Element;
+export function jsx<N extends string = string>(name: N, properties?: jsx.Properties | null, ...children: jsx.Children): Element<N>;
 
 // @public (undocumented)
 export namespace jsx {
@@ -563,7 +553,7 @@ export namespace jsx {
         // Warning: (ae-forgotten-export) The symbol "dom" needs to be exported by the entry point index.d.ts
         //
         // (undocumented)
-        export type Element = dom.Element;
+        export type Element<N extends string = string> = dom.Element<N>;
         // (undocumented)
         export interface IntrinsicElements {
             // (undocumented)
@@ -840,11 +830,13 @@ export namespace Node {
     // (undocumented)
     export function isNode(value: unknown): value is Node;
     // (undocumented)
-    export interface JSON {
+    export interface JSON<T extends string = string> {
         // (undocumented)
-        [key: string]: json.JSON;
+        [key: string]: json.JSON | undefined;
         // (undocumented)
-        type: string;
+        path?: string;
+        // (undocumented)
+        type: T;
     }
     // (undocumented)
     export interface Traversal {
@@ -1153,28 +1145,26 @@ export namespace Text {
     // (undocumented)
     export function isText(value: unknown): value is Text;
     // (undocumented)
-    export interface JSON extends Node.JSON {
+    export interface JSON extends Node.JSON<"text"> {
         // (undocumented)
         data: string;
-        // (undocumented)
-        type: "text";
     }
 }
 
 // @public (undocumented)
-export class Type extends Node {
+export class Type<N extends string = string> extends Node {
     // (undocumented)
     static empty(): Type;
     // (undocumented)
-    get name(): string;
+    get name(): N;
     // (undocumented)
-    static of(name: string, publicId?: Option<string>, systemId?: Option<string>): Type;
+    static of<N extends string = string>(name: N, publicId?: Option<string>, systemId?: Option<string>): Type<N>;
     // (undocumented)
     get publicId(): Option<string>;
     // (undocumented)
     get systemId(): Option<string>;
     // (undocumented)
-    toJSON(): Type.JSON;
+    toJSON(): Type.JSON<N>;
     // (undocumented)
     toString(): string;
 }
@@ -1182,19 +1172,17 @@ export class Type extends Node {
 // @public (undocumented)
 export namespace Type {
     // @internal (undocumented)
-    export function fromType(json: JSON): Trampoline<Type>;
+    export function fromType<N extends string = string>(json: JSON<N>): Trampoline<Type<N>>;
     // (undocumented)
     export function isType(value: unknown): value is Type;
     // (undocumented)
-    export interface JSON extends Node.JSON {
+    export interface JSON<N extends string = string> extends Node.JSON<"type"> {
         // (undocumented)
-        name: string;
+        name: N;
         // (undocumented)
         publicId: string | null;
         // (undocumented)
         systemId: string | null;
-        // (undocumented)
-        type: "type";
     }
 }
 

--- a/docs/review/api/alfa-rules.api.md
+++ b/docs/review/api/alfa-rules.api.md
@@ -24,205 +24,205 @@ import { Tag } from '@siteimprove/alfa-act';
 import { Text } from '@siteimprove/alfa-dom';
 
 // @public (undocumented)
-const _default: Rule.Atomic<Page, Element, never, Element>;
+const _default: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_10: Rule.Atomic<Page, Element, never, Element>;
+const _default_10: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_11: Rule.Atomic<Page, Attribute, never, Attribute>;
+const _default_11: Rule.Atomic<Page, Attribute<string>, never, Attribute<string>>;
 
 // @public (undocumented)
-const _default_12: Rule.Atomic<Page, Element, never, Element>;
+const _default_12: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_13: Rule.Atomic<Page, Element, never, Element>;
+const _default_13: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_14: Rule.Atomic<Page, Attribute, never, Attribute>;
+const _default_14: Rule.Atomic<Page, Attribute<string>, never, Attribute<string>>;
 
 // @public (undocumented)
-const _default_15: Rule.Atomic<Page, Element, never, Element>;
+const _default_15: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_16: Rule.Atomic<Page, Element, never, Element>;
+const _default_16: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_17: Rule.Atomic<Page, Element, never, Element>;
+const _default_17: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_18: Rule.Atomic<Page, Element, never, Element>;
+const _default_18: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_19: Rule.Atomic<Page, Group<Element>, Question.Metadata, Group<Element>>;
+const _default_19: Rule.Atomic<Page, Group<Element<string>>, Question.Metadata, Group<Element<string>>>;
 
 // @public (undocumented)
-const _default_2: Rule.Atomic<Page, Document, Question.Metadata, Element>;
+const _default_2: Rule.Atomic<Page, Document, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
-const _default_20: Rule.Atomic<Page, Element, never, Element>;
+const _default_20: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_21: Rule.Atomic<Page, Element, never, Element>;
+const _default_21: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_22: Rule.Atomic<Page, Attribute, never, Attribute>;
+const _default_22: Rule.Atomic<Page, Attribute<string>, never, Attribute<string>>;
 
 // @public (undocumented)
-const _default_23: Rule.Atomic<Page, Attribute, never, Attribute>;
+const _default_23: Rule.Atomic<Page, Attribute<string>, never, Attribute<string>>;
 
 // @public (undocumented)
-const _default_24: Rule.Atomic<Page, Attribute, never, Attribute>;
+const _default_24: Rule.Atomic<Page, Attribute<string>, never, Attribute<string>>;
 
 // @public (undocumented)
-const _default_25: Rule.Atomic<Page, Attribute, never, Attribute>;
+const _default_25: Rule.Atomic<Page, Attribute<string>, never, Attribute<string>>;
 
 // @public (undocumented)
-const _default_26: Rule.Atomic<Page, Element, Question.Metadata, Element>;
+const _default_26: Rule.Atomic<Page, Element<string>, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
-const _default_27: Rule.Atomic<Page, Element, Question.Metadata, Element>;
+const _default_27: Rule.Atomic<Page, Element<string>, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
-const _default_28: Rule.Atomic<Page, Element, Question.Metadata, Element>;
+const _default_28: Rule.Atomic<Page, Element<string>, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
-const _default_29: Rule.Atomic<Page, Element, Question.Metadata, Element>;
+const _default_29: Rule.Atomic<Page, Element<string>, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
-const _default_3: Rule.Atomic<Page, Element, Question.Metadata, Node>;
+const _default_3: Rule.Atomic<Page, Element<string>, Question.Metadata, Node>;
 
 // @public (undocumented)
-const _default_30: Rule.Atomic<Page, Element, Question.Metadata, Element>;
+const _default_30: Rule.Atomic<Page, Element<string>, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
-const _default_31: Rule.Composite<Page, Element, Question.Metadata, Element>;
+const _default_31: Rule.Composite<Page, Element<string>, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
-const _default_32: Rule.Atomic<Page, Element, never, Element>;
+const _default_32: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_33: Rule.Atomic<Page, Element, Question.Metadata, Element>;
+const _default_33: Rule.Atomic<Page, Element<string>, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
-const _default_34: Rule.Composite<Page, Element, Question.Metadata, Element>;
+const _default_34: Rule.Composite<Page, Element<string>, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
-const _default_35: Rule.Atomic<Page, Element, Question.Metadata, Element>;
+const _default_35: Rule.Atomic<Page, Element<string>, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
-const _default_36: Rule.Atomic<Page, Element, Question.Metadata, Element>;
+const _default_36: Rule.Atomic<Page, Element<string>, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
-const _default_37: Rule.Atomic<Page, Element, Question.Metadata, Element>;
+const _default_37: Rule.Atomic<Page, Element<string>, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
-const _default_38: Rule.Atomic<Page, Element, Question.Metadata, Element>;
+const _default_38: Rule.Atomic<Page, Element<string>, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
-const _default_39: Rule.Composite<Page, Element, Question.Metadata, Element>;
+const _default_39: Rule.Composite<Page, Element<string>, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
 const _default_4: Rule.Atomic<Page, Document, Question.Metadata, Document>;
 
 // @public (undocumented)
-const _default_40: Rule.Atomic<Page, Element, Question.Metadata, Element>;
+const _default_40: Rule.Atomic<Page, Element<string>, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
-const _default_41: Rule.Composite<Page, Element, Question.Metadata, Element>;
+const _default_41: Rule.Composite<Page, Element<string>, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
-const _default_42: Rule.Composite<Page, Element, Question.Metadata, Element>;
+const _default_42: Rule.Composite<Page, Element<string>, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
-const _default_43: Rule.Atomic<Page, Element, Question.Metadata, Element>;
+const _default_43: Rule.Atomic<Page, Element<string>, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
-const _default_44: Rule.Atomic<Page, Element, never, Element>;
+const _default_44: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_45: Rule.Atomic<Page, Group<Element>, Question.Metadata, Group<Element>>;
+const _default_45: Rule.Atomic<Page, Group<Element<string>>, Question.Metadata, Group<Element<string>>>;
 
 // @public (undocumented)
-const _default_46: Rule.Atomic<Page, Element, never, Element>;
+const _default_46: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_47: Rule.Atomic<Page, Element, never, Element>;
+const _default_47: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_48: Rule.Atomic<Page, Element, never, Element>;
+const _default_48: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_49: Rule.Atomic<Page, Attribute, never, Attribute>;
+const _default_49: Rule.Atomic<Page, Attribute<string>, never, Attribute<string>>;
 
 // @public (undocumented)
 const _default_5: Rule.Atomic<Page, Document, never, Document>;
 
 // @public (undocumented)
-const _default_50: Rule.Atomic<Page, Element, never, Element>;
+const _default_50: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_51: Rule.Atomic<Page, Element, never, Element>;
+const _default_51: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_52: Rule.Atomic<Page, Element, Question.Metadata, Element>;
+const _default_52: Rule.Atomic<Page, Element<string>, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
-const _default_53: Rule.Atomic<Page, Element, Question.Metadata, Element>;
+const _default_53: Rule.Atomic<Page, Element<string>, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
-const _default_54: Rule.Composite<Page, Element, Question.Metadata, Element>;
+const _default_54: Rule.Composite<Page, Element<string>, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
-const _default_55: Rule.Atomic<Page, Element, never, Element>;
+const _default_55: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_56: Rule.Atomic<Page, Element, never, Element>;
+const _default_56: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_57: Rule.Atomic<Page, Group<Element>, Question.Metadata, Group<Element>>;
+const _default_57: Rule.Atomic<Page, Group<Element<string>>, Question.Metadata, Group<Element<string>>>;
 
 // @public (undocumented)
-const _default_58: Rule.Atomic<Page, Group<Element>, never, Group<Element>>;
+const _default_58: Rule.Atomic<Page, Group<Element<string>>, never, Group<Element<string>>>;
 
 // @public (undocumented)
 const _default_59: Rule.Atomic<Page, Text, never, Text>;
 
 // @public (undocumented)
-const _default_6: Rule.Atomic<Page, Element, never, Element>;
+const _default_6: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
 const _default_60: Rule.Atomic<Page, Document, never, Document>;
 
 // @public (undocumented)
-const _default_61: Rule.Atomic<Page, Element, never, Element>;
+const _default_61: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
 const _default_62: Rule.Atomic<Page, Document, never, Document>;
 
 // @public (undocumented)
-const _default_63: Rule.Atomic<Page, Element, never, Element>;
+const _default_63: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_64: Rule.Atomic<Page, Element, never, Element>;
+const _default_64: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_65: Rule.Atomic<Page, Element, never, Element>;
+const _default_65: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_66: Rule.Atomic<Page, Element, Question.Metadata, Element>;
+const _default_66: Rule.Atomic<Page, Element<string>, Question.Metadata, Element<string>>;
 
 // @public (undocumented)
 const _default_67: Rule.Atomic<Page, Text, Question.Metadata, Text>;
 
 // @public (undocumented)
-const _default_68: Rule.Atomic<Page, Element, never, Element>;
+const _default_68: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_69: Rule.Atomic<Page, Element, never, Element>;
+const _default_69: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_7: Rule.Atomic<Page, Element, never, Element>;
+const _default_7: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
 const _default_70: Rule.Atomic<Page, Text, Question.Metadata, Text>;
@@ -231,79 +231,79 @@ const _default_70: Rule.Atomic<Page, Text, Question.Metadata, Text>;
 const _default_71: Rule.Atomic<Page, Document, never, Document>;
 
 // @public (undocumented)
-const _default_72: Rule.Atomic<Page, Element, never, Element>;
+const _default_72: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_73: Rule.Atomic<Page, Element, never, Element>;
+const _default_73: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_74: Rule.Atomic<Page, Element, never, Element>;
+const _default_74: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_75: Rule.Atomic<Page, Element, never, Element>;
+const _default_75: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_76: Rule.Atomic<Page, Element, never, Element>;
+const _default_76: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_77: Rule.Atomic<Page, Element, never, Element>;
+const _default_77: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_78: Rule.Atomic<Page, Element, never, Element>;
+const _default_78: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_79: Rule.Atomic<Page, Element, never, Element>;
+const _default_79: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_8: Rule.Atomic<Page, Element, never, Element>;
+const _default_8: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_80: Rule.Atomic<Page, Element, never, Element>;
+const _default_80: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_81: Rule.Atomic<Page, Element, never, Element>;
+const _default_81: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_82: Rule.Atomic<Page, Group<Element>, Question.Metadata, Group<Element>>;
+const _default_82: Rule.Atomic<Page, Group<Element<string>>, Question.Metadata, Group<Element<string>>>;
 
 // @public (undocumented)
 const _default_83: Rule.Atomic<Page, Text, never, Text>;
 
 // @public (undocumented)
-const _default_84: Rule.Atomic<Page, Element, never, Element>;
+const _default_84: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_85: Rule.Atomic<Page, Element, never, Element>;
+const _default_85: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_86: Rule.Atomic<Page, Element, never, Element>;
+const _default_86: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
 const _default_87: Rule.Atomic<Page, Document, Question.Metadata, Document>;
 
 // @public (undocumented)
-const _default_88: Rule.Atomic<Page, Element, never, Element>;
+const _default_88: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_89: Rule.Atomic<Page, Element, never, Element>;
+const _default_89: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_9: Rule.Atomic<Page, Attribute, never, Attribute>;
+const _default_9: Rule.Atomic<Page, Attribute<string>, never, Attribute<string>>;
 
 // @public (undocumented)
-const _default_90: Rule.Atomic<Page, Element, never, Element>;
+const _default_90: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_91: Rule.Atomic<Page, Element, never, Element>;
+const _default_91: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_92: Rule.Atomic<Page, Element, never, Element>;
+const _default_92: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_93: Rule.Atomic<Page, Element, never, Element>;
+const _default_93: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 // @public (undocumented)
-const _default_94: Rule.Atomic<Page, Element, never, Element>;
+const _default_94: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
 declare namespace experimentalRules {
     export {

--- a/packages/alfa-dom/src/h.ts
+++ b/packages/alfa-dom/src/h.ts
@@ -32,12 +32,12 @@ const { nor } = Predicate;
 /**
  * @public
  */
-export function h(
-  name: string,
+export function h<N extends string = string>(
+  name: N,
   attributes?: Array<Attribute> | Record<string, string | boolean>,
   children?: Array<Node | string>,
   style?: Array<Declaration> | Record<string, string>
-): Element {
+): Element<N> {
   return h.element(name, attributes, children, style);
 }
 
@@ -45,12 +45,12 @@ export function h(
  * @public
  */
 export namespace h {
-  export function element(
-    name: string,
+  export function element<N extends string = string>(
+    name: N,
     attributes: Array<Attribute> | Record<string, string | boolean> = [],
     children: Array<Node | string> = [],
     style: Array<Declaration> | Record<string, string> = []
-  ): Element {
+  ): Element<N> {
     attributes = Array.isArray(attributes)
       ? attributes
       : entries(attributes).reduce<Array<Attribute>>(
@@ -105,7 +105,10 @@ export namespace h {
     return element;
   }
 
-  export function attribute(name: string, value: string): Attribute {
+  export function attribute<N extends string = string>(
+    name: N,
+    value: string
+  ): Attribute<N> {
     return Attribute.of(None, None, name, value);
   }
 
@@ -139,11 +142,11 @@ export namespace h {
     );
   }
 
-  export function type(
-    name: string,
+  export function type<N extends string = string>(
+    name: N,
     publicId?: string,
     systemId?: string
-  ): Type {
+  ): Type<N> {
     return Type.of(name, Option.from(publicId), Option.from(systemId));
   }
 

--- a/packages/alfa-dom/src/jsx.ts
+++ b/packages/alfa-dom/src/jsx.ts
@@ -9,11 +9,11 @@ const { entries } = Object;
 /**
  * @public
  */
-export function jsx(
-  name: string,
+export function jsx<N extends string = string>(
+  name: N,
   properties: jsx.Properties | null = null,
   ...children: jsx.Children
-): Element {
+): Element<N> {
   const attributes: Record<string, string | boolean> = {};
   const style: Record<string, string> = {};
 
@@ -80,7 +80,7 @@ export namespace jsx {
    * as it might provide an opportunity to get rid of this namespace entirely.
    */
   export namespace JSX {
-    export type Element = dom.Element;
+    export type Element<N extends string = string> = dom.Element<N>;
 
     export interface IntrinsicElements {
       [tag: string]: Properties;

--- a/packages/alfa-dom/src/node.ts
+++ b/packages/alfa-dom/src/node.ts
@@ -464,9 +464,10 @@ export abstract class Node
  * @public
  */
 export namespace Node {
-  export interface JSON {
-    [key: string]: json.JSON;
-    type: string;
+  export interface JSON<T extends string = string> {
+    [key: string]: json.JSON | undefined;
+    type: T;
+    path?: string;
   }
 
   export interface EARL extends earl.EARL {

--- a/packages/alfa-dom/src/node/attribute.ts
+++ b/packages/alfa-dom/src/node/attribute.ts
@@ -191,7 +191,9 @@ export namespace Attribute {
   /**
    * @internal
    */
-  export function fromAttribute(attribute: JSON): Trampoline<Attribute> {
+  export function fromAttribute<N extends string = string>(
+    attribute: JSON<N>
+  ): Trampoline<Attribute<N>> {
     return Trampoline.done(
       Attribute.of(
         Option.from(attribute.namespace as Namespace | null),

--- a/packages/alfa-dom/src/node/attribute.ts
+++ b/packages/alfa-dom/src/node/attribute.ts
@@ -132,6 +132,7 @@ export class Attribute extends Node {
   public toJSON(): Attribute.JSON {
     return {
       type: "attribute",
+      path: this.path(),
       namespace: this._namespace.getOr(null),
       prefix: this._prefix.getOr(null),
       name: this._name,
@@ -175,8 +176,7 @@ export class Attribute extends Node {
  * @public
  */
 export namespace Attribute {
-  export interface JSON extends Node.JSON {
-    type: "attribute";
+  export interface JSON extends Node.JSON<"attribute"> {
     namespace: string | null;
     prefix: string | null;
     name: string;

--- a/packages/alfa-dom/src/node/attribute.ts
+++ b/packages/alfa-dom/src/node/attribute.ts
@@ -16,26 +16,26 @@ const { equals, not } = Predicate;
 /**
  * @public
  */
-export class Attribute extends Node {
-  public static of(
+export class Attribute<N extends string = string> extends Node {
+  public static of<N extends string = string>(
     namespace: Option<Namespace>,
     prefix: Option<string>,
-    name: string,
+    name: N,
     value: string
-  ): Attribute {
+  ): Attribute<N> {
     return new Attribute(namespace, prefix, name, value);
   }
 
   private readonly _namespace: Option<Namespace>;
   private readonly _prefix: Option<string>;
-  private readonly _name: string;
+  private readonly _name: N;
   private readonly _value: string;
   private _owner: Option<Element> = None;
 
   private constructor(
     namespace: Option<Namespace>,
     prefix: Option<string>,
-    name: string,
+    name: N,
     value: string
   ) {
     super([]);
@@ -54,12 +54,12 @@ export class Attribute extends Node {
     return this._prefix;
   }
 
-  public get name(): string {
+  public get name(): N | Lowercase<N> {
     return Attribute.foldCase(this._name, this._owner);
   }
 
   public get qualifiedName(): string {
-    return this._prefix.reduce(
+    return this._prefix.reduce<string>(
       (name, prefix) => `${prefix}:${name}`,
       this._name
     );
@@ -129,7 +129,7 @@ export class Attribute extends Node {
       : None;
   }
 
-  public toJSON(): Attribute.JSON {
+  public toJSON(): Attribute.JSON<N> {
     return {
       type: "attribute",
       path: this.path(),
@@ -176,10 +176,11 @@ export class Attribute extends Node {
  * @public
  */
 export namespace Attribute {
-  export interface JSON extends Node.JSON<"attribute"> {
+  export interface JSON<N extends string = string>
+    extends Node.JSON<"attribute"> {
     namespace: string | null;
     prefix: string | null;
-    name: string;
+    name: N;
     value: string;
   }
 
@@ -207,9 +208,12 @@ export namespace Attribute {
    *
    * @internal
    */
-  export function foldCase(name: string, owner: Option<Element>): string {
+  export function foldCase<N extends string = string>(
+    name: N,
+    owner: Option<Element>
+  ): N | Lowercase<N> {
     return owner.some((owner) => owner.namespace.some(equals(Namespace.HTML)))
-      ? name.toLowerCase()
+      ? (name.toLowerCase() as Lowercase<N>)
       : name;
   }
 

--- a/packages/alfa-dom/src/node/attribute/predicate/has-name.ts
+++ b/packages/alfa-dom/src/node/attribute/predicate/has-name.ts
@@ -1,19 +1,22 @@
 import { Predicate } from "@siteimprove/alfa-predicate";
+import { Refinement } from "@siteimprove/alfa-refinement";
 
 import { Attribute } from "../../attribute";
 
 /**
  * @public
  */
-export function hasName(predicate: Predicate<string>): Predicate<Attribute>;
+export function hasName<N extends string = string>(
+  predicate: Refinement<string, N>
+): Refinement<Attribute, Attribute<N>>;
 
 /**
  * @public
  */
-export function hasName(
-  name: string,
-  ...rest: Array<string>
-): Predicate<Attribute>;
+export function hasName<N extends string = string>(
+  name: N,
+  ...rest: Array<N>
+): Refinement<Attribute, Attribute<N>>;
 
 export function hasName(
   nameOrPredicate: string | Predicate<string>,

--- a/packages/alfa-dom/src/node/comment.ts
+++ b/packages/alfa-dom/src/node/comment.ts
@@ -44,6 +44,7 @@ export class Comment extends Node {
   public toJSON(): Comment.JSON {
     return {
       type: "comment",
+      path: this.path(),
       data: this._data,
     };
   }
@@ -57,8 +58,7 @@ export class Comment extends Node {
  * @public
  */
 export namespace Comment {
-  export interface JSON extends Node.JSON {
-    type: "comment";
+  export interface JSON extends Node.JSON<"comment"> {
     data: string;
   }
 

--- a/packages/alfa-dom/src/node/document.ts
+++ b/packages/alfa-dom/src/node/document.ts
@@ -54,6 +54,7 @@ export class Document extends Node {
   public toJSON(): Document.JSON {
     return {
       type: "document",
+      path: this.path(),
       children: this._children.map((child) => child.toJSON()),
       style: this._style.map((sheet) => sheet.toJSON()),
     };
@@ -93,8 +94,7 @@ export class Document extends Node {
  * @public
  */
 export namespace Document {
-  export interface JSON extends Node.JSON {
-    type: "document";
+  export interface JSON extends Node.JSON<"document"> {
     children: Array<Node.JSON>;
     style: Array<Sheet.JSON>;
   }

--- a/packages/alfa-dom/src/node/element.ts
+++ b/packages/alfa-dom/src/node/element.ts
@@ -368,7 +368,9 @@ export namespace Element {
   /**
    * @internal
    */
-  export function fromElement(json: JSON): Trampoline<Element> {
+  export function fromElement<N extends string = string>(
+    json: JSON<N>
+  ): Trampoline<Element<N>> {
     return Trampoline.traverse(json.children, Node.fromNode).map((children) => {
       const element = Element.of(
         Option.from(json.namespace as Namespace | null),

--- a/packages/alfa-dom/src/node/element.ts
+++ b/packages/alfa-dom/src/node/element.ts
@@ -273,6 +273,7 @@ export class Element extends Node implements Slot, Slotable {
   public toJSON(): Element.JSON {
     return {
       type: "element",
+      path: this.path(),
       namespace: this._namespace.getOr(null),
       prefix: this._prefix.getOr(null),
       name: this._name,
@@ -343,8 +344,7 @@ export class Element extends Node implements Slot, Slotable {
  * @public
  */
 export namespace Element {
-  export interface JSON extends Node.JSON {
-    type: "element";
+  export interface JSON extends Node.JSON<"element"> {
     namespace: string | null;
     prefix: string | null;
     name: string;

--- a/packages/alfa-dom/src/node/element.ts
+++ b/packages/alfa-dom/src/node/element.ts
@@ -21,15 +21,18 @@ const { not } = Predicate;
 /**
  * @public
  */
-export class Element extends Node implements Slot, Slotable {
-  public static of(
+export class Element<N extends string = string>
+  extends Node
+  implements Slot, Slotable
+{
+  public static of<N extends string = string>(
     namespace: Option<Namespace>,
     prefix: Option<string>,
-    name: string,
+    name: N,
     attributes: Iterable<Attribute> = [],
     children: Iterable<Node> = [],
     style: Option<Block> = None
-  ): Element {
+  ): Element<N> {
     return new Element(
       namespace,
       prefix,
@@ -42,7 +45,7 @@ export class Element extends Node implements Slot, Slotable {
 
   private readonly _namespace: Option<Namespace>;
   private readonly _prefix: Option<string>;
-  private readonly _name: string;
+  private readonly _name: N;
   private readonly _attributes: Map<string, Attribute>;
   private readonly _style: Option<Block>;
   private _shadow: Option<Shadow> = None;
@@ -53,7 +56,7 @@ export class Element extends Node implements Slot, Slotable {
   private constructor(
     namespace: Option<Namespace>,
     prefix: Option<string>,
-    name: string,
+    name: N,
     attributes: Array<Attribute>,
     children: Array<Node>,
     style: Option<Block>
@@ -85,12 +88,12 @@ export class Element extends Node implements Slot, Slotable {
     return this._prefix;
   }
 
-  public get name(): string {
+  public get name(): N {
     return this._name;
   }
 
   public get qualifiedName(): string {
-    return this._prefix.reduce(
+    return this._prefix.reduce<string>(
       (name, prefix) => `${prefix}:${name}`,
       this._name
     );
@@ -178,9 +181,11 @@ export class Element extends Node implements Slot, Slotable {
     return Sequence.from(children);
   }
 
-  public attribute(name: string): Option<Attribute>;
+  public attribute<A extends string = string>(name: A): Option<Attribute<A>>;
 
-  public attribute(predicate: Predicate<Attribute>): Option<Attribute>;
+  public attribute<A extends string = string>(
+    predicate: Predicate<Attribute<A>>
+  ): Option<Attribute<A>>;
 
   public attribute(
     nameOrPredicate: string | Predicate<Attribute>
@@ -270,7 +275,7 @@ export class Element extends Node implements Slot, Slotable {
     return path;
   }
 
-  public toJSON(): Element.JSON {
+  public toJSON(): Element.JSON<N> {
     return {
       type: "element",
       path: this.path(),
@@ -344,10 +349,11 @@ export class Element extends Node implements Slot, Slotable {
  * @public
  */
 export namespace Element {
-  export interface JSON extends Node.JSON<"element"> {
+  export interface JSON<N extends string = string>
+    extends Node.JSON<"element"> {
     namespace: string | null;
     prefix: string | null;
-    name: string;
+    name: N;
     attributes: Array<Attribute.JSON>;
     style: Block.JSON | null;
     children: Array<Node.JSON>;

--- a/packages/alfa-dom/src/node/element/predicate/has-name.ts
+++ b/packages/alfa-dom/src/node/element/predicate/has-name.ts
@@ -1,4 +1,5 @@
 import { Predicate } from "@siteimprove/alfa-predicate";
+import { Refinement } from "@siteimprove/alfa-refinement";
 
 import { Element } from "../../element";
 
@@ -7,15 +8,17 @@ const { equals } = Predicate;
 /**
  * @public
  */
-export function hasName(predicate: Predicate<string>): Predicate<Element>;
+export function hasName<N extends string = string>(
+  predicate: Refinement<string, N>
+): Refinement<Element, Element<N>>;
 
 /**
  * @public
  */
-export function hasName(
-  name: string,
-  ...rest: Array<string>
-): Predicate<Element>;
+export function hasName<N extends string = string>(
+  name: N,
+  ...rest: Array<N>
+): Refinement<Element, Element<N>>;
 
 export function hasName(
   nameOrPredicate: string | Predicate<string>,

--- a/packages/alfa-dom/src/node/element/predicate/is-suggested-focusable.ts
+++ b/packages/alfa-dom/src/node/element/predicate/is-suggested-focusable.ts
@@ -39,10 +39,13 @@ export function isSuggestedFocusable(element: Element): boolean {
         .some(
           (parent) =>
             parent.name === "details" &&
+            // Checking that element is the first <summary> child of parent.
             parent
               .children()
               .filter(Element.isElement)
-              .find(Element.hasName("summary"))
+              // Switching on element.name does not narrow the type, so we must
+              // keep it as Element<string>.
+              .find(Element.hasName<string>("summary"))
               .includes(element)
         );
   }

--- a/packages/alfa-dom/src/node/fragment.ts
+++ b/packages/alfa-dom/src/node/fragment.ts
@@ -25,6 +25,7 @@ export class Fragment extends Node {
   public toJSON(): Fragment.JSON {
     return {
       type: "fragment",
+      path: this.path(),
       children: this._children.map((child) => child.toJSON()),
     };
   }
@@ -49,8 +50,7 @@ export class Fragment extends Node {
  * @public
  */
 export namespace Fragment {
-  export interface JSON extends Node.JSON {
-    type: "fragment";
+  export interface JSON extends Node.JSON<"fragment"> {
     children: Array<Node.JSON>;
   }
 

--- a/packages/alfa-dom/src/node/text.ts
+++ b/packages/alfa-dom/src/node/text.ts
@@ -71,6 +71,7 @@ export class Text extends Node implements Slotable {
   public toJSON(): Text.JSON {
     return {
       type: "text",
+      path: this.path(),
       data: this.data,
     };
   }
@@ -84,8 +85,7 @@ export class Text extends Node implements Slotable {
  * @public
  */
 export namespace Text {
-  export interface JSON extends Node.JSON {
-    type: "text";
+  export interface JSON extends Node.JSON<"text"> {
     data: string;
   }
 

--- a/packages/alfa-dom/src/node/type.ts
+++ b/packages/alfa-dom/src/node/type.ts
@@ -79,7 +79,9 @@ export namespace Type {
   /**
    * @internal
    */
-  export function fromType(json: JSON): Trampoline<Type> {
+  export function fromType<N extends string = string>(
+    json: JSON<N>
+  ): Trampoline<Type<N>> {
     return Trampoline.done(
       Type.of(json.name, Option.from(json.publicId), Option.from(json.systemId))
     );

--- a/packages/alfa-dom/src/node/type.ts
+++ b/packages/alfa-dom/src/node/type.ts
@@ -6,12 +6,12 @@ import { Node } from "../node";
 /**
  * @public
  */
-export class Type extends Node {
-  public static of(
-    name: string,
+export class Type<N extends string = string> extends Node {
+  public static of<N extends string = string>(
+    name: N,
     publicId: Option<string> = None,
     systemId: Option<string> = None
-  ): Type {
+  ): Type<N> {
     return new Type(name, publicId, systemId);
   }
 
@@ -19,12 +19,12 @@ export class Type extends Node {
     return new Type("html", None, None);
   }
 
-  private readonly _name: string;
+  private readonly _name: N;
   private readonly _publicId: Option<string>;
   private readonly _systemId: Option<string>;
 
   private constructor(
-    name: string,
+    name: N,
     publicId: Option<string>,
     systemId: Option<string>
   ) {
@@ -35,7 +35,7 @@ export class Type extends Node {
     this._systemId = systemId;
   }
 
-  public get name(): string {
+  public get name(): N {
     return this._name;
   }
 
@@ -47,7 +47,7 @@ export class Type extends Node {
     return this._systemId;
   }
 
-  public toJSON(): Type.JSON {
+  public toJSON(): Type.JSON<N> {
     return {
       type: "type",
       path: this.path(),
@@ -66,8 +66,8 @@ export class Type extends Node {
  * @public
  */
 export namespace Type {
-  export interface JSON extends Node.JSON<"type"> {
-    name: string;
+  export interface JSON<N extends string = string> extends Node.JSON<"type"> {
+    name: N;
     publicId: string | null;
     systemId: string | null;
   }

--- a/packages/alfa-dom/src/node/type.ts
+++ b/packages/alfa-dom/src/node/type.ts
@@ -50,6 +50,7 @@ export class Type extends Node {
   public toJSON(): Type.JSON {
     return {
       type: "type",
+      path: this.path(),
       name: this._name,
       publicId: this._publicId.getOr(null),
       systemId: this._systemId.getOr(null),
@@ -65,8 +66,7 @@ export class Type extends Node {
  * @public
  */
 export namespace Type {
-  export interface JSON extends Node.JSON {
-    type: "type";
+  export interface JSON extends Node.JSON<"type"> {
     name: string;
     publicId: string | null;
     systemId: string | null;


### PR DESCRIPTION
Add a `path` property to DOM nodes JSON serialisation, to match EARL and SARIF ones.
Unfortunately, we can't make it mandatory because this serialisation is also our (input) interface with native DOM or Dory. Native DOM does not provide an easy way to find the node's path, and there is no need to change Dory for that.

Also adds some improved typing of nodes that are named (Element, Attribute, Type) and their serialisation.