### PR TITLE
Replace Questions' message by Diagnostic

### DIFF
--- a/docs/review/api/alfa-act.api.md
+++ b/docs/review/api/alfa-act.api.md
@@ -386,7 +386,7 @@ export namespace Outcome {
 
 // @public
 export class Question<TYPE, SUBJECT, CONTEXT, ANSWER, T = ANSWER, URI extends string = string> implements Functor<T>, Applicative<T>, Monad<T>, Serializable<Question.JSON<TYPE, SUBJECT, CONTEXT, URI>> {
-    protected constructor(type: TYPE, uri: URI, message: string, subject: SUBJECT, context: CONTEXT, quester: Mapper<ANSWER, T>);
+    protected constructor(type: TYPE, uri: URI, diagnostic: Diagnostic, subject: SUBJECT, context: CONTEXT, quester: Mapper<ANSWER, T>);
     // (undocumented)
     answer(answer: ANSWER): T;
     // (undocumented)
@@ -404,6 +404,10 @@ export class Question<TYPE, SUBJECT, CONTEXT, ANSWER, T = ANSWER, URI extends st
     // (undocumented)
     protected readonly _context: CONTEXT;
     // (undocumented)
+    get diagnostic(): Diagnostic;
+    // (undocumented)
+    protected readonly _diagnostic: Diagnostic;
+    // (undocumented)
     flatMap<U>(mapper: Mapper<T, Question<TYPE, SUBJECT, CONTEXT, ANSWER, U, URI>>): Question<TYPE, SUBJECT, CONTEXT, ANSWER, U, URI>;
     // (undocumented)
     flatten<TYPE, SUBJECT, CONTEXT, ANSWER, T>(this: Question<TYPE, SUBJECT, CONTEXT, ANSWER, Question<TYPE, SUBJECT, CONTEXT, ANSWER, T>>): Question<TYPE, SUBJECT, CONTEXT, ANSWER, T>;
@@ -412,11 +416,7 @@ export class Question<TYPE, SUBJECT, CONTEXT, ANSWER, T = ANSWER, URI extends st
     // (undocumented)
     map<U>(mapper: Mapper<T, U>): Question<TYPE, SUBJECT, CONTEXT, ANSWER, U, URI>;
     // (undocumented)
-    get message(): string;
-    // (undocumented)
-    protected readonly _message: string;
-    // (undocumented)
-    static of<TYPE, SUBJECT, CONTEXT, ANSWER, URI extends string = string>(type: TYPE, uri: URI, message: string, subject: SUBJECT, context: CONTEXT): Question<TYPE, SUBJECT, CONTEXT, ANSWER, ANSWER, URI>;
+    static of<TYPE, SUBJECT, CONTEXT, ANSWER, URI extends string = string>(type: TYPE, uri: URI, diagnostic: Diagnostic, subject: SUBJECT, context: CONTEXT): Question<TYPE, SUBJECT, CONTEXT, ANSWER, ANSWER, URI>;
     // (undocumented)
     protected readonly _quester: Mapper<ANSWER, T>;
     // (undocumented)
@@ -446,7 +446,7 @@ export namespace Question {
         // (undocumented)
         context: Serializable.ToJSON<CONTEXT>;
         // (undocumented)
-        message: string;
+        diagnostic: Diagnostic.JSON;
         // (undocumented)
         subject: Serializable.ToJSON<SUBJECT>;
         // (undocumented)
@@ -456,7 +456,7 @@ export namespace Question {
     }
     // @internal
     export class Rhetorical<TYPE, SUBJECT, CONTEXT, ANSWER, T = ANSWER, URI extends string = string> extends Question<TYPE, SUBJECT, CONTEXT, ANSWER, T, URI> {
-        constructor(type: TYPE, uri: URI, message: string, subject: SUBJECT, context: CONTEXT, answer: T);
+        constructor(type: TYPE, uri: URI, diagnostic: Diagnostic, subject: SUBJECT, context: CONTEXT, answer: T);
         // (undocumented)
         answer(): T;
         // (undocumented)

--- a/docs/review/api/alfa-rules.api.md
+++ b/docs/review/api/alfa-rules.api.md
@@ -7,6 +7,7 @@
 import * as act from '@siteimprove/alfa-act';
 import { Array as Array_2 } from '@siteimprove/alfa-array';
 import { Attribute } from '@siteimprove/alfa-dom';
+import { Diagnostic } from '@siteimprove/alfa-act';
 import { Document } from '@siteimprove/alfa-dom';
 import * as earl from '@siteimprove/alfa-earl';
 import { Element } from '@siteimprove/alfa-dom';
@@ -374,9 +375,9 @@ export namespace Question {
         [K in Uri]: [Data[K]["type"], Type[Data[K]["type"]]];
     };
     // (undocumented)
-    export function of<S, U extends Uri = Uri>(uri: U, subject: S, message?: string): act.Question<Data[U]["type"], S, S, Type[Data[U]["type"]], Type[Data[U]["type"]], U>;
+    export function of<S, U extends Uri = Uri>(uri: U, subject: S, diagnostic?: Diagnostic): act.Question<Data[U]["type"], S, S, Type[Data[U]["type"]], Type[Data[U]["type"]], U>;
     // (undocumented)
-    export function of<S, C, U extends Uri = Uri>(uri: U, subject: S, context: C, message?: string): act.Question<Data[U]["type"], S, C, Type[Data[U]["type"]], Type[Data[U]["type"]], U>;
+    export function of<S, C, U extends Uri = Uri>(uri: U, subject: S, context: C, diagnostic?: Diagnostic): act.Question<Data[U]["type"], S, C, Type[Data[U]["type"]], Type[Data[U]["type"]], U>;
     export interface Type {
         // (undocumented)
         "color[]": Iterable<RGB>;
@@ -403,7 +404,7 @@ export namespace Question {
         };
         readonly "has-audio-track": {
             readonly type: "boolean";
-            readonly message: "Does the `<video>` element have an audio track that describes its\n            visual information?";
+            readonly message: "Does the `<video>` element have an audio track that describes its visual information?";
         };
         readonly "has-captions": {
             readonly type: "boolean";
@@ -411,7 +412,7 @@ export namespace Question {
         };
         readonly "has-description": {
             readonly type: "boolean";
-            readonly message: "Is the visual information of the [audio/video] available through its\n            audio or a separate audio description track?";
+            readonly message: "Is the visual information of the [audio/video] available through its audio or a separate audio description track?";
         };
         readonly "is-audio-streaming": {
             readonly type: "boolean";
@@ -431,7 +432,7 @@ export namespace Question {
         };
         readonly "play-button": {
             readonly type: "node";
-            readonly message: "Where is the button that controls playback of the `<audio>`\n                    element?";
+            readonly message: "Where is the button that controls playback of the `<audio>` element?";
         };
         readonly "text-alternative": {
             readonly type: "node";
@@ -439,7 +440,7 @@ export namespace Question {
         };
         readonly "track-describes-video": {
             readonly type: "boolean";
-            readonly message: "Does at least 1 track describe the visual information of the `<video>`\n      element, either in the language of the `<video>` element or the language\n      of the page?";
+            readonly message: "Does at least 1 track describe the visual information of the `<video>` element, either in the language of the `<video>` element or the language of the page?";
         };
         readonly transcript: {
             readonly type: "node";
@@ -455,19 +456,19 @@ export namespace Question {
         };
         readonly "name-describes-purpose": {
             readonly type: "boolean";
-            readonly message: "Does the accessible name of the `<(target.name]>` element\n            describe its purpose?";
+            readonly message: "Does the accessible name of the `<(target.name]>` element describe its purpose?";
         };
         readonly "audio-control-mechanism": {
             readonly type: "node";
-            readonly message: "Where is the mechanism that can pause or stop the audio of the\n            `<[target.name]>` element?";
+            readonly message: "Where is the mechanism that can pause or stop the audio of the `<[target.name]>` element?";
         };
         readonly "is-above-duration-threshold": {
             readonly type: "boolean";
-            readonly message: "Does the `<[element.name]>` element have a duration of more\n              than 3 seconds?";
+            readonly message: "Does the `<[element.name]>` element have a duration of more than 3 seconds?";
         };
         readonly "is-below-audio-duration-threshold": {
             readonly type: "boolean";
-            readonly message: "Does the `<[target.name]>` element have a total audio duration\n            of less than 3 seconds?";
+            readonly message: "Does the `<[target.name]>` element have a total audio duration of less than 3 seconds?";
         };
         readonly "is-content-equivalent": {
             readonly type: "boolean";
@@ -507,7 +508,7 @@ export namespace Question {
         };
         readonly "error-indicator-describes-resolution": {
             readonly type: "boolean";
-            readonly message: "Does the error indicator describe, in text, the cause of the error or how\n      to resolve it?";
+            readonly message: "Does the error indicator describe, in text, the cause of the error or how to resolve it?";
         };
         readonly "error-indicator-identifies-form-field": {
             readonly type: "boolean";

--- a/packages/alfa-act/src/question.ts
+++ b/packages/alfa-act/src/question.ts
@@ -9,6 +9,7 @@ import { Refinement } from "@siteimprove/alfa-refinement";
 import { Result } from "@siteimprove/alfa-result";
 
 import * as json from "@siteimprove/alfa-json";
+import { Diagnostic } from "./diagnostic";
 
 const { isOption } = Option;
 const { isBoolean, isFunction } = Refinement;
@@ -44,14 +45,14 @@ export class Question<
   public static of<TYPE, SUBJECT, CONTEXT, ANSWER, URI extends string = string>(
     type: TYPE,
     uri: URI,
-    message: string,
+    diagnostic: Diagnostic,
     subject: SUBJECT,
     context: CONTEXT
   ): Question<TYPE, SUBJECT, CONTEXT, ANSWER, ANSWER, URI> {
     return new Question(
       type,
       uri,
-      message,
+      diagnostic,
       subject,
       context,
       (answer) => answer
@@ -60,7 +61,7 @@ export class Question<
 
   protected readonly _type: TYPE;
   protected readonly _uri: URI;
-  protected readonly _message: string;
+  protected readonly _diagnostic: Diagnostic;
   protected readonly _subject: SUBJECT;
   protected readonly _context: CONTEXT;
   protected readonly _quester: Mapper<ANSWER, T>;
@@ -68,14 +69,14 @@ export class Question<
   protected constructor(
     type: TYPE,
     uri: URI,
-    message: string,
+    diagnostic: Diagnostic,
     subject: SUBJECT,
     context: CONTEXT,
     quester: Mapper<ANSWER, T>
   ) {
     this._type = type;
     this._uri = uri;
-    this._message = normalize(message);
+    this._diagnostic = diagnostic;
     this._subject = subject;
     this._context = context;
     this._quester = quester;
@@ -89,8 +90,8 @@ export class Question<
     return this._uri;
   }
 
-  public get message(): string {
-    return this._message;
+  public get diagnostic(): Diagnostic {
+    return this._diagnostic;
   }
 
   public get subject(): SUBJECT {
@@ -166,7 +167,7 @@ export class Question<
       ? new Question.Rhetorical(
           this._type,
           this._uri,
-          this._message,
+          this._diagnostic,
           this._subject,
           this._context,
           this.answer(answer!)
@@ -180,7 +181,7 @@ export class Question<
     return new Question(
       this._type,
       this._uri,
-      this._message,
+      this._diagnostic,
       this._subject,
       this._context,
       (answer) => mapper(this._quester(answer))
@@ -199,7 +200,7 @@ export class Question<
     return new Question(
       this._type,
       this._uri,
-      this._message,
+      this._diagnostic,
       this._subject,
       this._context,
       (answer) => mapper(this._quester(answer))._quester(answer)
@@ -218,7 +219,7 @@ export class Question<
     return new Question(
       this._type,
       this._uri,
-      this._message,
+      this._diagnostic,
       this._subject,
       this._context,
       (answer) => this._quester(answer)._quester(answer)
@@ -229,7 +230,7 @@ export class Question<
     return {
       type: Serializable.toJSON(this._type),
       uri: this._uri,
-      message: this._message,
+      diagnostic: this._diagnostic.toJSON(),
       subject: Serializable.toJSON(this._subject),
       context: Serializable.toJSON(this._context),
     };
@@ -244,7 +245,7 @@ export namespace Question {
     [key: string]: json.JSON;
     type: Serializable.ToJSON<TYPE>;
     uri: URI;
-    message: string;
+    diagnostic: Diagnostic.JSON;
     subject: Serializable.ToJSON<SUBJECT>;
     context: Serializable.ToJSON<CONTEXT>;
   }
@@ -282,12 +283,12 @@ export namespace Question {
     public constructor(
       type: TYPE,
       uri: URI,
-      message: string,
+      diagnostic: Diagnostic,
       subject: SUBJECT,
       context: CONTEXT,
       answer: T
     ) {
-      super(type, uri, message, subject, context, () => answer);
+      super(type, uri, diagnostic, subject, context, () => answer);
       this._answer = answer;
     }
 
@@ -306,15 +307,11 @@ export namespace Question {
       return new Rhetorical(
         this._type,
         this._uri,
-        this._message,
+        this._diagnostic,
         this._subject,
         this._context,
         mapper(this._answer)
       );
     }
   }
-}
-
-function normalize(string: string): string {
-  return string.replace(/\s+/g, " ").trim();
 }

--- a/packages/alfa-assert/test/fixture/rule.ts
+++ b/packages/alfa-assert/test/fixture/rule.ts
@@ -56,7 +56,13 @@ export const CantTell = (uri: string) =>
             string,
             boolean,
             "is-passed"
-          >("boolean", "is-passed", "Does the rule pass?", target, target);
+          >(
+            "boolean",
+            "is-passed",
+            Diagnostic.of("Does the rule pass?"),
+            target,
+            target
+          );
           return {
             1: isPassed.map((passed) =>
               passed

--- a/packages/alfa-rules/src/common/expectation/media-text-alternative.ts
+++ b/packages/alfa-rules/src/common/expectation/media-text-alternative.ts
@@ -65,13 +65,15 @@ export function audioTextAlternative(target: Element, device: Device) {
   const alt = Question.of(
     "text-alternative",
     target,
-    `Where is the text alternative of the \`<audio>\` element?`
+    Diagnostic.of(`Where is the text alternative of the \`<audio>\` element?`)
   );
 
   const label = Question.of(
     "label",
     target,
-    `Where is the text that labels the \`<audio>\` element as a video alternative?`
+    Diagnostic.of(
+      `Where is the text that labels the \`<audio>\` element as a video alternative?`
+    )
   );
 
   return mediaTextAlternative(alt, label, device, "<video>");
@@ -81,13 +83,15 @@ export function videoTextAlternative(target: Element, device: Device) {
   const alt = Question.of(
     "text-alternative",
     target,
-    `Where is the text alternative of the \`<video>\` element?`
+    Diagnostic.of(`Where is the text alternative of the \`<video>\` element?`)
   );
 
   const label = Question.of(
     "label",
     target,
-    `Where is the text that labels the \`<video>\` element as a video alternative?`
+    Diagnostic.of(
+      `Where is the text that labels the \`<video>\` element as a video alternative?`
+    )
   );
 
   return mediaTextAlternative(alt, label, device, "<video>");

--- a/packages/alfa-rules/src/common/question.ts
+++ b/packages/alfa-rules/src/common/question.ts
@@ -113,8 +113,7 @@ export namespace Question {
     },
     "has-audio-track": {
       type: "boolean",
-      message: `Does the \`<video>\` element have an audio track that describes its
-            visual information?`,
+      message: `Does the \`<video>\` element have an audio track that describes its visual information?`,
     },
     "has-captions": {
       type: "boolean",
@@ -122,8 +121,7 @@ export namespace Question {
     },
     "has-description": {
       type: "boolean",
-      message: `Is the visual information of the [audio/video] available through its
-            audio or a separate audio description track?`,
+      message: `Is the visual information of the [audio/video] available through its audio or a separate audio description track?`,
     },
     "is-audio-streaming": {
       type: "boolean",
@@ -143,8 +141,7 @@ export namespace Question {
     },
     "play-button": {
       type: "node",
-      message: `Where is the button that controls playback of the \`<audio>\`
-                    element?`,
+      message: `Where is the button that controls playback of the \`<audio>\` element?`,
     },
     "text-alternative": {
       type: "node",
@@ -152,9 +149,7 @@ export namespace Question {
     },
     "track-describes-video": {
       type: "boolean",
-      message: `Does at least 1 track describe the visual information of the \`<video>\`
-      element, either in the language of the \`<video>\` element or the language
-      of the page?`,
+      message: `Does at least 1 track describe the visual information of the \`<video>\` element, either in the language of the \`<video>\` element or the language of the page?`,
     },
     transcript: {
       type: "node",
@@ -172,24 +167,20 @@ export namespace Question {
     // R39
     "name-describes-purpose": {
       type: "boolean",
-      message: `Does the accessible name of the \`<(target.name]>\` element
-            describe its purpose?`,
+      message: `Does the accessible name of the \`<(target.name]>\` element describe its purpose?`,
     },
     // R50 [R48, R49]
     "audio-control-mechanism": {
       type: "node",
-      message: `Where is the mechanism that can pause or stop the audio of the
-            \`<[target.name]>\` element?`,
+      message: `Where is the mechanism that can pause or stop the audio of the \`<[target.name]>\` element?`,
     },
     "is-above-duration-threshold": {
       type: "boolean",
-      message: `Does the \`<[element.name]>\` element have a duration of more
-              than 3 seconds?`,
+      message: `Does the \`<[element.name]>\` element have a duration of more than 3 seconds?`,
     },
     "is-below-audio-duration-threshold": {
       type: "boolean",
-      message: `Does the \`<[target.name]>\` element have a total audio duration
-            of less than 3 seconds?`,
+      message: `Does the \`<[target.name]>\` element have a total audio duration of less than 3 seconds?`,
     },
     // R55
     "is-content-equivalent": {
@@ -234,8 +225,7 @@ export namespace Question {
     },
     "error-indicator-describes-resolution": {
       type: "boolean",
-      message: `Does the error indicator describe, in text, the cause of the error or how
-      to resolve it?`,
+      message: `Does the error indicator describe, in text, the cause of the error or how to resolve it?`,
     },
     "error-indicator-identifies-form-field": {
       type: "boolean",

--- a/packages/alfa-rules/src/common/question.ts
+++ b/packages/alfa-rules/src/common/question.ts
@@ -1,3 +1,4 @@
+import { Diagnostic } from "@siteimprove/alfa-act";
 import { RGB } from "@siteimprove/alfa-css";
 import { Node } from "@siteimprove/alfa-dom";
 import { Option } from "@siteimprove/alfa-option";
@@ -50,7 +51,7 @@ export namespace Question {
   export function of<S, U extends Uri = Uri>(
     uri: U,
     subject: S,
-    message?: string
+    diagnostic?: Diagnostic
   ): act.Question<
     Data[U]["type"],
     S,
@@ -64,7 +65,7 @@ export namespace Question {
     uri: U,
     subject: S,
     context: C,
-    message?: string
+    diagnostic?: Diagnostic
   ): act.Question<
     Data[U]["type"],
     S,
@@ -77,8 +78,8 @@ export namespace Question {
   export function of<S, U extends Uri = Uri>(
     uri: U,
     subject: S,
-    contextOrMessage?: S | string,
-    message?: string
+    contextOrDiagnostic?: S | Diagnostic,
+    diagnostic?: Diagnostic
   ): act.Question<
     Data[U]["type"],
     S,
@@ -88,18 +89,13 @@ export namespace Question {
     U
   > {
     let context: S = subject;
-    if (
-      // We assume that no context will be a string.
-      // Since contexts are guaranteed to be test targets, this is OK. They are
-      // more likely to be text nodes that the actual text in it.
-      typeof contextOrMessage === "string"
-    ) {
-      message = contextOrMessage;
+    if (Diagnostic.isDiagnostic(contextOrDiagnostic)) {
+      diagnostic = contextOrDiagnostic;
     } else {
-      context = contextOrMessage ?? subject;
-      message = message ?? Data[uri].message;
+      context = contextOrDiagnostic ?? subject;
+      diagnostic = diagnostic ?? Diagnostic.of(Data[uri].message);
     }
-    return act.Question.of(Data[uri].type, uri, message, subject, context);
+    return act.Question.of(Data[uri].type, uri, diagnostic, subject, context);
   }
 
   const Data = {

--- a/packages/alfa-rules/src/sia-r15/rule.ts
+++ b/packages/alfa-rules/src/sia-r15/rule.ts
@@ -66,7 +66,9 @@ export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
               Question.of(
                 "reference-equivalent-resources",
                 target,
-                "Do the <iframe> elements embed equivalent resources?"
+                Diagnostic.of(
+                  "Do the <iframe> elements embed equivalent resources?"
+                )
               ).map((embedEquivalentResources) =>
                 expectation(
                   embedEquivalentResources,

--- a/packages/alfa-rules/src/sia-r23/rule.ts
+++ b/packages/alfa-rules/src/sia-r23/rule.ts
@@ -30,14 +30,15 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
           1: Question.of(
             "transcript",
             target,
-            `Where is the transcript of the \`<audio>\` element?`
+            Diagnostic.of(`Where is the transcript of the \`<audio>\` element?`)
           ).map((transcript) => {
             if (transcript.isNone()) {
               return Question.of(
                 "transcript-link",
                 target,
-                `Where is the link pointing to the transcript of the \`<audio>\`
-                element?`
+                Diagnostic.of(
+                  `Where is the link pointing to the transcript of the \`<audio>\` element?`
+                )
               ).map((transcriptLink) => {
                 if (transcriptLink.isNone()) {
                   return Option.of(Outcomes.HasNoTranscript);
@@ -54,7 +55,9 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
                 return Question.of(
                   "transcript-perceivable",
                   target,
-                  `Is the transcript of the \`<audio>\` element perceivable?`
+                  Diagnostic.of(
+                    `Is the transcript of the \`<audio>\` element perceivable?`
+                  )
                 ).map((isPerceivable) =>
                   expectation(
                     isPerceivable,

--- a/packages/alfa-rules/src/sia-r24/rule.ts
+++ b/packages/alfa-rules/src/sia-r24/rule.ts
@@ -26,7 +26,7 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
           1: Question.of(
             "transcript",
             target,
-            `Where is the transcript of the \`<video>\` element?`
+            Diagnostic.of(`Where is the transcript of the \`<video>\` element?`)
           ).map((transcript) =>
             expectation(
               transcript.isSome(),
@@ -35,8 +35,9 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
                 Question.of(
                   "transcript-link",
                   target,
-                  `Where is the link pointing to the transcript of the \`<video>\`
-                  element?`
+                  Diagnostic.of(
+                    `Where is the link pointing to the transcript of the \`<video>\` element?`
+                  )
                 ).map((transcriptLink) =>
                   expectation(
                     transcriptLink.isSome(),

--- a/packages/alfa-rules/src/sia-r25/rule.ts
+++ b/packages/alfa-rules/src/sia-r25/rule.ts
@@ -26,8 +26,9 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
           1: Question.of(
             "has-description",
             target,
-            `Is the visual information of the \`<video>\` available through its
-            audio or a separate audio description track?`
+            Diagnostic.of(
+              `Is the visual information of the \`<video>\` available through its audio or a separate audio description track?`
+            )
           ).map((hasAudio) =>
             expectation(
               hasAudio,

--- a/packages/alfa-rules/src/sia-r33/rule.ts
+++ b/packages/alfa-rules/src/sia-r33/rule.ts
@@ -26,7 +26,7 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
           1: Question.of(
             "transcript",
             target,
-            `Where is the transcript of the \`<video>\` element?`
+            Diagnostic.of(`Where is the transcript of the \`<video>\` element?`)
           ).map((transcript) =>
             expectation(
               transcript.isSome(),
@@ -35,7 +35,9 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
                 Question.of(
                   "transcript-link",
                   target,
-                  `Where is the link pointing to the transcript of the \`<video>\` element?`
+                  Diagnostic.of(
+                    `Where is the link pointing to the transcript of the \`<video>\` element?`
+                  )
                 ).map((transcriptLink) =>
                   expectation(
                     transcriptLink.isSome(),

--- a/packages/alfa-rules/src/sia-r39/rule.ts
+++ b/packages/alfa-rules/src/sia-r39/rule.ts
@@ -6,7 +6,6 @@ import { Criterion, Technique } from "@siteimprove/alfa-wcag";
 import { Page } from "@siteimprove/alfa-web";
 
 import { expectation } from "../common/expectation";
-import { normalize } from "../common/normalize";
 
 import { hasAccessibleName, isIgnored } from "../common/predicate";
 

--- a/packages/alfa-rules/src/sia-r39/rule.ts
+++ b/packages/alfa-rules/src/sia-r39/rule.ts
@@ -6,6 +6,7 @@ import { Criterion, Technique } from "@siteimprove/alfa-wcag";
 import { Page } from "@siteimprove/alfa-web";
 
 import { expectation } from "../common/expectation";
+import { normalize } from "../common/normalize";
 
 import { hasAccessibleName, isIgnored } from "../common/predicate";
 
@@ -56,8 +57,9 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
           1: Question.of(
             "name-describes-purpose",
             target,
-            `Does the accessible name of the \`<${target.name}>\` element
-            describe its purpose?`
+            Diagnostic.of(
+              `Does the accessible name of the \`<${target.name}>\` element describe its purpose?`
+            )
           ).map((nameDescribesPurpose) =>
             expectation(
               nameDescribesPurpose,

--- a/packages/alfa-rules/src/sia-r41/rule.ts
+++ b/packages/alfa-rules/src/sia-r41/rule.ts
@@ -73,7 +73,7 @@ export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
               Question.of(
                 "reference-equivalent-resources",
                 target,
-                `Do the links resolve to equivalent resources?`
+                Diagnostic.of(`Do the links resolve to equivalent resources?`)
               ).map((embedEquivalentResources) =>
                 expectation(
                   embedEquivalentResources,

--- a/packages/alfa-rules/src/sia-r48/rule.ts
+++ b/packages/alfa-rules/src/sia-r48/rule.ts
@@ -44,8 +44,9 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
             const isAboveDurationThreshold = Question.of(
               "is-above-duration-threshold",
               element,
-              `Does the \`<${element.name}>\` element have a duration of more
-              than 3 seconds?`
+              Diagnostic.of(
+                `Does the \`<${element.name}>\` element have a duration of more than 3 seconds?`
+              )
             ).map((isAboveDurationThreshold) =>
               isAboveDurationThreshold ? Option.of(element) : None
             );
@@ -56,7 +57,9 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
               return Question.of(
                 "has-audio",
                 element,
-                `Does the \`<${element.name}>\` element contain audio?`
+                Diagnostic.of(
+                  `Does the \`<${element.name}>\` element contain audio?`
+                )
               ).map((hasAudio) => (hasAudio ? isAboveDurationThreshold : None));
             }
           });
@@ -67,8 +70,9 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
           1: Question.of(
             "is-below-audio-duration-threshold",
             target,
-            `Does the \`<${target.name}>\` element have a total audio duration
-            of less than 3 seconds?`
+            Diagnostic.of(
+              `Does the \`<${target.name}>\` element have a total audio duration of less than 3 seconds?`
+            )
           ).map((isBelowAudioDurationThreshold) =>
             expectation(
               isBelowAudioDurationThreshold,

--- a/packages/alfa-rules/src/sia-r49/rule.ts
+++ b/packages/alfa-rules/src/sia-r49/rule.ts
@@ -49,8 +49,9 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
             const isAboveDurationThreshold = Question.of(
               "is-above-duration-threshold",
               element,
-              `Does the \`<${element.name}>\` element have a duration of more
-              than 3 seconds?`
+              Diagnostic.of(
+                `Does the \`<${element.name}>\` element have a duration of more than 3 seconds?`
+              )
             ).map((isAboveDurationThreshold) =>
               isAboveDurationThreshold ? Option.of(element) : None
             );
@@ -61,7 +62,9 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
               return Question.of(
                 "has-audio",
                 element,
-                `Does the \`<${element.name}>\` element contain audio?`
+                Diagnostic.of(
+                  `Does the \`<${element.name}>\` element contain audio?`
+                )
               ).map((hasAudio) => (hasAudio ? isAboveDurationThreshold : None));
             }
           });
@@ -72,8 +75,9 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
           1: Question.of(
             "audio-control-mechanism",
             target,
-            `Where is the mechanism that can pause or stop the audio of the
-            \`<${target.name}>\` element?`
+            Diagnostic.of(
+              `Where is the mechanism that can pause or stop the audio of the \`<${target.name}>\` element?`
+            )
           )
             // If the applicable <video> or <audio> element uses native controls
             // we assume that the mechanism is the element itself.

--- a/packages/alfa-rules/src/sia-r55/rule.ts
+++ b/packages/alfa-rules/src/sia-r55/rule.ts
@@ -63,7 +63,9 @@ export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
         const sameResource = Question.of(
           "is-content-equivalent",
           target,
-          `Do these ${role} landmarks have the same or equivalent content?`
+          Diagnostic.of(
+            `Do these ${role} landmarks have the same or equivalent content?`
+          )
         );
 
         return {

--- a/packages/alfa-rules/src/sia-r69/rule.ts
+++ b/packages/alfa-rules/src/sia-r69/rule.ts
@@ -1,5 +1,4 @@
 import { Rule } from "@siteimprove/alfa-act";
-import { RGB } from "@siteimprove/alfa-css";
 import { Element, Text, Namespace, Node } from "@siteimprove/alfa-dom";
 import { Iterable } from "@siteimprove/alfa-iterable";
 import { Predicate } from "@siteimprove/alfa-predicate";

--- a/packages/alfa-rules/src/sia-r81/rule.ts
+++ b/packages/alfa-rules/src/sia-r81/rule.ts
@@ -78,7 +78,7 @@ export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
               Question.of(
                 "reference-equivalent-resources",
                 target,
-                `Do the links resolve to equivalent resources?`
+                Diagnostic.of(`Do the links resolve to equivalent resources?`)
               ).map((embedEquivalentResources) =>
                 expectation(
                   embedEquivalentResources,


### PR DESCRIPTION
In `Question`, replace the `message` field by a full blown `Diagnostic`.

Questions now need to be built wrapping the message in `Diagnostic.of` and the message can be accessed by replacing `question.message` with `question.diagnostic.message`.
