### PR TITLE
Change :focus-visible to match :focus elements

### DIFF
--- a/docs/review/api/alfa-selector.api.md
+++ b/docs/review/api/alfa-selector.api.md
@@ -119,7 +119,7 @@ export namespace Selector {
         get type(): "attribute";
         // (undocumented)
         get value(): Option<string>;
-        }
+    }
     // (undocumented)
     export namespace Attribute {
         // (undocumented)
@@ -343,7 +343,7 @@ export namespace Selector {
     // (undocumented)
     export class FocusVisible extends Pseudo.Class<"focus-visible"> {
         // (undocumented)
-        matches(): boolean;
+        matches(element: Element, context?: Context): boolean;
         // (undocumented)
         static of(): FocusVisible;
     }
@@ -928,9 +928,8 @@ export namespace Selector {
     }
     const // (undocumented)
     parse: Parser<Slice<Token>, Simple | Compound | Complex | List<Simple | Compound | Complex>, string, []>;
-    {};
+        {};
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/alfa-rules/test/sia-r65/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r65/rule.spec.tsx
@@ -218,7 +218,7 @@ test(`evaluate() passes an <a> element that removes the default focus outline
           outline: "none",
         }),
 
-        h.rule.style("a:focus:focus-visible", {
+        h.rule.style("a:focus-visible", {
           outline: "1px solid blue",
         }),
       ]),
@@ -244,7 +244,7 @@ test(`evaluate() fails an <a> element that removes the default focus outline
     [target, <button />],
     [
       h.sheet([
-        h.rule.style("a:focus:focus-visible", {
+        h.rule.style("a:focus-visible", {
           outline: "none",
         }),
       ]),

--- a/packages/alfa-selector/src/selector.ts
+++ b/packages/alfa-selector/src/selector.ts
@@ -62,7 +62,8 @@ export namespace Selector {
     implements
       Iterable<Simple | Compound | Complex | Relative>,
       Equatable,
-      Serializable {
+      Serializable
+  {
     public abstract get type(): T;
 
     /**
@@ -1301,7 +1302,7 @@ export namespace Selector {
   }
 
   /**
-   * {@link https://drafts.csswg.org/selectors/#focus-visible-pseudo}
+   * {@link https://drafts.csswg.org/selectors/#the-focus-visible-pseudo}
    */
   export class FocusVisible extends Pseudo.Class<"focus-visible"> {
     public static of(): FocusVisible {
@@ -1312,11 +1313,18 @@ export namespace Selector {
       super("focus-visible");
     }
 
-    public matches(): boolean {
+    public matches(
+      element: Element,
+      context: Context = Context.empty()
+    ): boolean {
+      // :focus-visible matches elements that are focused and where UA decides
+      // focus should be shown. That is notably text fields and keyboard-focused
+      // elements (some UA don't show focus indicator on mouse-focused elements)
       // For the purposes of accessibility testing, we currently assume that
-      // focus related styling can safely be "hidden" behind the :focus-visible
-      // pseudo-class and it will therefore always match.
-      return true;
+      // we always want to look at a mode where the focus is visible. This is
+      // notably due to the fact that it is a UA decision, and therefore not
+      // a problem for the authors to fix if done incorrectly.
+      return context.isFocused(element);
     }
   }
 


### PR DESCRIPTION
We incorrectly understood that `:focus-visible` was an addition to `:focus`, and that it would only apply in a combination `:focus:focus-visible`.
It turns out that `:focus-visible` already matches a subset of `:focus` (based on UA choices).

This PR changes the `matches` of `FocusVisible` from "always" to "same as `Focus`" to reflect that.
