### PR TITLE
SIA-ER62: `background-image` should ignore transparent link element

### DIFF
--- a/packages/alfa-rules/src/sia-er62/rule.ts
+++ b/packages/alfa-rules/src/sia-er62/rule.ts
@@ -16,6 +16,7 @@ import { Context } from "@siteimprove/alfa-selector";
 import { Sequence } from "@siteimprove/alfa-sequence";
 import { Set } from "@siteimprove/alfa-set";
 import { Style } from "@siteimprove/alfa-style";
+import { Computed as BackgroundImage } from "@siteimprove/alfa-style/src/property/background-image";
 import { Criterion } from "@siteimprove/alfa-wcag";
 import { Page } from "@siteimprove/alfa-web";
 
@@ -506,6 +507,13 @@ namespace Distinguishable {
       "background-image"
     ).value;
 
+    function hasNoBackgroundImage(image: BackgroundImage): boolean {
+      return (
+        Keyword.isKeyword(image.values[0]) &&
+        image.values[0].equals(Keyword.of("none"))
+      );
+    }
+
     return or(
       hasComputedStyle(
         "background-color",
@@ -525,15 +533,9 @@ namespace Distinguishable {
       // When there is no `background-image` set on the link, we consider it to be the same as the container's
       hasComputedStyle(
         "background-image",
-        not((image) => {
-          let hasNoBackgroundImage: boolean = false;
-          for (const value of image.values) {
-            if (Keyword.isKeyword(value) && value.equals(Keyword.of("none"))) {
-              hasNoBackgroundImage = true;
-            }
-          }
-          return hasNoBackgroundImage || image.equals(imageReference);
-        }),
+        not(
+          (image) => hasNoBackgroundImage(image) || image.equals(imageReference)
+        ),
         device,
         context
       )

--- a/packages/alfa-rules/src/sia-er62/rule.ts
+++ b/packages/alfa-rules/src/sia-er62/rule.ts
@@ -2,7 +2,7 @@ import { Rule } from "@siteimprove/alfa-act";
 import { DOM } from "@siteimprove/alfa-aria";
 import { Array } from "@siteimprove/alfa-array";
 import { Cache } from "@siteimprove/alfa-cache";
-import { Color } from "@siteimprove/alfa-css";
+import { Color, Keyword } from "@siteimprove/alfa-css";
 import { Device } from "@siteimprove/alfa-device";
 import { Element, Node, Text } from "@siteimprove/alfa-dom";
 import { Iterable } from "@siteimprove/alfa-iterable";
@@ -522,9 +522,18 @@ namespace Distinguishable {
       // Any difference in `background-image` is considered enough. If different
       // `background-image` ultimately yield the same background (e.g. the same
       // image at two different URLs), this creates false negatives.
+      // When there is no `background-image` set on the link, we consider it to be the same as the container's
       hasComputedStyle(
         "background-image",
-        not((image) => image.equals(imageReference)),
+        not((image) => {
+          let hasNoBackgroundImage: boolean = false;
+          for (const value of image.values) {
+            if (Keyword.isKeyword(value) && value.equals(Keyword.of("none"))) {
+              hasNoBackgroundImage = true;
+            }
+          }
+          return hasNoBackgroundImage || image.equals(imageReference);
+        }),
         device,
         context
       )

--- a/packages/alfa-rules/test/sia-er62/rule.expectation.spec.tsx
+++ b/packages/alfa-rules/test/sia-er62/rule.expectation.spec.tsx
@@ -118,6 +118,37 @@ test(`evaluate() fails an <a> element that has no distinguishing features and is
   ]);
 });
 
+test(`evaluate() fails an <a> element that has no distinguishing features and is
+ part of a paragraph with a background image`, async (t) => {
+  const target = <a href="#">Link</a>;
+
+  const document = h.document(
+    [<p>Hello {target}</p>],
+    [
+      h.sheet([
+        h.rule.style("p", {
+          backgroundImage:
+            "linear-gradient(to right, #F9F9F1 50%, #0000D1 50%)",
+        }),
+
+        h.rule.style("a", {
+          textDecoration: "none",
+        }),
+      ]),
+    ]
+  );
+
+  t.deepEqual(await evaluate(ER62, { document }), [
+    failed(ER62, target, {
+      1: Outcomes.IsNotDistinguishable(
+        [noStyle],
+        [addCursor(noStyle)],
+        [addOutline(noStyle)]
+      ),
+    }),
+  ]);
+});
+
 test(`evaluate() fails an <a> element that has no distinguishing features and
  has a background color equal to that of the paragraph`, async (t) => {
   const target = <a href="#">Link</a>;
@@ -153,11 +184,11 @@ test(`evaluate() fails an <a> element that has no distinguishing features and
   ]);
 });
 
-// /******************************************************************
-//  *
-//  * Box-shadow as Distinguishing Feature
-//  *
-//  ******************************************************************/
+/******************************************************************
+ *
+ * Box-shadow as Distinguishing Feature
+ *
+ ******************************************************************/
 
 test(`evaluate() passes an applicable <a> element that removes the default text
  decoration and instead applies a box shadow`, async (t) => {
@@ -217,11 +248,11 @@ test(`evaluate() fails an applicable <a> element that removes the default text
   ]);
 });
 
-// /******************************************************************
-//  *
-//  * Border as Distinguishing Feature
-//  *
-//  ******************************************************************/
+/******************************************************************
+ *
+ * Border as Distinguishing Feature
+ *
+ ******************************************************************/
 
 test(`evaluate() passes an applicable <a> element that removes the default text
  decoration and instead applies a bottom border`, async (t) => {
@@ -331,11 +362,11 @@ test(`evaluate() fails an <a> element that has no distinguishing features and
   ]);
 });
 
-// /******************************************************************
-//  *
-//  * Font as Distinguishing Feature
-//  *
-//  ******************************************************************/
+/******************************************************************
+ *
+ * Font as Distinguishing Feature
+ *
+ ******************************************************************/
 test(`evaluate() passes a link whose bolder than surrounding text`, async (t) => {
   const target = <a href="#">Link</a>;
 
@@ -408,11 +439,11 @@ test(`evaluate() passes a link with different font-family than surrounding text`
   ]);
 });
 
-// /******************************************************************
-//  *
-//  * Outline as Distinguishing Feature
-//  *
-//  ******************************************************************/
+/******************************************************************
+ *
+ * Outline as Distinguishing Feature
+ *
+ ******************************************************************/
 test(`evaluate() passes an applicable <a> element that removes the default text
  decoration and instead applies an outline`, async (t) => {
   const target = <a href="#">Link</a>;
@@ -545,7 +576,7 @@ test(`evaluate() passes an <a> element in superscript`, async (t) => {
  *
  ******************************************************************/
 
-test(`evaluate() passes an <a> element with a <p> parent element when 
+test(`evaluate() passes an <a> element with a <p> parent element when
       background, box-shadow and text-decoration are distinguishing features`, async (t) => {
   const target = <a href="#">Link</a>;
 


### PR DESCRIPTION
Resolves #1131
