### PR TITLE
Simplify expectation helper

### DIFF
--- a/packages/alfa-rules/src/common/act/expectation.ts
+++ b/packages/alfa-rules/src/common/act/expectation.ts
@@ -1,39 +1,30 @@
-import { Diagnostic, Interview, Question } from "@siteimprove/alfa-act";
-import { None, Option, Some } from "@siteimprove/alfa-option";
+import { Diagnostic, Interview } from "@siteimprove/alfa-act";
+import { None, Option } from "@siteimprove/alfa-option";
 import { Result } from "@siteimprove/alfa-result";
 import { Thunk } from "@siteimprove/alfa-thunk";
 import { Trilean } from "@siteimprove/alfa-trilean";
 
-type Path<Q, S, C> = Interview<Q, S, C, Option.Maybe<Result<Diagnostic>>>;
-
-function toExpectation<Q, S, C>(
-  path: Path<Q, S, C>
-): Interview<Q, S, C, Option<Result<Diagnostic>>> {
-  if (path instanceof Question) {
-    return path.map(toExpectation);
-  }
-
-  if (Option.isOption(path)) {
-    return path;
-  }
-
-  return Some.of(path);
-}
+type Expectation<Q, S, C> = Interview<
+  Q,
+  S,
+  C,
+  Option.Maybe<Result<Diagnostic>>
+>;
 
 export function expectation<Q, S, C>(
   test: Trilean,
-  ifTrue: Thunk<Path<Q, S, C>>,
-  ifFalse: Thunk<Path<Q, S, C>>,
-  ifUnknown: Thunk<Path<Q, S, C>> = Thunk.of(None)
-): Interview<Q, S, C, Option<Result<Diagnostic>>> {
+  ifTrue: Thunk<Expectation<Q, S, C>>,
+  ifFalse: Thunk<Expectation<Q, S, C>>,
+  ifUnknown: Thunk<Expectation<Q, S, C>> = Thunk.of(None)
+): Expectation<Q, S, C> {
   switch (test) {
     case true:
-      return toExpectation(ifTrue());
+      return ifTrue();
 
     case false:
-      return toExpectation(ifFalse());
+      return ifFalse();
 
     default:
-      return toExpectation(ifUnknown());
+      return ifUnknown();
   }
 }


### PR DESCRIPTION
In #286, we allowed expectation to be `Option.Maybe` instead of just `Option` ([this change](https://github.com/Siteimprove/alfa/pull/286/files#diff-5e38584e1360a99b4db83cc874a7c2eb41f343d6b80484b462280cb95df8bc21L254)) This made `toExpectation` completely useless since it was doing this transformation, but we never cleaned it 🙈 

Note that now, the cases where the thunks are inexpensive (e.g. static) could be rewritten from `expectation(test, () => Outcomes.OK, () => Outcomes.KO)` to `test ? Outcomes.OK : Outcomes.KO`, but it probably still make sense to keep wrapping in the `expectation helper for the sake of keeping things similar, and of course there are cases where the thunks are expensive (notably if they contain questions) and thus should be frozen as continuations…