### PR TITLE
Add a `nodeId` to trees

### DIFF
--- a/docs/review/api/alfa-aria.api.md
+++ b/docs/review/api/alfa-aria.api.md
@@ -19,6 +19,7 @@ import * as json from '@siteimprove/alfa-json';
 import { Mapper } from '@siteimprove/alfa-mapper';
 import { Namespace } from '@siteimprove/alfa-dom';
 import { Node as Node_2 } from '@siteimprove/alfa-dom';
+import { Node as Node_3 } from '@siteimprove/alfa-tree';
 import { Option } from '@siteimprove/alfa-option';
 import { Predicate } from '@siteimprove/alfa-predicate';
 import { Refinement } from '@siteimprove/alfa-refinement';
@@ -81,11 +82,9 @@ export namespace Attribute {
 // @public (undocumented)
 export class Container extends Node<"container"> {
     // (undocumented)
-    clone(parent?: Option<Node>): Container;
-    // (undocumented)
     isIgnored(): boolean;
     // (undocumented)
-    static of(owner: dom_2.Node, children?: Iterable<Node>): Container;
+    static of(owner: dom_2.Node, children?: Iterable<Node>, nodeID?: Node_3.Id.User): Container;
     // (undocumented)
     toString(): string;
 }
@@ -120,13 +119,11 @@ export class Element extends Node<"element"> {
     // (undocumented)
     get attributes(): ReadonlyArray<Attribute>;
     // (undocumented)
-    clone(): Element;
-    // (undocumented)
     isIgnored(): boolean;
     // (undocumented)
     get name(): Option<Name>;
     // (undocumented)
-    static of(owner: dom_2.Node, role?: Option<Role>, name?: Option<Name>, attributes?: Iterable_2<Attribute>, children?: Iterable_2<Node>): Element;
+    static of(owner: dom_2.Node, role?: Option<Role>, name?: Option<Name>, attributes?: Iterable_2<Attribute>, children?: Iterable_2<Node>, nodeId?: Node_3.Id.User): Element;
     // (undocumented)
     get role(): Option<Role>;
     // (undocumented)
@@ -233,11 +230,9 @@ function hasValue(value: string, ...rest: Array<string>): Predicate<Name>;
 // @public (undocumented)
 export class Inert extends Node<"inert"> {
     // (undocumented)
-    clone(): Inert;
-    // (undocumented)
     isIgnored(): boolean;
     // (undocumented)
-    static of(owner: dom_2.Node): Inert;
+    static of(owner: dom_2.Node, nodeId?: Node_3.Id.User): Inert;
     // (undocumented)
     toJSON(): Node.JSON<"inert">;
     // (undocumented)
@@ -509,8 +504,8 @@ export namespace Name {
 }
 
 // @public (undocumented)
-export abstract class Node<T extends string = string> extends tree.Node<Node.Traversal.Flag, T> implements Serializable<Node.JSON<T>> {
-    protected constructor(owner: dom_2.Node, children: Array<Node>, type: T);
+export abstract class Node<T extends string = string> extends tree.Node<Node.Traversal.Flag, T, "aria"> implements Serializable<Node.JSON<T>> {
+    protected constructor(owner: dom_2.Node, children: Array<Node>, type: T, nodeId: Node.Id | tree.Node.Id.User);
     // (undocumented)
     attribute<N extends Attribute.Name>(refinement: Refinement<Attribute, Attribute<N>>): Option<Attribute<N>>;
     // (undocumented)
@@ -519,8 +514,6 @@ export abstract class Node<T extends string = string> extends tree.Node<Node.Tra
     attribute<N extends Attribute.Name>(name: N): Option<Attribute<N>>;
     // (undocumented)
     children(options?: Node.Traversal): Sequence<Node>;
-    // (undocumented)
-    abstract clone(parent?: Option<Node>): Node;
     // (undocumented)
     abstract isIgnored(): boolean;
     // (undocumented)
@@ -595,17 +588,36 @@ export interface Node {
 export namespace Node {
     // (undocumented)
     export function from(node: dom_2.Node, device: Device): Node;
+    // @internal (undocumented)
+    export class Id<N extends string = string> extends tree.Node.Id.System<"aria", N> {
+        protected constructor(namespace: N, id: number);
+        protected constructor(type: "aria", namespace: N, id: number);
+        static create(): Id<"">;
+        // (undocumented)
+        static create<N extends string = string>(namespace: N): Id<N>;
+    }
+    // @internal (undocumented)
+    export namespace Id {
+        // (undocumented)
+        export function isId(value: tree.Node.Id.System): value is Id;
+        // (undocumented)
+        export function isId(value: unknown): value is Id;
+    }
+    const includeIgnored: Traversal;
     // (undocumented)
     export interface JSON<T extends string = string> extends tree.Node.JSON<T> {
         // (undocumented)
         node: string;
     }
+    const // Warning: (ae-forgotten-export) The symbol "predicate" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    hasName: typeof predicate_3.hasName;
     // (undocumented)
     export class Traversal extends Flags<Traversal.Flag> {
         // (undocumented)
         static of(...flags: Array<Traversal.Flag>): Traversal;
     }
-    const includeIgnored: Traversal;
     // (undocumented)
     export namespace Traversal {
         // (undocumented)
@@ -616,10 +628,6 @@ export namespace Node {
         const // (undocumented)
         empty: Traversal;
     }
-    const // Warning: (ae-forgotten-export) The symbol "predicate" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    hasName: typeof predicate_3.hasName;
 }
 
 // @public (undocumented)
@@ -699,13 +707,11 @@ export namespace Role {
 // @public (undocumented)
 export class Text extends Node<"text"> {
     // (undocumented)
-    clone(): Text;
-    // (undocumented)
     isIgnored(): boolean;
     // (undocumented)
     get name(): Option<Name>;
     // (undocumented)
-    static of(owner: dom_2.Node, name: Option<Name>): Text;
+    static of(owner: dom_2.Node, name: Option<Name>, nodeId?: Node_3.Id.User): Text;
     // (undocumented)
     toJSON(): Text.JSON;
     // (undocumented)

--- a/docs/review/api/alfa-dom.api.md
+++ b/docs/review/api/alfa-dom.api.md
@@ -39,7 +39,7 @@ export class Attribute<N extends string = string> extends Node<"attribute"> {
     // (undocumented)
     get namespace(): Option<Namespace>;
     // (undocumented)
-    static of<N extends string = string>(namespace: Option<Namespace>, prefix: Option<string>, name: N, value: string, nodeId?: Node_2.Id.User): Attribute<N>;
+    static of<N extends string = string>(namespace: Option<Namespace>, prefix: Option<string>, name: N, value: string, nodeId?: Node_2.Id.User | string): Attribute<N>;
     // (undocumented)
     get owner(): Option<Element>;
     // (undocumented)
@@ -120,7 +120,7 @@ export class Comment extends Node<"comment"> {
     // @internal (undocumented)
     protected _internalPath(options?: Node.Traversal): string;
     // (undocumented)
-    static of(data: string, nodeId?: Node_2.Id.User): Comment;
+    static of(data: string, nodeId?: Node_2.Id.User | string): Comment;
     // (undocumented)
     toJSON(): Comment.JSON;
     // (undocumented)
@@ -216,7 +216,7 @@ export class Document extends Node<"document"> {
     // @internal (undocumented)
     protected _internalPath(options?: Node.Traversal): string;
     // (undocumented)
-    static of(children: Iterable<Node>, style?: Iterable<Sheet>, nodeId?: Node_2.Id.User): Document;
+    static of(children: Iterable<Node>, style?: Iterable<Sheet>, nodeId?: Node_2.Id.User | string): Document;
     // (undocumented)
     parent(options?: Node.Traversal): Option<Node>;
     // (undocumented)
@@ -262,8 +262,6 @@ export class Element<N extends string = string> extends Node<"element"> implemen
     get classes(): Sequence<string>;
     // (undocumented)
     get content(): Option<Document>;
-    // @internal
-    static _createUnsafe<N extends string = string>(nodeId: number, namespace: Option<Namespace>, prefix: Option<string>, name: N, attributes?: Iterable_2<Attribute>, children?: Iterable_2<Node>, style?: Option<Block>): Element<N>;
     // (undocumented)
     get id(): Option<string>;
     // @internal (undocumented)
@@ -275,7 +273,7 @@ export class Element<N extends string = string> extends Node<"element"> implemen
     // (undocumented)
     get namespace(): Option<Namespace>;
     // (undocumented)
-    static of<N extends string = string>(namespace: Option<Namespace>, prefix: Option<string>, name: N, attributes?: Iterable_2<Attribute>, children?: Iterable_2<Node>, style?: Option<Block>, nodeId?: Node_2.Id.User): Element<N>;
+    static of<N extends string = string>(namespace: Option<Namespace>, prefix: Option<string>, name: N, attributes?: Iterable_2<Attribute>, children?: Iterable_2<Node>, style?: Option<Block>, nodeId?: Node_2.Id.User | string): Element<N>;
     // (undocumented)
     parent(options?: Node.Traversal): Option<Node>;
     // (undocumented)
@@ -377,7 +375,7 @@ export class Fragment extends Node<"fragment"> {
     // @internal (undocumented)
     protected _internalPath(): string;
     // (undocumented)
-    static of(children: Iterable<Node>, nodeId?: Node_2.Id.User): Fragment;
+    static of(children: Iterable<Node>, nodeId?: Node_2.Id.User | string): Fragment;
     // (undocumented)
     toString(): string;
 }
@@ -756,7 +754,7 @@ export namespace NamespaceRule {
 }
 
 // @public (undocumented)
-export abstract class Node<T extends string = string> extends tree.Node<Node.Traversal.Flag, T, "dom"> implements earl.Serializable<Node.EARL>, json.Serializable<tree.Node.JSON<T>>, sarif.Serializable<sarif.Location> {
+export abstract class Node<T extends string = string> extends tree.Node<Node.Traversal.Flag, T, "dom"> implements earl.Serializable<Node.EARL>, json.Serializable<Node.JSON<T>>, sarif.Serializable<sarif.Location> {
     protected constructor(children: Array<Node>, type: T, nodeId: Node.Id | tree.Node.Id.User);
     // (undocumented)
     equals(value: Node): boolean;
@@ -882,7 +880,6 @@ export namespace Node {
         static create(): Id<"">;
         // (undocumented)
         static create<N extends string = string>(namespace: N): Id<N>;
-        static _createUnsafe(id: number): Id<"">;
     }
     // @internal (undocumented)
     export namespace Id {
@@ -890,6 +887,8 @@ export namespace Node {
         export function isId(value: tree.Node.Id.System): value is Id;
         // (undocumented)
         export function isId(value: unknown): value is Id;
+        // (undocumented)
+        export function makeId<T extends string = string, N extends string = string>(value?: N | tree.Node.Id.User<T, N>): Id<""> | Id<N> | tree.Node.Id.User<T, N>;
     }
     // (undocumented)
     export function isNode(value: unknown): value is Node;
@@ -1035,7 +1034,7 @@ export class Shadow extends Node<"shadow"> {
     // (undocumented)
     get mode(): Shadow.Mode;
     // (undocumented)
-    static of(children: Iterable<Node>, style?: Iterable<Sheet>, mode?: Shadow.Mode, nodeId?: Node_2.Id.User): Shadow;
+    static of(children: Iterable<Node>, style?: Iterable<Sheet>, mode?: Shadow.Mode, nodeId?: Node_2.Id.User | string): Shadow;
     // (undocumented)
     parent(options?: Node.Traversal): Option<Node>;
     // (undocumented)
@@ -1210,7 +1209,7 @@ export class Text extends Node<"text"> implements Slotable {
     // @internal (undocumented)
     protected _internalPath(options?: Node.Traversal): string;
     // (undocumented)
-    static of(data: string, nodeId?: Node_2.Id.User): Text;
+    static of(data: string, nodeId?: Node_2.Id.User | string): Text;
     // (undocumented)
     parent(options?: Node.Traversal): Option<Node>;
     // (undocumented)
@@ -1239,7 +1238,7 @@ export class Type<N extends string = string> extends Node<"type"> {
     // (undocumented)
     get name(): N;
     // (undocumented)
-    static of<N extends string = string>(name: N, publicId?: Option<string>, systemId?: Option<string>, nodeId?: Node_2.Id.User): Type<N>;
+    static of<N extends string = string>(name: N, publicId?: Option<string>, systemId?: Option<string>, nodeId?: Node_2.Id.User | string): Type<N>;
     // (undocumented)
     get publicId(): Option<string>;
     // (undocumented)

--- a/docs/review/api/alfa-dom.api.md
+++ b/docs/review/api/alfa-dom.api.md
@@ -10,6 +10,7 @@ import { Flags } from '@siteimprove/alfa-flags';
 import { Iterable as Iterable_2 } from '@siteimprove/alfa-iterable';
 import * as json from '@siteimprove/alfa-json';
 import { Media } from '@siteimprove/alfa-media';
+import { Node as Node_2 } from '@siteimprove/alfa-tree';
 import { Option } from '@siteimprove/alfa-option';
 import { Predicate } from '@siteimprove/alfa-predicate';
 import { Refinement } from '@siteimprove/alfa-refinement';
@@ -38,7 +39,7 @@ export class Attribute<N extends string = string> extends Node<"attribute"> {
     // (undocumented)
     get namespace(): Option<Namespace>;
     // (undocumented)
-    static of<N extends string = string>(namespace: Option<Namespace>, prefix: Option<string>, name: N, value: string): Attribute<N>;
+    static of<N extends string = string>(namespace: Option<Namespace>, prefix: Option<string>, name: N, value: string, nodeId?: Node_2.Id.User): Attribute<N>;
     // (undocumented)
     get owner(): Option<Element>;
     // (undocumented)
@@ -119,7 +120,7 @@ export class Comment extends Node<"comment"> {
     // @internal (undocumented)
     protected _internalPath(options?: Node.Traversal): string;
     // (undocumented)
-    static of(data: string): Comment;
+    static of(data: string, nodeId?: Node_2.Id.User): Comment;
     // (undocumented)
     toJSON(): Comment.JSON;
     // (undocumented)
@@ -215,7 +216,7 @@ export class Document extends Node<"document"> {
     // @internal (undocumented)
     protected _internalPath(options?: Node.Traversal): string;
     // (undocumented)
-    static of(children: Iterable<Node>, style?: Iterable<Sheet>): Document;
+    static of(children: Iterable<Node>, style?: Iterable<Sheet>, nodeId?: Node_2.Id.User): Document;
     // (undocumented)
     parent(options?: Node.Traversal): Option<Node>;
     // (undocumented)
@@ -272,7 +273,7 @@ export class Element<N extends string = string> extends Node<"element"> implemen
     // (undocumented)
     get namespace(): Option<Namespace>;
     // (undocumented)
-    static of<N extends string = string>(namespace: Option<Namespace>, prefix: Option<string>, name: N, attributes?: Iterable_2<Attribute>, children?: Iterable_2<Node>, style?: Option<Block>): Element<N>;
+    static of<N extends string = string>(namespace: Option<Namespace>, prefix: Option<string>, name: N, attributes?: Iterable_2<Attribute>, children?: Iterable_2<Node>, style?: Option<Block>, nodeId?: Node_2.Id.User): Element<N>;
     // (undocumented)
     parent(options?: Node.Traversal): Option<Node>;
     // (undocumented)
@@ -374,7 +375,7 @@ export class Fragment extends Node<"fragment"> {
     // @internal (undocumented)
     protected _internalPath(): string;
     // (undocumented)
-    static of(children: Iterable<Node>): Fragment;
+    static of(children: Iterable<Node>, nodeId?: Node_2.Id.User): Fragment;
     // (undocumented)
     toString(): string;
 }
@@ -753,8 +754,8 @@ export namespace NamespaceRule {
 }
 
 // @public (undocumented)
-export abstract class Node<T extends string = string> extends tree.Node<Node.Traversal.Flag, T> implements earl.Serializable<Node.EARL>, json.Serializable<tree.Node.JSON<T>>, sarif.Serializable<sarif.Location> {
-    protected constructor(children: Array<Node>, type: T);
+export abstract class Node<T extends string = string> extends tree.Node<Node.Traversal.Flag, T, "dom"> implements earl.Serializable<Node.EARL>, json.Serializable<tree.Node.JSON<T>>, sarif.Serializable<sarif.Location> {
+    protected constructor(children: Array<Node>, type: T, nodeId: Node.Id | tree.Node.Id.User);
     // (undocumented)
     equals(value: Node): boolean;
     // (undocumented)
@@ -872,11 +873,38 @@ export namespace Node {
     export function from(json: JSON): Node;
     // @internal (undocumented)
     export function fromNode(json: JSON): Trampoline<Node>;
+    // @internal (undocumented)
+    export class Id<N extends string = string> extends tree.Node.Id.System<"dom", N> {
+        protected constructor(namespace: N, id: number);
+        protected constructor(type: "dom", namespace: N, id: number);
+        static create(): Id<"">;
+        // (undocumented)
+        static create<N extends string = string>(namespace: N): Id<N>;
+    }
+    // @internal (undocumented)
+    export namespace Id {
+        // (undocumented)
+        export function isId(value: tree.Node.Id.System): value is Id;
+        // (undocumented)
+        export function isId(value: unknown): value is Id;
+    }
     // (undocumented)
     export function isNode(value: unknown): value is Node;
     // (undocumented)
     export interface JSON<T extends string = string> extends tree.Node.JSON<T> {
     }
+    const // Warning: (ae-forgotten-export) The symbol "traversal" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    getNodesBetween: typeof traversal.getNodesBetween;
+    const // Warning: (ae-forgotten-export) The symbol "predicate" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    hasChild: typeof predicate_3.hasChild, // (undocumented)
+    hasDescendant: typeof predicate_3.hasDescendant, // (undocumented)
+    hasInclusiveDescendant: typeof predicate_3.hasInclusiveDescendant, // (undocumented)
+    hasTextContent: typeof predicate_3.hasTextContent, // (undocumented)
+    isRoot: typeof predicate_3.isRoot;
     // (undocumented)
     export class Traversal extends Flags<Traversal.Flag> {
         // (undocumented)
@@ -894,18 +922,6 @@ export namespace Node {
         const // (undocumented)
         empty: Traversal;
     }
-    const // Warning: (ae-forgotten-export) The symbol "traversal" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    getNodesBetween: typeof traversal.getNodesBetween;
-    const // Warning: (ae-forgotten-export) The symbol "predicate" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    hasChild: typeof predicate_3.hasChild, // (undocumented)
-    hasDescendant: typeof predicate_3.hasDescendant, // (undocumented)
-    hasInclusiveDescendant: typeof predicate_3.hasInclusiveDescendant, // (undocumented)
-    hasTextContent: typeof predicate_3.hasTextContent, // (undocumented)
-    isRoot: typeof predicate_3.isRoot;
 }
 
 // @public (undocumented)
@@ -1016,7 +1032,7 @@ export class Shadow extends Node<"shadow"> {
     // (undocumented)
     get mode(): Shadow.Mode;
     // (undocumented)
-    static of(children: Iterable<Node>, style?: Iterable<Sheet>, mode?: Shadow.Mode): Shadow;
+    static of(children: Iterable<Node>, style?: Iterable<Sheet>, mode?: Shadow.Mode, nodeId?: Node_2.Id.User): Shadow;
     // (undocumented)
     parent(options?: Node.Traversal): Option<Node>;
     // (undocumented)
@@ -1191,7 +1207,7 @@ export class Text extends Node<"text"> implements Slotable {
     // @internal (undocumented)
     protected _internalPath(options?: Node.Traversal): string;
     // (undocumented)
-    static of(data: string): Text;
+    static of(data: string, nodeId?: Node_2.Id.User): Text;
     // (undocumented)
     parent(options?: Node.Traversal): Option<Node>;
     // (undocumented)
@@ -1220,7 +1236,7 @@ export class Type<N extends string = string> extends Node<"type"> {
     // (undocumented)
     get name(): N;
     // (undocumented)
-    static of<N extends string = string>(name: N, publicId?: Option<string>, systemId?: Option<string>): Type<N>;
+    static of<N extends string = string>(name: N, publicId?: Option<string>, systemId?: Option<string>, nodeId?: Node_2.Id.User): Type<N>;
     // (undocumented)
     get publicId(): Option<string>;
     // (undocumented)

--- a/docs/review/api/alfa-dom.api.md
+++ b/docs/review/api/alfa-dom.api.md
@@ -262,6 +262,8 @@ export class Element<N extends string = string> extends Node<"element"> implemen
     get classes(): Sequence<string>;
     // (undocumented)
     get content(): Option<Document>;
+    // @internal
+    static _createUnsafe<N extends string = string>(nodeId: number, namespace: Option<Namespace>, prefix: Option<string>, name: N, attributes?: Iterable_2<Attribute>, children?: Iterable_2<Node>, style?: Option<Block>): Element<N>;
     // (undocumented)
     get id(): Option<string>;
     // @internal (undocumented)
@@ -880,6 +882,7 @@ export namespace Node {
         static create(): Id<"">;
         // (undocumented)
         static create<N extends string = string>(namespace: N): Id<N>;
+        static _createUnsafe(id: number): Id<"">;
     }
     // @internal (undocumented)
     export namespace Id {

--- a/docs/review/api/alfa-tree.api.md
+++ b/docs/review/api/alfa-tree.api.md
@@ -6,6 +6,8 @@
 
 import { Equatable } from '@siteimprove/alfa-equatable';
 import { Flags } from '@siteimprove/alfa-flags';
+import { Hash } from '@siteimprove/alfa-hash';
+import { Hashable } from '@siteimprove/alfa-hash';
 import * as json from '@siteimprove/alfa-json';
 import { Option } from '@siteimprove/alfa-option';
 import { Predicate } from '@siteimprove/alfa-predicate';
@@ -13,10 +15,10 @@ import { Refinement } from '@siteimprove/alfa-refinement';
 import { Sequence } from '@siteimprove/alfa-sequence';
 
 // @public
-export abstract class Node<F extends Flags.allFlags, T extends string = string> implements Iterable<Node<F>>, Equatable, json.Serializable<Node.JSON<T>> {
+export abstract class Node<F extends Flags.allFlags, T extends string = string, N extends string = string> implements Iterable<Node<F>>, Equatable, json.Serializable<Node.JSON<T>> {
     // (undocumented)
     [Symbol.iterator](): Iterator<Node<F>>;
-    protected constructor(children: Array<Node<F>>, type: T);
+    protected constructor(children: Array<Node<F>>, type: T, nodeId: Node.Id.System<N> | Node.Id.User);
     // (undocumented)
     ancestors(options?: Flags<F>): Sequence<Node<F>>;
     // @internal (undocumented)
@@ -74,6 +76,8 @@ export abstract class Node<F extends Flags.allFlags, T extends string = string> 
     // (undocumented)
     next(options?: Flags<F>): Option<Node<F>>;
     // (undocumented)
+    get nodeId(): Node.Id.System<N> | Node.Id.User;
+    // (undocumented)
     parent(options?: Flags<F>): Option<Node<F>>;
     // (undocumented)
     protected _parent: Option<Node<F>>;
@@ -95,12 +99,106 @@ export abstract class Node<F extends Flags.allFlags, T extends string = string> 
 
 // @public (undocumented)
 export namespace Node {
+    // @internal (undocumented)
+    export abstract class Id<K extends Id.Kind, T extends string = string, N extends string = string> implements Equatable, Hashable, json.Serializable<Id.JSON<T, N>> {
+        protected constructor(kind: K, type: T, namespace: N, id: number);
+        // (undocumented)
+        equals(value: Id<Id.Kind>): value is this;
+        // (undocumented)
+        equals(value: unknown): boolean;
+        // (undocumented)
+        hash(hash: Hash): void;
+        // (undocumented)
+        get id(): number;
+        // (undocumented)
+        protected readonly _id: number;
+        // (undocumented)
+        get kind(): K;
+        // (undocumented)
+        protected readonly _kind: K;
+        // (undocumented)
+        get namespace(): N;
+        // (undocumented)
+        protected readonly _namespace: N;
+        // (undocumented)
+        toJSON(): Id.JSON<T, N>;
+        // (undocumented)
+        toString(): string;
+        // (undocumented)
+        get type(): T;
+        // (undocumented)
+        protected readonly _type: T;
+    }
+    // @internal (undocumented)
+    export namespace Id {
+        // (undocumented)
+        export interface JSON<T extends string = string, N extends string = string> {
+            // (undocumented)
+            [key: string]: json.JSON;
+            // (undocumented)
+            id: number;
+            // (undocumented)
+            namespace: N;
+            // (undocumented)
+            type: T;
+        }
+        // (undocumented)
+        export enum Kind {
+            // (undocumented)
+            System = "alfa",
+            // (undocumented)
+            User = "user"
+        }
+        // (undocumented)
+        export abstract class System<T extends string = string, N extends string = string> extends Id<Kind.System, `alfa-${T}`, N> {
+            protected constructor(type: T, namespace: N, id: number);
+        }
+        // (undocumented)
+        export namespace System {
+            // (undocumented)
+            export function isSystem(value: Id<Kind>): value is System;
+            // (undocumented)
+            export function isSystem(value: unknown): value is System;
+        }
+        const // (undocumented)
+        user: typeof User.of, // (undocumented)
+        isUser: typeof User.isUser;
+        // Warning: (ae-incompatible-release-tags) The symbol "User" is marked as @public, but its signature references "Kind" which is marked as @internal
+        //
+        // @public (undocumented)
+        export class User<T extends string = string, N extends string = string> extends Id<Kind.User, T, N> {
+            protected constructor(type: T, namespace: N, id: number);
+            // (undocumented)
+            static fromId<T extends string = string, N extends string = string>(json: Id.JSON<T, N>): User<T, N>;
+            // (undocumented)
+            static of(id: number): User<"", "">;
+            // (undocumented)
+            static of<T extends string = string>(type: T, id: number): User<T, "">;
+            // (undocumented)
+            static of<T extends string = string, N extends string = string>(type: T, namespace: N, id: number): User<T, N>;
+        }
+        // @public (undocumented)
+        export namespace User {
+            // Warning: (ae-incompatible-release-tags) The symbol "isUser" is marked as @public, but its signature references "Kind" which is marked as @internal
+            //
+            // (undocumented)
+            export function isUser(value: Id<Kind>): value is User;
+            // (undocumented)
+            export function isUser(value: unknown): value is User;
+        }
+        const // (undocumented)
+        isSystem: typeof System.isSystem;
+    }
     // (undocumented)
     export interface JSON<T extends string = string> {
         // (undocumented)
         [key: string]: json.JSON | undefined;
         // (undocumented)
         children?: Array<JSON>;
+        // Warning: (ae-incompatible-release-tags) The symbol "nodeId" is marked as @public, but its signature references "Id" which is marked as @internal
+        //
+        // (undocumented)
+        nodeId?: Id.JSON;
         // (undocumented)
         type: T;
     }

--- a/packages/alfa-aria/src/node.ts
+++ b/packages/alfa-aria/src/node.ts
@@ -105,8 +105,6 @@ export abstract class Node<T extends string = string>
     );
   }
 
-  // public abstract clone(parent?: Option<Node>): Node;
-
   public abstract isIgnored(): boolean;
 
   public toJSON(): Node.JSON<T> {

--- a/packages/alfa-aria/src/node/container.ts
+++ b/packages/alfa-aria/src/node/container.ts
@@ -1,4 +1,3 @@
-import { None, Option } from "@siteimprove/alfa-option";
 import { Node as treeNode } from "@siteimprove/alfa-tree";
 
 import * as dom from "@siteimprove/alfa-dom";
@@ -28,13 +27,6 @@ export class Container extends Node<"container"> {
   ) {
     super(owner, children, "container", nodeId);
   }
-
-  // public clone(parent: Option<Node> = None): Container {
-  //   return new Container(
-  //     this._node,
-  //     (this._children as Array<Node>).map((child) => child.clone())
-  //   );
-  // }
 
   public isIgnored(): boolean {
     return true;

--- a/packages/alfa-aria/src/node/container.ts
+++ b/packages/alfa-aria/src/node/container.ts
@@ -1,4 +1,5 @@
 import { None, Option } from "@siteimprove/alfa-option";
+import { Node as treeNode } from "@siteimprove/alfa-tree";
 
 import * as dom from "@siteimprove/alfa-dom";
 
@@ -8,20 +9,32 @@ import { Node } from "../node";
  * @public
  */
 export class Container extends Node<"container"> {
-  public static of(owner: dom.Node, children: Iterable<Node> = []): Container {
-    return new Container(owner, Array.from(children));
-  }
-
-  private constructor(owner: dom.Node, children: Array<Node>) {
-    super(owner, children, "container");
-  }
-
-  public clone(parent: Option<Node> = None): Container {
+  public static of(
+    owner: dom.Node,
+    children: Iterable<Node> = [],
+    nodeID?: treeNode.Id.User
+  ): Container {
     return new Container(
-      this._node,
-      (this._children as Array<Node>).map((child) => child.clone())
+      owner,
+      Array.from(children),
+      nodeID ?? Node.Id.create(owner.nodeId.namespace)
     );
   }
+
+  private constructor(
+    owner: dom.Node,
+    children: Array<Node>,
+    nodeId: Node.Id | treeNode.Id.User
+  ) {
+    super(owner, children, "container", nodeId);
+  }
+
+  // public clone(parent: Option<Node> = None): Container {
+  //   return new Container(
+  //     this._node,
+  //     (this._children as Array<Node>).map((child) => child.clone())
+  //   );
+  // }
 
   public isIgnored(): boolean {
     return true;

--- a/packages/alfa-aria/src/node/element.ts
+++ b/packages/alfa-aria/src/node/element.ts
@@ -2,6 +2,7 @@ import { Iterable } from "@siteimprove/alfa-iterable";
 import { None, Option } from "@siteimprove/alfa-option";
 import { Predicate } from "@siteimprove/alfa-predicate";
 import { Refinement } from "@siteimprove/alfa-refinement";
+import { Node as treeNode } from "@siteimprove/alfa-tree";
 
 import * as dom from "@siteimprove/alfa-dom";
 
@@ -19,14 +20,16 @@ export class Element extends Node<"element"> {
     role: Option<Role> = None,
     name: Option<Name> = None,
     attributes: Iterable<Attribute> = [],
-    children: Iterable<Node> = []
+    children: Iterable<Node> = [],
+    nodeId?: treeNode.Id.User
   ): Element {
     return new Element(
       owner,
       role,
       name,
       Array.from(attributes),
-      Array.from(children)
+      Array.from(children),
+      nodeId ?? Node.Id.create(owner.nodeId.namespace)
     );
   }
 
@@ -39,9 +42,10 @@ export class Element extends Node<"element"> {
     role: Option<Role>,
     name: Option<Name>,
     attributes: Array<Attribute>,
-    children: Array<Node>
+    children: Array<Node>,
+    nodeId: Node.Id | treeNode.Id.User
   ) {
-    super(owner, children, "element");
+    super(owner, children, "element", nodeId);
 
     this._role = role;
     this._name = name;
@@ -81,15 +85,15 @@ export class Element extends Node<"element"> {
     );
   }
 
-  public clone(): Element {
-    return new Element(
-      this._node,
-      this._role,
-      this._name,
-      this._attributes,
-      (this._children as Array<Node>).map((child) => child.clone())
-    );
-  }
+  // public clone(): Element {
+  //   return new Element(
+  //     this._node,
+  //     this._role,
+  //     this._name,
+  //     this._attributes,
+  //     (this._children as Array<Node>).map((child) => child.clone())
+  //   );
+  // }
 
   public isIgnored(): boolean {
     return false;

--- a/packages/alfa-aria/src/node/element.ts
+++ b/packages/alfa-aria/src/node/element.ts
@@ -85,16 +85,6 @@ export class Element extends Node<"element"> {
     );
   }
 
-  // public clone(): Element {
-  //   return new Element(
-  //     this._node,
-  //     this._role,
-  //     this._name,
-  //     this._attributes,
-  //     (this._children as Array<Node>).map((child) => child.clone())
-  //   );
-  // }
-
   public isIgnored(): boolean {
     return false;
   }

--- a/packages/alfa-aria/src/node/inert.ts
+++ b/packages/alfa-aria/src/node/inert.ts
@@ -15,10 +15,6 @@ export class Inert extends Node<"inert"> {
     super(owner, [], "inert", nodeId);
   }
 
-  // public clone(): Inert {
-  //   return new Inert(this._node);
-  // }
-
   public isIgnored(): boolean {
     return true;
   }

--- a/packages/alfa-aria/src/node/inert.ts
+++ b/packages/alfa-aria/src/node/inert.ts
@@ -1,4 +1,5 @@
 import * as dom from "@siteimprove/alfa-dom";
+import { Node as treeNode } from "@siteimprove/alfa-tree";
 
 import { Node } from "../node";
 
@@ -6,17 +7,17 @@ import { Node } from "../node";
  * @public
  */
 export class Inert extends Node<"inert"> {
-  public static of(owner: dom.Node): Inert {
-    return new Inert(owner);
+  public static of(owner: dom.Node, nodeId?: treeNode.Id.User): Inert {
+    return new Inert(owner, nodeId ?? Node.Id.create(owner.nodeId.namespace));
   }
 
-  private constructor(owner: dom.Node) {
-    super(owner, [], "inert");
+  private constructor(owner: dom.Node, nodeId: Node.Id | treeNode.Id.User) {
+    super(owner, [], "inert", nodeId);
   }
 
-  public clone(): Inert {
-    return new Inert(this._node);
-  }
+  // public clone(): Inert {
+  //   return new Inert(this._node);
+  // }
 
   public isIgnored(): boolean {
     return true;

--- a/packages/alfa-aria/src/node/text.ts
+++ b/packages/alfa-aria/src/node/text.ts
@@ -38,10 +38,6 @@ export class Text extends Node<"text"> {
     return this._name;
   }
 
-  // public clone(): Text {
-  //   return new Text(this._node, this._name);
-  // }
-
   public isIgnored(): boolean {
     return false;
   }

--- a/packages/alfa-aria/src/node/text.ts
+++ b/packages/alfa-aria/src/node/text.ts
@@ -1,4 +1,5 @@
 import { Option } from "@siteimprove/alfa-option";
+import { Node as treeNode } from "@siteimprove/alfa-tree";
 
 import * as dom from "@siteimprove/alfa-dom";
 
@@ -9,14 +10,26 @@ import { Node } from "../node";
  * @public
  */
 export class Text extends Node<"text"> {
-  public static of(owner: dom.Node, name: Option<Name>): Text {
-    return new Text(owner, name);
+  public static of(
+    owner: dom.Node,
+    name: Option<Name>,
+    nodeId?: treeNode.Id.User
+  ): Text {
+    return new Text(
+      owner,
+      name,
+      nodeId ?? Node.Id.create(owner.nodeId.namespace)
+    );
   }
 
   private readonly _name: Option<Name>;
 
-  private constructor(owner: dom.Node, name: Option<Name>) {
-    super(owner, [], "text");
+  private constructor(
+    owner: dom.Node,
+    name: Option<Name>,
+    nodeId: Node.Id | treeNode.Id.User
+  ) {
+    super(owner, [], "text", nodeId);
 
     this._name = name;
   }
@@ -25,9 +38,9 @@ export class Text extends Node<"text"> {
     return this._name;
   }
 
-  public clone(): Text {
-    return new Text(this._node, this._name);
-  }
+  // public clone(): Text {
+  //   return new Text(this._node, this._name);
+  // }
 
   public isIgnored(): boolean {
     return false;

--- a/packages/alfa-dom/src/node.ts
+++ b/packages/alfa-dom/src/node.ts
@@ -33,7 +33,7 @@ export abstract class Node<T extends string = string>
   extends tree.Node<Node.Traversal.Flag, T, "dom">
   implements
     earl.Serializable<Node.EARL>,
-    json.Serializable<tree.Node.JSON<T>>,
+    json.Serializable<Node.JSON<T>>,
     sarif.Serializable<sarif.Location>
 {
   protected constructor(
@@ -434,6 +434,25 @@ export namespace Node {
 
     export function isId(value: unknown): value is Id {
       return value instanceof Id;
+    }
+    /**
+     * @internal
+     */
+    export function makeId<
+      T extends string = string,
+      N extends string = string
+    >(
+      value?: N | tree.Node.Id.User<T, N>
+    ): Id<""> | Id<N> | tree.Node.Id.User<T, N> {
+      if (tree.Node.Id.isUser(value)) {
+        return value;
+      }
+
+      if (value === undefined) {
+        return Id.create();
+      }
+
+      return Id.create(value);
     }
   }
 }

--- a/packages/alfa-dom/src/node.ts
+++ b/packages/alfa-dom/src/node.ts
@@ -435,6 +435,7 @@ export namespace Node {
     export function isId(value: unknown): value is Id {
       return value instanceof Id;
     }
+
     /**
      * @internal
      */

--- a/packages/alfa-dom/src/node.ts
+++ b/packages/alfa-dom/src/node.ts
@@ -387,27 +387,40 @@ export namespace Node {
   /**
    * @internal
    */
-  export class Id extends tree.Node.Id.System<"dom"> {
-    public static create(): Id {
+  export class Id<N extends string = string> extends tree.Node.Id.System<
+    "dom",
+    N
+  > {
+    /**
+     * Create a new Node id by incrementing counter.
+     */
+    public static create(): Id<"">;
+
+    public static create<N extends string = string>(namespace: N): Id<N>;
+
+    public static create<N extends string = string>(namespace?: N): Id<N | ""> {
       this._lastUsedId += 1;
-      return new Id(this._lastUsedId);
+      return new Id(namespace ?? "", this._lastUsedId);
     }
 
     private static _lastUsedId = -1;
 
-    protected constructor(id: number);
+    protected constructor(namespace: N, id: number);
 
-    protected constructor(prefix: string, namespace: string, id: number);
+    protected constructor(type: "dom", namespace: N, id: number);
 
     protected constructor(
-      prefixOrId: string | number,
-      namespace?: string,
+      namespaceOrType: "dom" | N,
+      idOrNamespace: N | number,
       id?: number
     ) {
-      // prefix and namespace are hardcoded for system IDs and only kept in
-      // the signature for compatibility with parent class, needed for correct
-      // inheritance of Node…
-      super("dom", typeof prefixOrId === "number" ? prefixOrId : id!);
+      // Type is hardcoded for system IDs and only kept in the signature for
+      // compatibility with parent class, needed for correct inheritance of Node…
+      super(
+        "dom",
+        id === undefined ? (namespaceOrType as N) : (idOrNamespace as N),
+        id ?? (idOrNamespace as number)
+      );
     }
   }
 

--- a/packages/alfa-dom/src/node/attribute.ts
+++ b/packages/alfa-dom/src/node/attribute.ts
@@ -23,14 +23,14 @@ export class Attribute<N extends string = string> extends Node<"attribute"> {
     prefix: Option<string>,
     name: N,
     value: string,
-    nodeId?: treeNode.Id.User
+    nodeId?: treeNode.Id.User | string
   ): Attribute<N> {
     return new Attribute(
       namespace,
       prefix,
       name,
       value,
-      nodeId ?? Node.Id.create()
+      Node.Id.makeId(nodeId)
     );
   }
 

--- a/packages/alfa-dom/src/node/attribute.ts
+++ b/packages/alfa-dom/src/node/attribute.ts
@@ -3,6 +3,7 @@ import { None, Option } from "@siteimprove/alfa-option";
 import { Predicate } from "@siteimprove/alfa-predicate";
 import { Sequence } from "@siteimprove/alfa-sequence";
 import { Trampoline } from "@siteimprove/alfa-trampoline";
+import { Node as treeNode } from "@siteimprove/alfa-tree";
 
 import { Namespace } from "../namespace";
 import { Node } from "../node";
@@ -21,9 +22,16 @@ export class Attribute<N extends string = string> extends Node<"attribute"> {
     namespace: Option<Namespace>,
     prefix: Option<string>,
     name: N,
-    value: string
+    value: string,
+    nodeId?: treeNode.Id.User
   ): Attribute<N> {
-    return new Attribute(namespace, prefix, name, value);
+    return new Attribute(
+      namespace,
+      prefix,
+      name,
+      value,
+      nodeId ?? Node.Id.create()
+    );
   }
 
   private readonly _namespace: Option<Namespace>;
@@ -36,9 +44,10 @@ export class Attribute<N extends string = string> extends Node<"attribute"> {
     namespace: Option<Namespace>,
     prefix: Option<string>,
     name: N,
-    value: string
+    value: string,
+    nodeId: Node.Id | treeNode.Id.User
   ) {
-    super([], "attribute");
+    super([], "attribute", nodeId);
 
     this._namespace = namespace;
     this._prefix = prefix;

--- a/packages/alfa-dom/src/node/comment.ts
+++ b/packages/alfa-dom/src/node/comment.ts
@@ -1,4 +1,5 @@
 import { Trampoline } from "@siteimprove/alfa-trampoline";
+import { Node as treeNode } from "@siteimprove/alfa-tree";
 
 import { Node } from "../node";
 
@@ -6,18 +7,18 @@ import { Node } from "../node";
  * @public
  */
 export class Comment extends Node<"comment"> {
-  public static of(data: string): Comment {
-    return new Comment(data);
+  public static of(data: string, nodeId?: treeNode.Id.User): Comment {
+    return new Comment(data, nodeId ?? Node.Id.create());
   }
 
   public static empty(): Comment {
-    return new Comment("");
+    return new Comment("", Node.Id.create());
   }
 
   private readonly _data: string;
 
-  private constructor(data: string) {
-    super([], "comment");
+  private constructor(data: string, nodeId: Node.Id | treeNode.Id.User) {
+    super([], "comment", nodeId);
 
     this._data = data;
   }

--- a/packages/alfa-dom/src/node/comment.ts
+++ b/packages/alfa-dom/src/node/comment.ts
@@ -7,8 +7,8 @@ import { Node } from "../node";
  * @public
  */
 export class Comment extends Node<"comment"> {
-  public static of(data: string, nodeId?: treeNode.Id.User): Comment {
-    return new Comment(data, nodeId ?? Node.Id.create());
+  public static of(data: string, nodeId?: treeNode.Id.User | string): Comment {
+    return new Comment(data, Node.Id.makeId(nodeId));
   }
 
   public static empty(): Comment {

--- a/packages/alfa-dom/src/node/document.ts
+++ b/packages/alfa-dom/src/node/document.ts
@@ -1,5 +1,6 @@
 import { None, Option } from "@siteimprove/alfa-option";
 import { Trampoline } from "@siteimprove/alfa-trampoline";
+import { Node as treeNode } from "@siteimprove/alfa-tree";
 
 import { Node } from "../node";
 import { Sheet } from "../style/sheet";
@@ -11,20 +12,29 @@ import { Element } from "./element";
 export class Document extends Node<"document"> {
   public static of(
     children: Iterable<Node>,
-    style: Iterable<Sheet> = []
+    style: Iterable<Sheet> = [],
+    nodeId?: treeNode.Id.User
   ): Document {
-    return new Document(Array.from(children), style);
+    return new Document(
+      Array.from(children),
+      style,
+      nodeId ?? Node.Id.create()
+    );
   }
 
   public static empty(): Document {
-    return new Document([], []);
+    return new Document([], [], Node.Id.create());
   }
 
   private readonly _style: Array<Sheet>;
   private _frame: Option<Element> = None;
 
-  private constructor(children: Array<Node>, style: Iterable<Sheet>) {
-    super(children, "document");
+  private constructor(
+    children: Array<Node>,
+    style: Iterable<Sheet>,
+    nodeId: Node.Id | treeNode.Id.User
+  ) {
+    super(children, "document", nodeId);
 
     this._style = Array.from(style);
   }

--- a/packages/alfa-dom/src/node/document.ts
+++ b/packages/alfa-dom/src/node/document.ts
@@ -13,13 +13,9 @@ export class Document extends Node<"document"> {
   public static of(
     children: Iterable<Node>,
     style: Iterable<Sheet> = [],
-    nodeId?: treeNode.Id.User
+    nodeId?: treeNode.Id.User | string
   ): Document {
-    return new Document(
-      Array.from(children),
-      style,
-      nodeId ?? Node.Id.create()
-    );
+    return new Document(Array.from(children), style, Node.Id.makeId(nodeId));
   }
 
   public static empty(): Document {

--- a/packages/alfa-dom/src/node/element.ts
+++ b/packages/alfa-dom/src/node/element.ts
@@ -3,6 +3,7 @@ import { None, Option, Some } from "@siteimprove/alfa-option";
 import { Predicate } from "@siteimprove/alfa-predicate";
 import { Sequence } from "@siteimprove/alfa-sequence";
 import { Trampoline } from "@siteimprove/alfa-trampoline";
+import { Node as treeNode } from "@siteimprove/alfa-tree";
 
 import { Namespace } from "../namespace";
 import { Node } from "../node";
@@ -31,7 +32,8 @@ export class Element<N extends string = string>
     name: N,
     attributes: Iterable<Attribute> = [],
     children: Iterable<Node> = [],
-    style: Option<Block> = None
+    style: Option<Block> = None,
+    nodeId?: treeNode.Id.User
   ): Element<N> {
     return new Element(
       namespace,
@@ -39,7 +41,8 @@ export class Element<N extends string = string>
       name,
       Array.from(attributes),
       Array.from(children),
-      style
+      style,
+      nodeId ?? Node.Id.create()
     );
   }
 
@@ -59,9 +62,10 @@ export class Element<N extends string = string>
     name: N,
     attributes: Array<Attribute>,
     children: Array<Node>,
-    style: Option<Block>
+    style: Option<Block>,
+    nodeId: Node.Id | treeNode.Id.User
   ) {
-    super(children, "element");
+    super(children, "element", nodeId);
 
     this._namespace = namespace;
     this._prefix = prefix;

--- a/packages/alfa-dom/src/node/element.ts
+++ b/packages/alfa-dom/src/node/element.ts
@@ -33,7 +33,7 @@ export class Element<N extends string = string>
     attributes: Iterable<Attribute> = [],
     children: Iterable<Node> = [],
     style: Option<Block> = None,
-    nodeId?: treeNode.Id.User
+    nodeId?: treeNode.Id.User | string
   ): Element<N> {
     return new Element(
       namespace,
@@ -42,7 +42,7 @@ export class Element<N extends string = string>
       Array.from(attributes),
       Array.from(children),
       style,
-      nodeId ?? Node.Id.create()
+      Node.Id.makeId(nodeId)
     );
   }
 

--- a/packages/alfa-dom/src/node/fragment.ts
+++ b/packages/alfa-dom/src/node/fragment.ts
@@ -9,9 +9,9 @@ import { Node } from "../node";
 export class Fragment extends Node<"fragment"> {
   public static of(
     children: Iterable<Node>,
-    nodeId?: treeNode.Id.User
+    nodeId?: treeNode.Id.User | string
   ): Fragment {
-    return new Fragment(Array.from(children), nodeId ?? Node.Id.create());
+    return new Fragment(Array.from(children), Node.Id.makeId(nodeId));
   }
 
   public static empty(): Fragment {

--- a/packages/alfa-dom/src/node/fragment.ts
+++ b/packages/alfa-dom/src/node/fragment.ts
@@ -1,4 +1,5 @@
 import { Trampoline } from "@siteimprove/alfa-trampoline";
+import { Node as treeNode } from "@siteimprove/alfa-tree";
 
 import { Node } from "../node";
 
@@ -6,16 +7,22 @@ import { Node } from "../node";
  * @public
  */
 export class Fragment extends Node<"fragment"> {
-  public static of(children: Iterable<Node>): Fragment {
-    return new Fragment(Array.from(children));
+  public static of(
+    children: Iterable<Node>,
+    nodeId?: treeNode.Id.User
+  ): Fragment {
+    return new Fragment(Array.from(children), nodeId ?? Node.Id.create());
   }
 
   public static empty(): Fragment {
-    return new Fragment([]);
+    return new Fragment([], Node.Id.create());
   }
 
-  private constructor(children: Array<Node>) {
-    super(children, "fragment");
+  private constructor(
+    children: Array<Node>,
+    nodeId: Node.Id | treeNode.Id.User
+  ) {
+    super(children, "fragment", nodeId);
   }
 
   /**

--- a/packages/alfa-dom/src/node/shadow.ts
+++ b/packages/alfa-dom/src/node/shadow.ts
@@ -1,5 +1,6 @@
 import { None, Option } from "@siteimprove/alfa-option";
 import { Trampoline } from "@siteimprove/alfa-trampoline";
+import { Node as treeNode } from "@siteimprove/alfa-tree";
 
 import { Node } from "../node";
 import { Sheet } from "../style/sheet";
@@ -12,13 +13,19 @@ export class Shadow extends Node<"shadow"> {
   public static of(
     children: Iterable<Node>,
     style: Iterable<Sheet> = [],
-    mode: Shadow.Mode = Shadow.Mode.Open
+    mode: Shadow.Mode = Shadow.Mode.Open,
+    nodeId?: treeNode.Id.User
   ): Shadow {
-    return new Shadow(Array.from(children), Array.from(style), mode);
+    return new Shadow(
+      Array.from(children),
+      Array.from(style),
+      mode,
+      nodeId ?? Node.Id.create()
+    );
   }
 
   public static empty(): Shadow {
-    return new Shadow([], [], Shadow.Mode.Open);
+    return new Shadow([], [], Shadow.Mode.Open, Node.Id.create());
   }
 
   private readonly _mode: Shadow.Mode;
@@ -28,9 +35,10 @@ export class Shadow extends Node<"shadow"> {
   private constructor(
     children: Array<Node>,
     style: Array<Sheet>,
-    mode: Shadow.Mode
+    mode: Shadow.Mode,
+    nodeId: Node.Id | treeNode.Id.User
   ) {
-    super(children, "shadow");
+    super(children, "shadow", nodeId);
 
     this._mode = mode;
     this._style = style;

--- a/packages/alfa-dom/src/node/shadow.ts
+++ b/packages/alfa-dom/src/node/shadow.ts
@@ -14,13 +14,13 @@ export class Shadow extends Node<"shadow"> {
     children: Iterable<Node>,
     style: Iterable<Sheet> = [],
     mode: Shadow.Mode = Shadow.Mode.Open,
-    nodeId?: treeNode.Id.User
+    nodeId?: treeNode.Id.User | string
   ): Shadow {
     return new Shadow(
       Array.from(children),
       Array.from(style),
       mode,
-      nodeId ?? Node.Id.create()
+      Node.Id.makeId(nodeId)
     );
   }
 

--- a/packages/alfa-dom/src/node/text.ts
+++ b/packages/alfa-dom/src/node/text.ts
@@ -1,5 +1,6 @@
 import { Option } from "@siteimprove/alfa-option";
 import { Trampoline } from "@siteimprove/alfa-trampoline";
+import { Node as treeNode } from "@siteimprove/alfa-tree";
 
 import { Node } from "../node";
 import { Element } from "./element";
@@ -11,18 +12,18 @@ import { Slotable } from "./slotable";
  * @public
  */
 export class Text extends Node<"text"> implements Slotable {
-  public static of(data: string): Text {
-    return new Text(data);
+  public static of(data: string, nodeId?: treeNode.Id.User): Text {
+    return new Text(data, nodeId ?? Node.Id.create());
   }
 
   public static empty(): Text {
-    return new Text("");
+    return new Text("", Node.Id.create());
   }
 
   private readonly _data: string;
 
-  private constructor(data: string) {
-    super([], "text");
+  private constructor(data: string, nodeId: Node.Id | treeNode.Id.User) {
+    super([], "text", nodeId);
 
     this._data = data;
   }

--- a/packages/alfa-dom/src/node/text.ts
+++ b/packages/alfa-dom/src/node/text.ts
@@ -12,8 +12,8 @@ import { Slotable } from "./slotable";
  * @public
  */
 export class Text extends Node<"text"> implements Slotable {
-  public static of(data: string, nodeId?: treeNode.Id.User): Text {
-    return new Text(data, nodeId ?? Node.Id.create());
+  public static of(data: string, nodeId?: treeNode.Id.User | string): Text {
+    return new Text(data, Node.Id.makeId(nodeId));
   }
 
   public static empty(): Text {

--- a/packages/alfa-dom/src/node/type.ts
+++ b/packages/alfa-dom/src/node/type.ts
@@ -12,9 +12,9 @@ export class Type<N extends string = string> extends Node<"type"> {
     name: N,
     publicId: Option<string> = None,
     systemId: Option<string> = None,
-    nodeId?: treeNode.Id.User
+    nodeId?: treeNode.Id.User | string
   ): Type<N> {
-    return new Type(name, publicId, systemId, nodeId ?? Node.Id.create());
+    return new Type(name, publicId, systemId, Node.Id.makeId(nodeId));
   }
 
   public static empty(): Type {

--- a/packages/alfa-dom/src/node/type.ts
+++ b/packages/alfa-dom/src/node/type.ts
@@ -1,5 +1,6 @@
 import { None, Option } from "@siteimprove/alfa-option";
 import { Trampoline } from "@siteimprove/alfa-trampoline";
+import { Node as treeNode } from "@siteimprove/alfa-tree";
 
 import { Node } from "../node";
 
@@ -10,13 +11,14 @@ export class Type<N extends string = string> extends Node<"type"> {
   public static of<N extends string = string>(
     name: N,
     publicId: Option<string> = None,
-    systemId: Option<string> = None
+    systemId: Option<string> = None,
+    nodeId?: treeNode.Id.User
   ): Type<N> {
-    return new Type(name, publicId, systemId);
+    return new Type(name, publicId, systemId, nodeId ?? Node.Id.create());
   }
 
   public static empty(): Type {
-    return new Type("html", None, None);
+    return new Type("html", None, None, Node.Id.create());
   }
 
   private readonly _name: N;
@@ -26,9 +28,10 @@ export class Type<N extends string = string> extends Node<"type"> {
   private constructor(
     name: N,
     publicId: Option<string>,
-    systemId: Option<string>
+    systemId: Option<string>,
+    nodeId: Node.Id | treeNode.Id.User
   ) {
-    super([], "type");
+    super([], "type", nodeId);
 
     this._name = name;
     this._publicId = publicId;

--- a/packages/alfa-dom/test/h.spec.ts
+++ b/packages/alfa-dom/test/h.spec.ts
@@ -4,6 +4,7 @@ import { test } from "@siteimprove/alfa-test";
 import { h } from "../src/h";
 
 import { Namespace } from "../src/namespace";
+import { Node } from "../src/node";
 
 import { Document } from "../src/node/document";
 import { Element } from "../src/node/element";

--- a/packages/alfa-dom/test/h.spec.ts
+++ b/packages/alfa-dom/test/h.spec.ts
@@ -17,12 +17,13 @@ import { Type } from "../src/node/type";
  */
 function removeId<N extends Node = Node>(node: N): Serializable.ToJSON<N> {
   function removeId(json: Node.JSON): Node.JSON {
-    return {
-      ...json,
-      children:
-        json.children !== undefined ? json.children.map(removeId) : undefined,
-      nodeId: undefined,
-    };
+    delete json.nodeId;
+
+    if (json.children !== undefined) {
+      json.children = (json.children as Array<Node.JSON>).map(removeId);
+    }
+
+    return json;
   }
 
   return removeId(node.toJSON()) as Serializable.ToJSON<N>;

--- a/packages/alfa-dom/test/node/element.spec.tsx
+++ b/packages/alfa-dom/test/node/element.spec.tsx
@@ -76,3 +76,27 @@ test("Element.of() accepts a user nodeId", (t) => {
     id: 42,
   });
 });
+
+test("Element.of() generates a system nodeId if none is provided", (t) => {
+  const element = Element.of(Option.of(Namespace.HTML), None, "div");
+
+  t.deepEqual(element.nodeId.kind, treeNode.Id.Kind.System);
+  t.deepEqual(element.nodeId.type, "alfa-dom");
+  t.deepEqual(element.nodeId.namespace, "");
+});
+
+test("Element.of() generates a system nodeId with namespace", (t) => {
+  const element = Element.of(
+    Option.of(Namespace.HTML),
+    None,
+    "div",
+    [],
+    [],
+    None,
+    "foo"
+  );
+
+  t.deepEqual(element.nodeId.kind, treeNode.Id.Kind.System);
+  t.deepEqual(element.nodeId.type, "alfa-dom");
+  t.deepEqual(element.nodeId.namespace, "foo");
+});

--- a/packages/alfa-dom/test/node/element.spec.tsx
+++ b/packages/alfa-dom/test/node/element.spec.tsx
@@ -1,4 +1,11 @@
+import { None, Option } from "@siteimprove/alfa-option";
 import { test } from "@siteimprove/alfa-test";
+import { Node as treeNode } from "@siteimprove/alfa-tree";
+
+import { Node } from "../../src/node";
+
+import { Element } from "../../src/node/element";
+import { Namespace } from "../../src/namespace";
 
 test("#tabIndex() returns the tab index explicitly assigned to an element", (t) => {
   t.equal((<div tabindex="42" />).tabIndex().get(), 42);
@@ -48,4 +55,24 @@ test(`#tabIndex() returns None for a <summary> element that is not the first
   </details>;
 
   t.equal(summary.tabIndex().isNone(), true);
+});
+
+test("Element.of() accepts a user nodeId", (t) => {
+  const element = Element.of(
+    Option.of(Namespace.HTML),
+    None,
+    "div",
+    [],
+    [],
+    None,
+    treeNode.Id.user("type", "namespace", 42)
+  );
+
+  t.deepEqual(element.nodeId.kind, treeNode.Id.Kind.User);
+
+  t.deepEqual(element.nodeId.toJSON(), {
+    type: "type",
+    namespace: "namespace",
+    id: 42,
+  });
 });

--- a/packages/alfa-rules/test/sia-er65/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-er65/rule.spec.tsx
@@ -9,14 +9,15 @@ import { oracle } from "../common/oracle";
 
 test(`evaluate() passes an <a> element that uses the default focus outline`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
-  const document = h.document([target, <button />]);
+  const document = h.document([target, button]);
 
   t.deepEqual(await evaluate(R65, { document }), [
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);
@@ -24,9 +25,10 @@ test(`evaluate() passes an <a> element that uses the default focus outline`, asy
 
 test(`evaluate() passes an <a> element that uses a non-default focus outline`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a:focus", {
@@ -40,7 +42,7 @@ test(`evaluate() passes an <a> element that uses a non-default focus outline`, a
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);
@@ -49,9 +51,10 @@ test(`evaluate() passes an <a> element that uses a non-default focus outline`, a
 test(`evaluate() fails an <a> element that removes the default focus outline and
       is determined to have no other focus indicator`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a:focus", {
@@ -73,7 +76,7 @@ test(`evaluate() fails an <a> element that removes the default focus outline and
       failed(R65, target, {
         1: Outcomes.HasNoFocusIndicator,
       }),
-      passed(R65, <button />, {
+      passed(R65, button, {
         1: Outcomes.HasFocusIndicator,
       }),
     ]
@@ -83,9 +86,10 @@ test(`evaluate() fails an <a> element that removes the default focus outline and
 test(`evaluate() passes an <a> element that removes the default focus outline
       and is determined to have some other focus indicator`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a:focus", {
@@ -107,7 +111,7 @@ test(`evaluate() passes an <a> element that removes the default focus outline
       passed(R65, target, {
         1: Outcomes.HasFocusIndicator,
       }),
-      passed(R65, <button />, {
+      passed(R65, button, {
         1: Outcomes.HasFocusIndicator,
       }),
     ]
@@ -117,9 +121,10 @@ test(`evaluate() passes an <a> element that removes the default focus outline
 test(`evaluate() passes an <a> element that removes the default focus outline
       and applies an underline on focus`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a", {
@@ -138,7 +143,7 @@ test(`evaluate() passes an <a> element that removes the default focus outline
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);
@@ -147,9 +152,10 @@ test(`evaluate() passes an <a> element that removes the default focus outline
 test(`evaluate() passes an <a> element that removes the default focus outline
       and whose parent applies an outline when focus is within the parent`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [<div>{target}</div>, <button />],
+    [<div>{target}</div>, button],
     [
       h.sheet([
         h.rule.style("div:focus-within", {
@@ -167,7 +173,7 @@ test(`evaluate() passes an <a> element that removes the default focus outline
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);
@@ -180,9 +186,10 @@ test(`evaluate() passes an <a> element that removes the default focus outline
       <span>Link</span>
     </a>
   );
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a:focus", {
@@ -200,7 +207,7 @@ test(`evaluate() passes an <a> element that removes the default focus outline
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);
@@ -209,9 +216,10 @@ test(`evaluate() passes an <a> element that removes the default focus outline
 test(`evaluate() passes an <a> element that removes the default focus outline
       and applies an outline only when focus should be visible`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a:focus", {
@@ -229,7 +237,7 @@ test(`evaluate() passes an <a> element that removes the default focus outline
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);
@@ -239,9 +247,10 @@ test(`evaluate() fails an <a> element that removes the default focus outline
       only when focus should be visible and is determined to have no other focus
       indicator`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a:focus:focus-visible", {
@@ -263,7 +272,7 @@ test(`evaluate() fails an <a> element that removes the default focus outline
       failed(R65, target, {
         1: Outcomes.HasNoFocusIndicator,
       }),
-      passed(R65, <button />, {
+      passed(R65, button, {
         1: Outcomes.HasFocusIndicator,
       }),
     ]
@@ -273,9 +282,10 @@ test(`evaluate() fails an <a> element that removes the default focus outline
 test(`evaluate() passes an <a> element that removes the default focus outline
       and applies a different color on focus`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a", {
@@ -296,7 +306,7 @@ test(`evaluate() passes an <a> element that removes the default focus outline
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);
@@ -305,9 +315,10 @@ test(`evaluate() passes an <a> element that removes the default focus outline
 test(`evaluate() passes an <a> element that removes the default focus outline
       and applies a different background color on focus`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a", {
@@ -328,7 +339,7 @@ test(`evaluate() passes an <a> element that removes the default focus outline
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);
@@ -337,9 +348,10 @@ test(`evaluate() passes an <a> element that removes the default focus outline
 test(`evaluate() passes an <a> element that removes the default focus outline
       and applies a box shadow on focus`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a", {
@@ -358,7 +370,7 @@ test(`evaluate() passes an <a> element that removes the default focus outline
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);
@@ -367,9 +379,10 @@ test(`evaluate() passes an <a> element that removes the default focus outline
 test(`evaluate() passes an <a> element that removes the default focus outline
       and applies a border on focus`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a:focus", {
@@ -384,7 +397,7 @@ test(`evaluate() passes an <a> element that removes the default focus outline
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);
@@ -393,9 +406,10 @@ test(`evaluate() passes an <a> element that removes the default focus outline
 test(`evaluate() passes an <a> element that removes the default focus outline
       and changes border color on focus`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a", {
@@ -413,7 +427,7 @@ test(`evaluate() passes an <a> element that removes the default focus outline
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);
@@ -425,8 +439,9 @@ test(`evaluate() passes an <a> element that has a class determined to have some 
       Link
     </a>
   );
+  const button = <button />;
 
-  const document = h.document([target, <button />]);
+  const document = h.document([target, button]);
 
   t.deepEqual(
     await evaluate(
@@ -444,7 +459,7 @@ test(`evaluate() passes an <a> element that has a class determined to have some 
       passed(R65, target, {
         1: Outcomes.HasGoodClass,
       }),
-      passed(R65, <button />, {
+      passed(R65, button, {
         1: Outcomes.HasFocusIndicator,
       }),
     ]
@@ -457,8 +472,9 @@ test(`evaluate() passes an <a> element that does not have a class determined to 
       Link
     </a>
   );
+  const button = <button />;
 
-  const document = h.document([target, <button />]);
+  const document = h.document([target, button]);
 
   t.deepEqual(
     await evaluate(
@@ -476,7 +492,7 @@ test(`evaluate() passes an <a> element that does not have a class determined to 
       passed(R65, target, {
         1: Outcomes.HasFocusIndicator,
       }),
-      passed(R65, <button />, {
+      passed(R65, button, {
         1: Outcomes.HasFocusIndicator,
       }),
     ]
@@ -489,9 +505,10 @@ test(`evaluate() falis an <a> element that does not have a class determined to h
       Link
     </a>
   );
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a:focus", {
@@ -518,7 +535,7 @@ test(`evaluate() falis an <a> element that does not have a class determined to h
       failed(R65, target, {
         1: Outcomes.HasNoFocusIndicator,
       }),
-      passed(R65, <button />, {
+      passed(R65, button, {
         1: Outcomes.HasFocusIndicator,
       }),
     ]

--- a/packages/alfa-rules/test/sia-r65/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r65/rule.spec.tsx
@@ -9,14 +9,15 @@ import { oracle } from "../common/oracle";
 
 test(`evaluate() passes an <a> element that uses the default focus outline`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
-  const document = h.document([target, <button />]);
+  const document = h.document([target, button]);
 
   t.deepEqual(await evaluate(R65, { document }), [
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);
@@ -24,9 +25,10 @@ test(`evaluate() passes an <a> element that uses the default focus outline`, asy
 
 test(`evaluate() passes an <a> element that uses a non-default focus outline`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a:focus", {
@@ -40,7 +42,7 @@ test(`evaluate() passes an <a> element that uses a non-default focus outline`, a
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);
@@ -49,9 +51,10 @@ test(`evaluate() passes an <a> element that uses a non-default focus outline`, a
 test(`evaluate() fails an <a> element that removes the default focus outline and
       is determined to have no other focus indicator`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a:focus", {
@@ -73,7 +76,7 @@ test(`evaluate() fails an <a> element that removes the default focus outline and
       failed(R65, target, {
         1: Outcomes.HasNoFocusIndicator,
       }),
-      passed(R65, <button />, {
+      passed(R65, button, {
         1: Outcomes.HasFocusIndicator,
       }),
     ]
@@ -83,9 +86,10 @@ test(`evaluate() fails an <a> element that removes the default focus outline and
 test(`evaluate() passes an <a> element that removes the default focus outline
       and is determined to have some other focus indicator`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a:focus", {
@@ -107,7 +111,7 @@ test(`evaluate() passes an <a> element that removes the default focus outline
       passed(R65, target, {
         1: Outcomes.HasFocusIndicator,
       }),
-      passed(R65, <button />, {
+      passed(R65, button, {
         1: Outcomes.HasFocusIndicator,
       }),
     ]
@@ -117,9 +121,10 @@ test(`evaluate() passes an <a> element that removes the default focus outline
 test(`evaluate() passes an <a> element that removes the default focus outline
       and applies an underline on focus`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a", {
@@ -138,7 +143,7 @@ test(`evaluate() passes an <a> element that removes the default focus outline
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);
@@ -147,9 +152,10 @@ test(`evaluate() passes an <a> element that removes the default focus outline
 test(`evaluate() passes an <a> element that removes the default focus outline
       and whose parent applies an outline when focus is within the parent`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [<div>{target}</div>, <button />],
+    [<div>{target}</div>, button],
     [
       h.sheet([
         h.rule.style("div:focus-within", {
@@ -167,7 +173,7 @@ test(`evaluate() passes an <a> element that removes the default focus outline
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);
@@ -180,9 +186,10 @@ test(`evaluate() passes an <a> element that removes the default focus outline
       <span>Link</span>
     </a>
   );
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a:focus", {
@@ -200,7 +207,7 @@ test(`evaluate() passes an <a> element that removes the default focus outline
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);
@@ -209,9 +216,10 @@ test(`evaluate() passes an <a> element that removes the default focus outline
 test(`evaluate() passes an <a> element that removes the default focus outline
       and applies an outline only when focus should be visible`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a:focus", {
@@ -229,7 +237,7 @@ test(`evaluate() passes an <a> element that removes the default focus outline
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);
@@ -239,9 +247,10 @@ test(`evaluate() fails an <a> element that removes the default focus outline
       only when focus should be visible and is determined to have no other focus
       indicator`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a:focus-visible", {
@@ -263,7 +272,7 @@ test(`evaluate() fails an <a> element that removes the default focus outline
       failed(R65, target, {
         1: Outcomes.HasNoFocusIndicator,
       }),
-      passed(R65, <button />, {
+      passed(R65, button, {
         1: Outcomes.HasFocusIndicator,
       }),
     ]
@@ -273,9 +282,10 @@ test(`evaluate() fails an <a> element that removes the default focus outline
 test(`evaluate() passes an <a> element that removes the default focus outline
       and applies a different color on focus`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a", {
@@ -296,7 +306,7 @@ test(`evaluate() passes an <a> element that removes the default focus outline
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);
@@ -305,9 +315,10 @@ test(`evaluate() passes an <a> element that removes the default focus outline
 test(`evaluate() passes an <a> element that removes the default focus outline
       and applies a different background color on focus`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a", {
@@ -328,7 +339,7 @@ test(`evaluate() passes an <a> element that removes the default focus outline
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);
@@ -337,9 +348,10 @@ test(`evaluate() passes an <a> element that removes the default focus outline
 test(`evaluate() passes an <a> element that removes the default focus outline
       and applies a box shadow on focus`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a", {
@@ -358,7 +370,7 @@ test(`evaluate() passes an <a> element that removes the default focus outline
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);
@@ -367,9 +379,10 @@ test(`evaluate() passes an <a> element that removes the default focus outline
 test(`evaluate() passes an <a> element that removes the default focus outline
       and applies a border on focus`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a:focus", {
@@ -384,7 +397,7 @@ test(`evaluate() passes an <a> element that removes the default focus outline
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);
@@ -393,9 +406,10 @@ test(`evaluate() passes an <a> element that removes the default focus outline
 test(`evaluate() passes an <a> element that removes the default focus outline
       and changes border color on focus`, async (t) => {
   const target = <a href="#">Link</a>;
+  const button = <button />;
 
   const document = h.document(
-    [target, <button />],
+    [target, button],
     [
       h.sheet([
         h.rule.style("a", {
@@ -413,7 +427,7 @@ test(`evaluate() passes an <a> element that removes the default focus outline
     passed(R65, target, {
       1: Outcomes.HasFocusIndicator,
     }),
-    passed(R65, <button />, {
+    passed(R65, button, {
       1: Outcomes.HasFocusIndicator,
     }),
   ]);

--- a/packages/alfa-tree/package.json
+++ b/packages/alfa-tree/package.json
@@ -21,6 +21,7 @@
     "@siteimprove/alfa-array": "workspace:^0.41.0",
     "@siteimprove/alfa-equatable": "workspace:^0.41.0",
     "@siteimprove/alfa-flags": "workspace:^0.41.0",
+    "@siteimprove/alfa-hash": "workspace:^0.41.0",
     "@siteimprove/alfa-json": "workspace:^0.41.0",
     "@siteimprove/alfa-option": "workspace:^0.41.0"
   },

--- a/packages/alfa-tree/src/tree.ts
+++ b/packages/alfa-tree/src/tree.ts
@@ -396,6 +396,8 @@ export namespace Node {
     [key: string]: json.JSON | undefined;
     type: T;
     children?: Array<JSON>;
+    // We need nodeId to be optional since this type is used as input for
+    // deserialising functions where nodeId may be absent (for system ids).
     nodeId?: Id.JSON;
   }
 

--- a/packages/alfa-tree/tsconfig.json
+++ b/packages/alfa-tree/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../alfa-flags"
     },
     {
+      "path": "../alfa-hash"
+    },
+    {
       "path": "../alfa-json"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2286,6 +2286,7 @@ __metadata:
     "@siteimprove/alfa-array": "workspace:^0.41.0"
     "@siteimprove/alfa-equatable": "workspace:^0.41.0"
     "@siteimprove/alfa-flags": "workspace:^0.41.0"
+    "@siteimprove/alfa-hash": "workspace:^0.41.0"
     "@siteimprove/alfa-json": "workspace:^0.41.0"
     "@siteimprove/alfa-option": "workspace:^0.41.0"
     "@siteimprove/alfa-test": "workspace:^0.41.0"


### PR DESCRIPTION
Part of #1160 

- Add a `nodeId` to `tree.Node` and expand it to DOM and ARIA trees.
- `nodeId` consists of a `kind` (`User` for user-provided ids; `system` for Alfa-generated ones); a `type` (`alfa-dom`/`alfa-aria` for system ids); a `namespace` (user inputed for system keys) and an actual id (a number). System ids are guaranteed to be unique; it is user responsibility to provide unique user ids.
- When serialised, system ids are always serialised as user ids, keeping the same `type` and `namespace`. This greatly limit the risk of de-serialised system ids colliding with freshly created ones. (there is still a risk to create a new system id whose serialisation would collide with a user id 🤔 )
- `namespace`, also for system ids, can be used for grouping ids. Typically, `namespace` is intended to be a `pageId` so that even system ids can be tagged with it.
- When generating system ids for ARIA nodes, the `namespace` is copied from the owning DOM node.
