### PR TITLE
Use windows-2019 as integrate target

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2019]
         node: [14, 16]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
We've seem quite a few failures on the windows build lately, e.g. [this one](https://github.com/Siteimprove/alfa/runs/5419661399?check_suite_focus=true). Given the error message 
```shell
Run yarn build
  yarn build
  shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
Error: Process completed with exit code 1.
```
I do suspect this might have something to do with the change of windows target of https://github.com/actions/virtual-environments/issues/4856

Trying to rollback to `windows-2019` to see if it ease the problem.
