### PR TITLE
Fix CSS lexer dropping character after hash delimiter

### DIFF
--- a/packages/alfa-css/src/syntax/lexer.ts
+++ b/packages/alfa-css/src/syntax/lexer.ts
@@ -561,7 +561,7 @@ const consumeToken: Parser.Infallible<[Array<number>, number], Token | null> =
           return [[input, i], Token.hash(name, isIdentifier)];
         }
 
-        return [[input, i + 1], Token.delim(code)];
+        return [[input, i], Token.delim(code)];
 
       case 0x27:
         return consumeString([input, i]);

--- a/packages/alfa-css/test/syntax/lexer.spec.ts
+++ b/packages/alfa-css/test/syntax/lexer.spec.ts
@@ -623,6 +623,19 @@ test(".lex() lexes a hash delimiter", (t) => {
   ]);
 });
 
+test(".lex() lexes two hash delimiters", (t) => {
+  lex(t, "##", [
+    {
+      type: "delim",
+      value: 0x23,
+    },
+    {
+      type: "delim",
+      value: 0x23,
+    },
+  ]);
+});
+
 test(".lex() lexes an important declaration", (t) => {
   lex(t, "display: none !important", [
     {


### PR DESCRIPTION
When [consuming a hash symbol](https://github.com/Siteimprove/alfa/blob/edf852a8ccaec61fb8c659c9bb22e8b24db377dd/packages/alfa-css/src/syntax/lexer.ts#L559), we immediately [increased the index](https://github.com/Siteimprove/alfa/blob/edf852a8ccaec61fb8c659c9bb22e8b24db377dd/packages/alfa-css/src/syntax/lexer.ts#L560) in the string to start looking for an identifier from the next character.

However, when this lookup fails, we return a delimiter by [incrementing the index again](https://github.com/Siteimprove/alfa/blob/edf852a8ccaec61fb8c659c9bb22e8b24db377dd/packages/alfa-css/src/syntax/lexer.ts#L572). This resulted in skipping the character after a delimiter 🙈 

(the PR contains an unrelated reformat of the full file, I assume because it was last touched before some updates in prettier config, check [this diff](https://github.com/Siteimprove/alfa/pull/1156/files/f94ac2776d47d0c7da32f597df987e5a2ea4d1a0..6c35a7800849c93577b6d0004fb7366aef30f1d6) for the actual changes)
