### PR TITLE
Do not expose elements with a non-rendered ancestor, even if referenced by `aria-owns`

### DIFF
--- a/packages/alfa-aria/src/node.ts
+++ b/packages/alfa-aria/src/node.ts
@@ -413,6 +413,7 @@ export namespace Node {
         // different from the DOM tree, but being rendered is a property of the
         // DOM, we may "jump" onto a node which is not rendered due to some DOM
         // ancestor (so, unknowingly of the current accessibility tree traversal).
+        // Therefore, we cannot just look at some property of the current node.
         //
         // Since `isRendered` is cached, and evaluating it is needed for almost
         // all nodes in the DOM, this is inexpensive.

--- a/packages/alfa-aria/src/node.ts
+++ b/packages/alfa-aria/src/node.ts
@@ -23,7 +23,8 @@ import { Container, Element, Inert, Text } from ".";
 
 import * as predicate from "./node/predicate";
 
-const { equals } = Predicate;
+const { equals, not, test } = Predicate;
+const { isRendered } = Style;
 
 /**
  * {@link https://w3c.github.io/aria/#accessibility_tree}
@@ -384,6 +385,10 @@ export namespace Node {
         // by means of `aria-hidden=true` are never exposed in the
         // accessibility tree, nor are their descendants.
         //
+        // Since `aria-hidden` affects descendants in the accessibility tree,
+        // not in the DOM, and since we build the accessibility tree top-down,
+        // we never need to look at more than the current node.
+        //
         // This behaviour is unfortunately not consistent across browsers,
         // which we may or may not want to deal with. For now, we pretend that
         // all browsers act consistently.
@@ -401,59 +406,50 @@ export namespace Node {
 
         const style = Style.from(node, device);
 
-        // Elements that are not rendered at all by means of `display: none`
-        // are never exposed in the accessibility tree, nor are their
-        // descendants.
+        // Elements that are not rendered at all by means are never exposed in
+        // the accessibility tree, nor are their descendants.
         //
-        // As we're building the accessibility tree top-down, we only need to
-        // check the element itself for `display: none` and can safely
-        // disregard its ancestors as they will already have been checked.
-        if (
-          style
-            .computed("display")
-            .some(({ values: [outside] }) => outside.value === "none")
-        ) {
+        // Since `aria-owns` can create an accessibility tree that is fairly
+        // different from the DOM tree, but being rendered is a property of the
+        // DOM, we may "jump" onto a node which is not rendered due to some DOM
+        // ancestor (so, unknowingly of the current accessibility tree traversal).
+        //
+        // Since `isRendered` is cached, and evaluating it is needed for almost
+        // all nodes in the DOM, this is inexpensive.
+        if (test(not(isRendered(device)), node)) {
           return Inert.of(node);
         }
 
         let children: (state: State) => Iterable<Node>;
 
-        // Children of <iframe> elements act as fallback content in legacy user
-        // agents and should therefore never be included in the accessibility
-        // tree.
-        if (node.name === "iframe") {
-          children = () => [];
-        }
+        // Get the children explicitly owned by the element. Children can be
+        // explicitly owned using the `aria-owns` attribute.
+        const explicit = owned
+          .get(node)
+          .getOrElse(() => Sequence.empty<dom.Node>());
 
-        // Otherwise, recursively build accessible nodes for the children of the
-        // element.
-        else {
-          // Get the children explicitly owned by the element. Children can be
-          // explicitly owned using the `aria-owns` attribute.
-          const explicit = owned
-            .get(node)
-            .getOrElse(() => Sequence.empty<dom.Node>());
+        // Get the children implicitly owned by the element. These are the
+        // children in the flat tree that are neither claimed already nor
+        // explicitly owned by the element.
+        const implicit = node
+          .children({
+            flattened: true,
+          })
+          .reject((child) => claimed.has(child) || explicit.includes(child));
 
-          // Get the children implicitly owned by the element. These are the
-          // children in the flat tree that are neither claimed already nor
-          // explicitly owned by the element.
-          const implicit = node
-            .children({
-              flattened: true,
-            })
-            .reject((child) => claimed.has(child) || explicit.includes(child));
-
-          // The children implicitly owned by the element come first, then the
-          // children explicitly owned by the element.
-          children = (state) =>
-            implicit
-              .concat(explicit)
-              .map((child) => fromNode(child, device, claimed, owned, state));
-        }
+        // The children implicitly owned by the element come first, then the
+        // children explicitly owned by the element.
+        children = (state) =>
+          implicit
+            .concat(explicit)
+            .map((child) => fromNode(child, device, claimed, owned, state));
 
         // Elements that are not visible by means of `visibility: hidden` or
         // `visibility: collapse`, are exposed in the accessibility tree as
         // containers as they may contain visible descendants.
+        //
+        // Since `visibility` is inherited, this correctly affects DOM descendants
+        // even if `aria-owns` is used to rewrite the tree.
         if (style.computed("visibility").value.value !== "visible") {
           return Container.of(node, children(state.visible(false)));
         }

--- a/packages/alfa-aria/test/node.spec.tsx
+++ b/packages/alfa-aria/test/node.spec.tsx
@@ -320,6 +320,77 @@ test(`.from() correctly handles circular aria-owns references between ancestors
   });
 });
 
+test(`.from() does not expose elements that are not rendered due to a DOM
+      ancestor, but referred to by aria-owns`, (t) => {
+  const target = <div id="target">Lorem ipsum…</div>;
+  const owner = <div aria-owns="target">Hello World</div>;
+
+  <div>
+    <div style={{ display: "none" }}>{target}</div>
+    {owner}
+  </div>;
+
+  t.deepEqual(Node.from(owner, device).toJSON(), {
+    type: "element",
+    node: "/div[1]/div[2]",
+    attributes: [{ name: "aria-owns", value: "target" }],
+    children: [
+      {
+        type: "text",
+        node: "/div[1]/div[2]/text()[1]",
+        name: "Hello World",
+        children: [],
+      },
+      {
+        type: "inert",
+        node: "/div[1]/div[1]/div[1]",
+        children: [],
+      },
+    ],
+    role: null,
+    name: null,
+  });
+});
+
+test(`.from() exposes elements that are aria-hidden due to a DOM
+      ancestor, but referred to by aria-owns`, (t) => {
+  const target = <div id="target">Lorem ipsum…</div>;
+  const owner = <div aria-owns="target">Hello World</div>;
+
+  <div>
+    <div aria-hidden="true">{target}</div>
+    {owner}
+  </div>;
+
+  t.deepEqual(Node.from(owner, device).toJSON(), {
+    type: "element",
+    node: "/div[1]/div[2]",
+    attributes: [{ name: "aria-owns", value: "target" }],
+    children: [
+      {
+        type: "text",
+        node: "/div[1]/div[2]/text()[1]",
+        name: "Hello World",
+        children: [],
+      },
+      {
+        type: "container",
+        node: "/div[1]/div[1]/div[1]",
+        children: [
+          {
+            type: "text",
+            node: "/div[1]/div[1]/div[1]/text()[1]",
+            name: "Lorem ipsum…",
+            children: [],
+          },
+        ],
+      },
+    ],
+    role: null,
+    name: null,
+  });
+});
+
 test(".from() exposes elements if they have a role", (t) => {
   const foo = <button />;
 
@@ -404,6 +475,29 @@ test(`.from() does not expose text nodes of a parent element with
       {
         type: "inert",
         node: "/div[1]/text()[1]",
+        children: [],
+      },
+    ],
+  });
+});
+
+test(`.from() does not expose fallback DOM nodes for legacy browsers`, (t) => {
+  const iframe = (
+    <iframe>
+      <div>Legacy content</div>
+    </iframe>
+  );
+
+  t.deepEqual(Node.from(iframe, device).toJSON(), {
+    type: "element",
+    node: "/iframe[1]",
+    role: null,
+    name: null,
+    attributes: [],
+    children: [
+      {
+        type: "inert",
+        node: "/iframe[1]/div[1]",
         children: [],
       },
     ],

--- a/packages/alfa-style/src/node/predicate/is-rendered.ts
+++ b/packages/alfa-style/src/node/predicate/is-rendered.ts
@@ -11,7 +11,7 @@ const { isFallback } = Element;
 const cache = Cache.empty<Device, Cache<Context, Cache<Node, boolean>>>();
 
 /**
- * {@link https://html.spec.whatwg.org/#being-rendered}
+ * {@link https://html.spec.whatwg.org/multipage/#being-rendered}
  *
  * @public
  */
@@ -24,10 +24,13 @@ export function isRendered(
       .get(device, Cache.empty)
       .get(context, Cache.empty)
       .get(node, () => {
+        // Nodes that are fallback content for legacy browsers are not
+        // being rendered (on modern browsers).
         if (isFallback(node)) {
           return false;
         }
 
+        // Elements with `display: none` are not being rendered
         if (
           Element.isElement(node) &&
           Style.from(node, device, context)
@@ -37,6 +40,7 @@ export function isRendered(
           return false;
         }
 
+        // Comments are never being rendered
         if (Comment.isComment(node)) {
           return false;
         }


### PR DESCRIPTION
Resolves #1111 
