### PR TITLE
Separate message from diagnostic in questions

### DIFF
--- a/docs/review/api/alfa-act.api.md
+++ b/docs/review/api/alfa-act.api.md
@@ -386,7 +386,7 @@ export namespace Outcome {
 
 // @public
 export class Question<TYPE, SUBJECT, CONTEXT, ANSWER, T = ANSWER, URI extends string = string> implements Functor<T>, Applicative<T>, Monad<T>, Serializable<Question.JSON<TYPE, SUBJECT, CONTEXT, URI>> {
-    protected constructor(type: TYPE, uri: URI, diagnostic: Diagnostic, subject: SUBJECT, context: CONTEXT, quester: Mapper<ANSWER, T>);
+    protected constructor(type: TYPE, uri: URI, message: string, diagnostic: Diagnostic, subject: SUBJECT, context: CONTEXT, quester: Mapper<ANSWER, T>);
     // (undocumented)
     answer(answer: ANSWER): T;
     // (undocumented)
@@ -416,7 +416,11 @@ export class Question<TYPE, SUBJECT, CONTEXT, ANSWER, T = ANSWER, URI extends st
     // (undocumented)
     map<U>(mapper: Mapper<T, U>): Question<TYPE, SUBJECT, CONTEXT, ANSWER, U, URI>;
     // (undocumented)
-    static of<TYPE, SUBJECT, CONTEXT, ANSWER, URI extends string = string>(type: TYPE, uri: URI, diagnostic: Diagnostic, subject: SUBJECT, context: CONTEXT): Question<TYPE, SUBJECT, CONTEXT, ANSWER, ANSWER, URI>;
+    get message(): string;
+    // (undocumented)
+    protected readonly _message: string;
+    // (undocumented)
+    static of<TYPE, SUBJECT, CONTEXT, ANSWER, URI extends string = string>(type: TYPE, uri: URI, message: string, subject: SUBJECT, context: CONTEXT, diagnostic?: Diagnostic): Question<TYPE, SUBJECT, CONTEXT, ANSWER, ANSWER, URI>;
     // (undocumented)
     protected readonly _quester: Mapper<ANSWER, T>;
     // (undocumented)
@@ -448,6 +452,8 @@ export namespace Question {
         // (undocumented)
         diagnostic: Diagnostic.JSON;
         // (undocumented)
+        message: string;
+        // (undocumented)
         subject: Serializable.ToJSON<SUBJECT>;
         // (undocumented)
         type: Serializable.ToJSON<TYPE>;
@@ -456,7 +462,7 @@ export namespace Question {
     }
     // @internal
     export class Rhetorical<TYPE, SUBJECT, CONTEXT, ANSWER, T = ANSWER, URI extends string = string> extends Question<TYPE, SUBJECT, CONTEXT, ANSWER, T, URI> {
-        constructor(type: TYPE, uri: URI, diagnostic: Diagnostic, subject: SUBJECT, context: CONTEXT, answer: T);
+        constructor(type: TYPE, uri: URI, message: string, diagnostic: Diagnostic, subject: SUBJECT, context: CONTEXT, answer: T);
         // (undocumented)
         answer(): T;
         // (undocumented)

--- a/docs/review/api/alfa-rules.api.md
+++ b/docs/review/api/alfa-rules.api.md
@@ -375,9 +375,9 @@ export namespace Question {
         [K in Uri]: [Data[K]["type"], Type[Data[K]["type"]]];
     };
     // (undocumented)
-    export function of<S, U extends Uri = Uri>(uri: U, subject: S, diagnostic?: Diagnostic): act.Question<Data[U]["type"], S, S, Type[Data[U]["type"]], Type[Data[U]["type"]], U>;
+    export function of<S, U extends Uri = Uri>(uri: U, subject: S, message?: string, diagnostic?: Diagnostic): act.Question<Data[U]["type"], S, S, Type[Data[U]["type"]], Type[Data[U]["type"]], U>;
     // (undocumented)
-    export function of<S, C, U extends Uri = Uri>(uri: U, subject: S, context: C, diagnostic?: Diagnostic): act.Question<Data[U]["type"], S, C, Type[Data[U]["type"]], Type[Data[U]["type"]], U>;
+    export function of<S, C, U extends Uri = Uri>(uri: U, subject: S, context: C, message?: string, diagnostic?: Diagnostic): act.Question<Data[U]["type"], S, C, Type[Data[U]["type"]], Type[Data[U]["type"]], U>;
     export interface Type {
         // (undocumented)
         "color[]": Iterable<RGB>;

--- a/packages/alfa-act/src/question.ts
+++ b/packages/alfa-act/src/question.ts
@@ -45,13 +45,15 @@ export class Question<
   public static of<TYPE, SUBJECT, CONTEXT, ANSWER, URI extends string = string>(
     type: TYPE,
     uri: URI,
-    diagnostic: Diagnostic,
+    message: string,
     subject: SUBJECT,
-    context: CONTEXT
+    context: CONTEXT,
+    diagnostic: Diagnostic = Diagnostic.of("No extra information")
   ): Question<TYPE, SUBJECT, CONTEXT, ANSWER, ANSWER, URI> {
     return new Question(
       type,
       uri,
+      message,
       diagnostic,
       subject,
       context,
@@ -61,6 +63,7 @@ export class Question<
 
   protected readonly _type: TYPE;
   protected readonly _uri: URI;
+  protected readonly _message: string;
   protected readonly _diagnostic: Diagnostic;
   protected readonly _subject: SUBJECT;
   protected readonly _context: CONTEXT;
@@ -69,6 +72,7 @@ export class Question<
   protected constructor(
     type: TYPE,
     uri: URI,
+    message: string,
     diagnostic: Diagnostic,
     subject: SUBJECT,
     context: CONTEXT,
@@ -76,6 +80,7 @@ export class Question<
   ) {
     this._type = type;
     this._uri = uri;
+    this._message = message;
     this._diagnostic = diagnostic;
     this._subject = subject;
     this._context = context;
@@ -88,6 +93,10 @@ export class Question<
 
   public get uri(): URI {
     return this._uri;
+  }
+
+  public get message(): string {
+    return this._message;
   }
 
   public get diagnostic(): Diagnostic {
@@ -167,6 +176,7 @@ export class Question<
       ? new Question.Rhetorical(
           this._type,
           this._uri,
+          this._message,
           this._diagnostic,
           this._subject,
           this._context,
@@ -181,6 +191,7 @@ export class Question<
     return new Question(
       this._type,
       this._uri,
+      this._message,
       this._diagnostic,
       this._subject,
       this._context,
@@ -200,6 +211,7 @@ export class Question<
     return new Question(
       this._type,
       this._uri,
+      this._message,
       this._diagnostic,
       this._subject,
       this._context,
@@ -219,6 +231,7 @@ export class Question<
     return new Question(
       this._type,
       this._uri,
+      this._message,
       this._diagnostic,
       this._subject,
       this._context,
@@ -230,6 +243,7 @@ export class Question<
     return {
       type: Serializable.toJSON(this._type),
       uri: this._uri,
+      message: this._message,
       diagnostic: this._diagnostic.toJSON(),
       subject: Serializable.toJSON(this._subject),
       context: Serializable.toJSON(this._context),
@@ -245,6 +259,7 @@ export namespace Question {
     [key: string]: json.JSON;
     type: Serializable.ToJSON<TYPE>;
     uri: URI;
+    message: string;
     diagnostic: Diagnostic.JSON;
     subject: Serializable.ToJSON<SUBJECT>;
     context: Serializable.ToJSON<CONTEXT>;
@@ -283,12 +298,13 @@ export namespace Question {
     public constructor(
       type: TYPE,
       uri: URI,
+      message: string,
       diagnostic: Diagnostic,
       subject: SUBJECT,
       context: CONTEXT,
       answer: T
     ) {
-      super(type, uri, diagnostic, subject, context, () => answer);
+      super(type, uri, message, diagnostic, subject, context, () => answer);
       this._answer = answer;
     }
 
@@ -307,6 +323,7 @@ export namespace Question {
       return new Rhetorical(
         this._type,
         this._uri,
+        this._message,
         this._diagnostic,
         this._subject,
         this._context,

--- a/packages/alfa-assert/test/fixture/rule.ts
+++ b/packages/alfa-assert/test/fixture/rule.ts
@@ -56,13 +56,7 @@ export const CantTell = (uri: string) =>
             string,
             boolean,
             "is-passed"
-          >(
-            "boolean",
-            "is-passed",
-            Diagnostic.of("Does the rule pass?"),
-            target,
-            target
-          );
+          >("boolean", "is-passed", "Does the rule pass?", target, target);
           return {
             1: isPassed.map((passed) =>
               passed

--- a/packages/alfa-rules/src/common/act/question.ts
+++ b/packages/alfa-rules/src/common/act/question.ts
@@ -51,6 +51,7 @@ export namespace Question {
   export function of<S, U extends Uri = Uri>(
     uri: U,
     subject: S,
+    message?: string,
     diagnostic?: Diagnostic
   ): act.Question<
     Data[U]["type"],
@@ -65,6 +66,7 @@ export namespace Question {
     uri: U,
     subject: S,
     context: C,
+    message?: string,
     diagnostic?: Diagnostic
   ): act.Question<
     Data[U]["type"],
@@ -78,7 +80,8 @@ export namespace Question {
   export function of<S, U extends Uri = Uri>(
     uri: U,
     subject: S,
-    contextOrDiagnostic?: S | Diagnostic,
+    contextOrMessage?: S | string,
+    messageOrDiagnostic?: string | Diagnostic,
     diagnostic?: Diagnostic
   ): act.Question<
     Data[U]["type"],
@@ -89,13 +92,31 @@ export namespace Question {
     U
   > {
     let context: S = subject;
-    if (Diagnostic.isDiagnostic(contextOrDiagnostic)) {
-      diagnostic = contextOrDiagnostic;
+    let message: string;
+
+    if (
+      // We assume that no context will be a string.
+      // Since contexts are guaranteed to be test targets, this is OK. They are
+      // more likely to be text nodes that the actual text in it.
+      typeof contextOrMessage === "string"
+    ) {
+      message = contextOrMessage ?? Data[uri].message;
+      // Type is ensured by overloads
+      diagnostic = messageOrDiagnostic as Diagnostic;
     } else {
-      context = contextOrDiagnostic ?? subject;
-      diagnostic = diagnostic ?? Diagnostic.of(Data[uri].message);
+      context = contextOrMessage ?? subject;
+      // Type is ensured by overloads
+      message = (messageOrDiagnostic as string) ?? Data[uri].message;
     }
-    return act.Question.of(Data[uri].type, uri, diagnostic, subject, context);
+
+    return act.Question.of(
+      Data[uri].type,
+      uri,
+      message,
+      subject,
+      context,
+      diagnostic
+    );
   }
 
   const Data = {

--- a/packages/alfa-rules/src/common/expectation/media-text-alternative.ts
+++ b/packages/alfa-rules/src/common/expectation/media-text-alternative.ts
@@ -64,15 +64,13 @@ export function audioTextAlternative(target: Element, device: Device) {
   const alt = Question.of(
     "text-alternative",
     target,
-    Diagnostic.of(`Where is the text alternative of the \`<audio>\` element?`)
+    `Where is the text alternative of the \`<audio>\` element?`
   );
 
   const label = Question.of(
     "label",
     target,
-    Diagnostic.of(
-      `Where is the text that labels the \`<audio>\` element as an audio alternative?`
-    )
+    `Where is the text that labels the \`<audio>\` element as an audio alternative?`
   );
 
   return mediaTextAlternative(alt, label, device, "<audio>");
@@ -82,15 +80,13 @@ export function videoTextAlternative(target: Element, device: Device) {
   const alt = Question.of(
     "text-alternative",
     target,
-    Diagnostic.of(`Where is the text alternative of the \`<video>\` element?`)
+    `Where is the text alternative of the \`<video>\` element?`
   );
 
   const label = Question.of(
     "label",
     target,
-    Diagnostic.of(
-      `Where is the text that labels the \`<video>\` element as a video alternative?`
-    )
+    `Where is the text that labels the \`<video>\` element as a video alternative?`
   );
 
   return mediaTextAlternative(alt, label, device, "<video>");

--- a/packages/alfa-rules/src/sia-r15/rule.ts
+++ b/packages/alfa-rules/src/sia-r15/rule.ts
@@ -66,9 +66,7 @@ export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
               Question.of(
                 "reference-equivalent-resources",
                 target,
-                Diagnostic.of(
-                  "Do the <iframe> elements embed equivalent resources?"
-                )
+                "Do the <iframe> elements embed equivalent resources?"
               ).map((embedEquivalentResources) =>
                 expectation(
                   embedEquivalentResources,

--- a/packages/alfa-rules/src/sia-r23/rule.ts
+++ b/packages/alfa-rules/src/sia-r23/rule.ts
@@ -30,15 +30,13 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
           1: Question.of(
             "transcript",
             target,
-            Diagnostic.of(`Where is the transcript of the \`<audio>\` element?`)
+            `Where is the transcript of the \`<audio>\` element?`
           ).map((transcript) => {
             if (transcript.isNone()) {
               return Question.of(
                 "transcript-link",
                 target,
-                Diagnostic.of(
-                  `Where is the link pointing to the transcript of the \`<audio>\` element?`
-                )
+                `Where is the link pointing to the transcript of the \`<audio>\` element?`
               ).map((transcriptLink) => {
                 if (transcriptLink.isNone()) {
                   return Option.of(Outcomes.HasNoTranscript);
@@ -55,9 +53,7 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
                 return Question.of(
                   "transcript-perceivable",
                   target,
-                  Diagnostic.of(
-                    `Is the transcript of the \`<audio>\` element perceivable?`
-                  )
+                  `Is the transcript of the \`<audio>\` element perceivable?`
                 ).map((isPerceivable) =>
                   expectation(
                     isPerceivable,

--- a/packages/alfa-rules/src/sia-r24/rule.ts
+++ b/packages/alfa-rules/src/sia-r24/rule.ts
@@ -26,7 +26,7 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
           1: Question.of(
             "transcript",
             target,
-            Diagnostic.of(`Where is the transcript of the \`<video>\` element?`)
+            `Where is the transcript of the \`<video>\` element?`
           ).map((transcript) =>
             expectation(
               transcript.isSome(),
@@ -35,9 +35,7 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
                 Question.of(
                   "transcript-link",
                   target,
-                  Diagnostic.of(
-                    `Where is the link pointing to the transcript of the \`<video>\` element?`
-                  )
+                  `Where is the link pointing to the transcript of the \`<video>\` element?`
                 ).map((transcriptLink) =>
                   expectation(
                     transcriptLink.isSome(),

--- a/packages/alfa-rules/src/sia-r25/rule.ts
+++ b/packages/alfa-rules/src/sia-r25/rule.ts
@@ -26,9 +26,7 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
           1: Question.of(
             "has-description",
             target,
-            Diagnostic.of(
-              `Is the visual information of the \`<video>\` available through its audio or a separate audio description track?`
-            )
+            `Is the visual information of the \`<video>\` available through its audio or a separate audio description track?`
           ).map((hasAudio) =>
             expectation(
               hasAudio,

--- a/packages/alfa-rules/src/sia-r33/rule.ts
+++ b/packages/alfa-rules/src/sia-r33/rule.ts
@@ -26,7 +26,7 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
           1: Question.of(
             "transcript",
             target,
-            Diagnostic.of(`Where is the transcript of the \`<video>\` element?`)
+            `Where is the transcript of the \`<video>\` element?`
           ).map((transcript) =>
             expectation(
               transcript.isSome(),
@@ -35,9 +35,7 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
                 Question.of(
                   "transcript-link",
                   target,
-                  Diagnostic.of(
-                    `Where is the link pointing to the transcript of the \`<video>\` element?`
-                  )
+                  `Where is the link pointing to the transcript of the \`<video>\` element?`
                 ).map((transcriptLink) =>
                   expectation(
                     transcriptLink.isSome(),

--- a/packages/alfa-rules/src/sia-r39/rule.ts
+++ b/packages/alfa-rules/src/sia-r39/rule.ts
@@ -57,9 +57,7 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
           1: Question.of(
             "name-describes-purpose",
             target,
-            Diagnostic.of(
-              `Does the accessible name of the \`<${target.name}>\` element describe its purpose?`
-            )
+            `Does the accessible name of the \`<${target.name}>\` element describe its purpose?`
           ).map((nameDescribesPurpose) =>
             expectation(
               nameDescribesPurpose,

--- a/packages/alfa-rules/src/sia-r41/rule.ts
+++ b/packages/alfa-rules/src/sia-r41/rule.ts
@@ -74,7 +74,7 @@ export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
               Question.of(
                 "reference-equivalent-resources",
                 target,
-                Diagnostic.of(`Do the links resolve to equivalent resources?`)
+                `Do the links resolve to equivalent resources?`
               ).map((embedEquivalentResources) =>
                 expectation(
                   embedEquivalentResources,

--- a/packages/alfa-rules/src/sia-r48/rule.ts
+++ b/packages/alfa-rules/src/sia-r48/rule.ts
@@ -44,9 +44,7 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
             const isAboveDurationThreshold = Question.of(
               "is-above-duration-threshold",
               element,
-              Diagnostic.of(
-                `Does the \`<${element.name}>\` element have a duration of more than 3 seconds?`
-              )
+              `Does the \`<${element.name}>\` element have a duration of more than 3 seconds?`
             ).map((isAboveDurationThreshold) =>
               isAboveDurationThreshold ? Option.of(element) : None
             );
@@ -57,9 +55,7 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
               return Question.of(
                 "has-audio",
                 element,
-                Diagnostic.of(
-                  `Does the \`<${element.name}>\` element contain audio?`
-                )
+                `Does the \`<${element.name}>\` element contain audio?`
               ).map((hasAudio) => (hasAudio ? isAboveDurationThreshold : None));
             }
           });
@@ -70,9 +66,7 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
           1: Question.of(
             "is-below-audio-duration-threshold",
             target,
-            Diagnostic.of(
-              `Does the \`<${target.name}>\` element have a total audio duration of less than 3 seconds?`
-            )
+            `Does the \`<${target.name}>\` element have a total audio duration of less than 3 seconds?`
           ).map((isBelowAudioDurationThreshold) =>
             expectation(
               isBelowAudioDurationThreshold,

--- a/packages/alfa-rules/src/sia-r49/rule.ts
+++ b/packages/alfa-rules/src/sia-r49/rule.ts
@@ -49,9 +49,7 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
             const isAboveDurationThreshold = Question.of(
               "is-above-duration-threshold",
               element,
-              Diagnostic.of(
-                `Does the \`<${element.name}>\` element have a duration of more than 3 seconds?`
-              )
+              `Does the \`<${element.name}>\` element have a duration of more than 3 seconds?`
             ).map((isAboveDurationThreshold) =>
               isAboveDurationThreshold ? Option.of(element) : None
             );
@@ -62,9 +60,7 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
               return Question.of(
                 "has-audio",
                 element,
-                Diagnostic.of(
-                  `Does the \`<${element.name}>\` element contain audio?`
-                )
+                `Does the \`<${element.name}>\` element contain audio?`
               ).map((hasAudio) => (hasAudio ? isAboveDurationThreshold : None));
             }
           });
@@ -75,9 +71,7 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
           1: Question.of(
             "audio-control-mechanism",
             target,
-            Diagnostic.of(
-              `Where is the mechanism that can pause or stop the audio of the \`<${target.name}>\` element?`
-            )
+            `Where is the mechanism that can pause or stop the audio of the \`<${target.name}>\` element?`
           )
             // If the applicable <video> or <audio> element uses native controls
             // we assume that the mechanism is the element itself.

--- a/packages/alfa-rules/src/sia-r55/rule.ts
+++ b/packages/alfa-rules/src/sia-r55/rule.ts
@@ -64,9 +64,7 @@ export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
         const sameResource = Question.of(
           "is-content-equivalent",
           target,
-          Diagnostic.of(
-            `Do these ${role} landmarks have the same or equivalent content?`
-          )
+          `Do these ${role} landmarks have the same or equivalent content?`
         );
 
         return {

--- a/packages/alfa-rules/src/sia-r81/rule.ts
+++ b/packages/alfa-rules/src/sia-r81/rule.ts
@@ -79,7 +79,7 @@ export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
               Question.of(
                 "reference-equivalent-resources",
                 target,
-                Diagnostic.of(`Do the links resolve to equivalent resources?`)
+                `Do the links resolve to equivalent resources?`
               ).map((embedEquivalentResources) =>
                 expectation(
                   embedEquivalentResources,


### PR DESCRIPTION
While working on #1033 I realised we actually need both a message and diagnostic for questions and cannot simply use the message inside the diagnostic 😕 For two reasons:

1. We still need to ask the question, even if we explain why we need it. I.e. we need to send ("What is the color?", ("I couldn't find because of a background image", `background-image: url(foo)`)) which is both a message and a diagnostic.
    This alone could be solved by nesting the diagnostic inside another one, or flattening in a `{message: "color?", reason: "background image", …}`-like object.
2. A convenient way to feed diagnostic to questions is to use `.answerIf` failure cases, since we'll mostly need these diagnostics when Alfa tried to get the answer itself and failed (i.e. we don't need a diagnostic for "Is the video streaming?" ; there is just no way we can find that and the reason would always be "Alfa can't figure it out"…)
    Currently, `.answerIf` can take a `Result<ANSWER, unknown>` to see if an answer was provided and produces a rhetorical question. The error part of the result can conveniently be used to fill the diagnostic of the question (if it is itself a diagnostic). This essentially means that R69's `answerIf` don't need to change and we don't need to open up the result of `getColors` to build the correct question with the correct diagnostic.
    However, while it is easy to replace a diagnostic (of unknown shape) by another one, it is much harder to merge them. Especially if trying to flatten things by using the second diagnostic's `message` to fill the first one's `reason`, all while trying to keep the structure of unknown objects 😖 A way to do it would be to have mutable diagnostics, but I prefer to keep immutability…

So, keeping both a message and a diagnostic. This sounds a bit imperfect, especially when filling the dummy diagnostics. But possibly a lesser evil.

Given that this is breaking by reverting the breaking change of #1027 I'd like to have that merge before releasing so as not to release a breaking change and it's immediate opposite breaking change…