### PR TITLE
ER62: fixes some corner cases with nested paragraphs

### DIFF
--- a/packages/alfa-rules/src/sia-er62/rule.ts
+++ b/packages/alfa-rules/src/sia-er62/rule.ts
@@ -82,7 +82,8 @@ export default Rule.Atomic.of<Page, Element>({
       applicability() {
         // Contains links (key) and the parents of the textnodes the links contain (value)
         let linkText: Map<Element, Set<Element>> = Map.empty();
-        // Contains containers (key) and the parents of the text nodes (non included in links) the containers have (value)
+        // Contains containers (key) and the parents of the text nodes
+        // (not included in links) the containers have (value)
         let nonLinkText: Map<Element, Set<Element>> = Map.empty();
 
         gather(document, None, None);
@@ -93,13 +94,13 @@ export default Rule.Atomic.of<Page, Element>({
           container: Option<Element>,
           link: Option<Element>
         ): void {
-          if (isElement(node)) {
-            const isLink = hasRole(device, (role) => role.is("link"));
-            const isParagraph = and(
-              hasRole(device, "paragraph"),
-              hasNonLinkText(device)
-            );
+          const isLink = hasRole(device, (role) => role.is("link"));
+          const isParagraph = and(
+            hasRole(device, "paragraph"),
+            hasNonLinkText(device)
+          );
 
+          if (isElement(node)) {
             if (container.isSome() && isLink(node)) {
               // For each link, store its containing paragraph
               containers = containers.set(node, container.get());
@@ -111,30 +112,30 @@ export default Rule.Atomic.of<Page, Element>({
             if (isParagraph(node)) {
               container = Option.of(node);
             }
-          }
-
-          const isTextNode = test(and(isText, isVisible(device)), node);
-          const parent = node.parent().filter(isElement);
-          if (isTextNode && container.isSome() && parent.isSome()) {
-            // For each link, store the parent of the text nodes it contains
-            if (link.isSome()) {
-              linkText = linkText.set(
-                link.get(),
-                linkText
-                  .get(link.get())
-                  .getOr(Set.empty<Element>())
-                  .add(parent.get())
-              );
-            }
-            // For each container, store the parent of the text nodes it contains
-            else {
-              nonLinkText = nonLinkText.set(
-                container.get(),
-                nonLinkText
-                  .get(container.get())
-                  .getOr(Set.empty<Element>())
-                  .add(parent.get())
-              );
+          } else {
+            const isTextNode = test(and(isText, isVisible(device)), node);
+            const parent = node.parent().filter(isElement);
+            if (isTextNode && container.isSome() && parent.isSome()) {
+              // For each link, store the parent of the text nodes it contains
+              if (link.isSome()) {
+                linkText = linkText.set(
+                  link.get(),
+                  linkText
+                    .get(link.get())
+                    .getOr(Set.empty<Element>())
+                    .add(parent.get())
+                );
+              }
+              // For each container, store the parent of the text nodes it contains
+              else {
+                nonLinkText = nonLinkText.set(
+                  container.get(),
+                  nonLinkText
+                    .get(container.get())
+                    .getOr(Set.empty<Element>())
+                    .add(parent.get())
+                );
+              }
             }
           }
 

--- a/packages/alfa-rules/src/sia-er62/rule.ts
+++ b/packages/alfa-rules/src/sia-er62/rule.ts
@@ -92,8 +92,7 @@ export default Rule.Atomic.of<Page, Element>({
         function gather(
           node: Node,
           container: Option<Element>,
-          link: Option<Element>,
-          indent = 0
+          link: Option<Element>
         ): void {
           const isLink = hasRole(device, (role) => role.is("link"));
           const isParagraph = hasRole(device, "paragraph");
@@ -150,7 +149,7 @@ export default Rule.Atomic.of<Page, Element>({
           });
 
           for (const child of children) {
-            gather(child, container, link, indent + 2);
+            gather(child, container, link);
           }
         }
 

--- a/packages/alfa-rules/test/sia-er62/rule.applicability.spec.tsx
+++ b/packages/alfa-rules/test/sia-er62/rule.applicability.spec.tsx
@@ -475,3 +475,34 @@ test(`evaluate() is inapplicable to an <a> element with a <p> parent element
 
   t.deepEqual(await evaluate(ER62, { document }), [inapplicable(ER62)]);
 });
+
+test(`evaluates() is inapplicable when the only non-link text is in a nested paragraph`, async (t) => {
+  // While nested <p> are not allowed in HTML, they do appear on some live sites.
+  // In a case like that, the link should not be applicable because the non-link
+  // text is in another paragraph
+  const document = h.document([
+    <p>
+      <a href="#">World</a>
+      <p>Hello</p>
+    </p>,
+  ]);
+
+  t.deepEqual(await evaluate(ER62, { document }), [inapplicable(ER62)]);
+});
+
+test(`evaluates() is inapplicable when there is no non-link text in a nested paragraph`, async (t) => {
+  // While nested <p> are not allowed in HTML, they do appear on some live sites.
+  // In a case like that, the link should not be applicable because its closest
+  // <p> ancestor has no non-link text to compare to.
+  const document = h.document([
+    <p>
+      Lorem ipsum
+      <p>Hello</p>
+      <p>
+        <a href="#">World</a>
+      </p>
+    </p>,
+  ]);
+
+  t.deepEqual(await evaluate(ER62, { document }), [inapplicable(ER62)]);
+});

--- a/packages/alfa-rules/test/sia-er62/rule.applicability.spec.tsx
+++ b/packages/alfa-rules/test/sia-er62/rule.applicability.spec.tsx
@@ -478,13 +478,14 @@ test(`evaluate() is inapplicable to an <a> element with a <p> parent element
 
 test(`evaluates() is inapplicable when the only non-link text is in a nested paragraph`, async (t) => {
   // While nested <p> are not allowed in HTML, they do appear on some live sites.
+  // And of course, roles can be overwritten.
   // In a case like that, the link should not be applicable because the non-link
   // text is in another paragraph
   const document = h.document([
-    <p>
+    <div role="paragraph">
       <a href="#">World</a>
-      <p>Hello</p>
-    </p>,
+      <div role="paragraph">Hello</div>
+    </div>,
   ]);
 
   t.deepEqual(await evaluate(ER62, { document }), [inapplicable(ER62)]);
@@ -492,16 +493,17 @@ test(`evaluates() is inapplicable when the only non-link text is in a nested par
 
 test(`evaluates() is inapplicable when there is no non-link text in a nested paragraph`, async (t) => {
   // While nested <p> are not allowed in HTML, they do appear on some live sites.
+  // And of course, roles can be overwritten.
   // In a case like that, the link should not be applicable because its closest
   // <p> ancestor has no non-link text to compare to.
   const document = h.document([
-    <p>
+    <div role="paragraph">
       Lorem ipsum
-      <p>Hello</p>
-      <p>
+      <div role="paragraph">Hello</div>
+      <div role="paragraph">
         <a href="#">World</a>
-      </p>
-    </p>,
+      </div>
+    </div>,
   ]);
 
   t.deepEqual(await evaluate(ER62, { document }), [inapplicable(ER62)]);


### PR DESCRIPTION
Links gathering wasn't correct in case of nested paragraphs.
Even though nested `<p>` elements are not allowed, they do appear. Additionally, roles can be overwritten…
