### PR TITLE
`isClipped`: recurse to offset parent and fix masking comparison

### DIFF
--- a/packages/alfa-rules/src/common/predicate/is-clipped.ts
+++ b/packages/alfa-rules/src/common/predicate/is-clipped.ts
@@ -9,7 +9,7 @@ import { hasPositioningParent } from "./has-positioning-parent";
 
 const { abs } = Math;
 const { isElement } = Element;
-const { or, test } = Predicate;
+const { not, or, test } = Predicate;
 const { and } = Refinement;
 
 const cache = Cache.empty<Device, Cache<Context, Cache<Node, boolean>>>();
@@ -41,13 +41,14 @@ export function isClipped(
               )
             ),
             // Or (it's not an element) and its parent is clipped
-            (node: Node) =>
+            and(not(isElement), (node: Node) =>
               node
                 .parent({
                   flattened: true,
                   nested: true,
                 })
                 .some(isClipped(device, context))
+            )
           ),
           node
         )

--- a/packages/alfa-rules/src/common/predicate/is-clipped.ts
+++ b/packages/alfa-rules/src/common/predicate/is-clipped.ts
@@ -158,7 +158,7 @@ function isClippedByMasking(
       ((clip.shape.top.type === "length" &&
         clip.shape.top.equals(clip.shape.bottom)) ||
         (clip.shape.left.type === "length" &&
-          clip.shape.top.equals(clip.shape.right)))
+          clip.shape.left.equals(clip.shape.right)))
     );
   };
 }

--- a/packages/alfa-rules/src/common/predicate/is-clipped.ts
+++ b/packages/alfa-rules/src/common/predicate/is-clipped.ts
@@ -5,6 +5,7 @@ import { Predicate } from "@siteimprove/alfa-predicate";
 import { Refinement } from "@siteimprove/alfa-refinement";
 import { Context } from "@siteimprove/alfa-selector";
 import { Style } from "@siteimprove/alfa-style";
+import { hasPositioningParent } from "./has-positioning-parent";
 
 const { abs } = Math;
 const { isElement } = Element;
@@ -28,16 +29,18 @@ export function isClipped(
       .get(node, () =>
         test(
           or(
-            // Either it a clipped element
+            // Either it is a clipped element
             and(
               isElement,
               or(
                 isClippedBySize(device, context),
                 isClippedByIndent(device, context),
-                isClippedByMasking(device, context)
+                isClippedByMasking(device, context),
+                // Or it is an element whose positioning parent is clipped
+                hasPositioningParent(device, isClipped(device, context))
               )
             ),
-            // Or its parent is clipped
+            // Or (it's not an element) and its parent is clipped
             (node: Node) =>
               node
                 .parent({

--- a/packages/alfa-rules/test/common/predicate/is-visible.spec.tsx
+++ b/packages/alfa-rules/test/common/predicate/is-visible.spec.tsx
@@ -2,6 +2,7 @@ import { h } from "@siteimprove/alfa-dom/h";
 import { test } from "@siteimprove/alfa-test";
 
 import { Device } from "@siteimprove/alfa-device";
+import { isClipped } from "../../../src/common/predicate/is-clipped";
 
 import * as predicate from "../../../src/common/predicate/is-visible";
 
@@ -47,11 +48,7 @@ test(`isVisible() returns false when a track element is a child of video`, (t) =
 test(`isVisible() returns false when a div element is child of an iframe element`, (t) => {
   const div = <div>hidden</div>;
 
-  const element = (
-    <iframe srcdoc="Hello">
-      {div}
-    </iframe>
-  );
+  const element = <iframe srcdoc="Hello">{div}</iframe>;
   h.document([element]);
 
   t.equal(isVisible(div), false);
@@ -495,7 +492,7 @@ test("isVisible() return true for an empty element with set dimensions", (t) => 
   t.equal(isVisible(element), true);
 });
 
-test("isVisible() return true for an empty absolutely positioned element stretched within its offset parent", (t) => {
+test("isVisible() returns true for an empty absolutely positioned element stretched within its offset parent", (t) => {
   const element = <div class="stretch"></div>;
 
   h.document(
@@ -517,7 +514,7 @@ test("isVisible() return true for an empty absolutely positioned element stretch
   t.equal(isVisible(element), true);
 });
 
-test("isVisible() return true for an element stretched horizontally and dimensioned vertically", (t) => {
+test("isVisible() returns true for an element stretched horizontally and dimensioned vertically", (t) => {
   const element = <div class="stretch"></div>;
 
   h.document(
@@ -538,19 +535,22 @@ test("isVisible() return true for an element stretched horizontally and dimensio
   t.equal(isVisible(element), true);
 });
 
-test("isVisible() return true for an element stretched vertically and dimensioned horizontally", (t) => {
-  const element = <div class="stretch"></div>;
+test("isVisible() returns true for an absolutely positioned element with a clipping ancestor before its offset parent ", (t) => {
+  const element = <div class="absolute">Hello world</div>;
 
   h.document(
-    [<div style={{ position: "relative" }}>{element}Hello world</div>],
+    [
+      <div style={{ position: "relative" }}>
+        <div class="clip">{element}</div>
+      </div>,
+    ],
     [
       h.sheet([
-        h.rule.style(".stretch", {
-          position: "absolute",
-          background: "red",
-          top: "1px",
-          bottom: "1px",
-          width: "100px",
+        h.rule.style(".absolute", { position: "absolute" }),
+        h.rule.style(".clip", {
+          overflow: "hidden",
+          height: "0px",
+          width: "0px",
         }),
       ]),
     ]

--- a/packages/alfa-rules/test/common/predicate/is-visible.spec.tsx
+++ b/packages/alfa-rules/test/common/predicate/is-visible.spec.tsx
@@ -2,7 +2,6 @@ import { h } from "@siteimprove/alfa-dom/h";
 import { test } from "@siteimprove/alfa-test";
 
 import { Device } from "@siteimprove/alfa-device";
-import { isClipped } from "../../../src/common/predicate/is-clipped";
 
 import * as predicate from "../../../src/common/predicate/is-visible";
 


### PR DESCRIPTION
Resolves #887 (again 🙄 )
Plus corrects a typo in `isClippedByMasking` 🙈 
