### PR TITLE
Rename `IsPerceivable`, and introduce `isIncludedInTheAccessibilityTree`

### DIFF
--- a/docs/review/api/alfa-aria.api.md
+++ b/docs/review/api/alfa-aria.api.md
@@ -103,6 +103,7 @@ export namespace DOM {
     hasNonEmptyAccessibleName: typeof dom.hasNonEmptyAccessibleName, // (undocumented)
     hasRole: typeof dom.hasRole, // (undocumented)
     isIgnored: typeof dom.isIgnored, // (undocumented)
+    isIncludedInTheAccessibilityTree: typeof dom.isIncludedInTheAccessibilityTree, // (undocumented)
     isMarkedDecorative: Predicate<Element_2<string>, []>, // (undocumented)
     isPerceivable: typeof dom.isPerceivable, // (undocumented)
     isProgrammaticallyHidden: typeof dom.isProgrammaticallyHidden, // (undocumented)
@@ -246,6 +247,9 @@ export class Inert extends Node<"inert"> {
 
 // @public
 function isIgnored<T extends Node_2>(device: Device): Predicate<T>;
+
+// @public
+function isIncludedInTheAccessibilityTree<T extends Node_2>(device: Device): Predicate<T>;
 
 // @public
 const isMarkedDecorative: Predicate<Element_2>;

--- a/docs/review/api/alfa-aria.api.md
+++ b/docs/review/api/alfa-aria.api.md
@@ -105,7 +105,7 @@ export namespace DOM {
     isIgnored: typeof dom.isIgnored, // (undocumented)
     isIncludedInTheAccessibilityTree: typeof dom.isIncludedInTheAccessibilityTree, // (undocumented)
     isMarkedDecorative: Predicate<Element_2<string>, []>, // (undocumented)
-    isPerceivable: typeof dom.isPerceivable, // (undocumented)
+    isPerceivableForAll: typeof dom.isPerceivableForAll, // (undocumented)
     isProgrammaticallyHidden: typeof dom.isProgrammaticallyHidden, // (undocumented)
     isSemanticallyDisabled: Predicate<Element_2<string>, []>;
 }
@@ -255,7 +255,7 @@ function isIncludedInTheAccessibilityTree<T extends Node_2>(device: Device): Pre
 const isMarkedDecorative: Predicate<Element_2>;
 
 // @public
-function isPerceivable<T extends Node_2>(device: Device): Predicate<T>;
+function isPerceivableForAll<T extends Node_2>(device: Device): Predicate<T>;
 
 // @public
 function isProgrammaticallyHidden(device: Device, context?: Context): Predicate<Element_2>;

--- a/packages/alfa-aria/src/dom/dom.ts
+++ b/packages/alfa-aria/src/dom/dom.ts
@@ -5,7 +5,7 @@ export * from "./predicate/has-implicit-role";
 export * from "./predicate/has-incorrect-role-without-name";
 export * from "./predicate/has-non-empty-accessible-name";
 export * from "./predicate/has-role";
-export * from "./predicate/is-ignored";
+export * from "./predicate/is-included-accessibility-tree";
 export * from "./predicate/is-marked-decorative";
 export * from "./predicate/is-perceivable";
 export * from "./predicate/is-programmatically-hidden";

--- a/packages/alfa-aria/src/dom/predicate/is-included-accessibility-tree.ts
+++ b/packages/alfa-aria/src/dom/predicate/is-included-accessibility-tree.ts
@@ -5,6 +5,21 @@ import { Predicate } from "@siteimprove/alfa-predicate";
 import { Node as ariaNode } from "../..";
 
 /**
+ * Check if a node is included in the accessibility tree.
+ *
+ * @remarks
+ * It's possible for a node itself to be ignored in the accessibility tree while
+ * still having children that aren't.
+ *
+ * @public
+ */
+export function isIncludedInTheAccessibilityTree<T extends Node>(
+  device: Device
+): Predicate<T> {
+  return (node) => !ariaNode.from(node, device).isIgnored();
+}
+
+/**
  * Check if a node is ignored in the accessibility tree.
  *
  * @remarks

--- a/packages/alfa-aria/src/dom/predicate/is-perceivable.ts
+++ b/packages/alfa-aria/src/dom/predicate/is-perceivable.ts
@@ -3,9 +3,9 @@ import { Node } from "@siteimprove/alfa-dom";
 import { Predicate } from "@siteimprove/alfa-predicate";
 import { Style } from "@siteimprove/alfa-style";
 
-import { isIgnored } from "./is-included-accessibility-tree";
+import { isIncludedInTheAccessibilityTree } from "./is-included-accessibility-tree";
 
-const { and, not } = Predicate;
+const { and } = Predicate;
 const { isVisible } = Style;
 
 /**
@@ -19,6 +19,6 @@ const { isVisible } = Style;
  */
 export function isPerceivable<T extends Node>(device: Device): Predicate<T> {
   return and(isVisible(device), (node) =>
-    node.inclusiveDescendants().some(not(isIgnored(device)))
+    node.inclusiveDescendants().some(isIncludedInTheAccessibilityTree(device))
   );
 }

--- a/packages/alfa-aria/src/dom/predicate/is-perceivable.ts
+++ b/packages/alfa-aria/src/dom/predicate/is-perceivable.ts
@@ -3,7 +3,7 @@ import { Node } from "@siteimprove/alfa-dom";
 import { Predicate } from "@siteimprove/alfa-predicate";
 import { Style } from "@siteimprove/alfa-style";
 
-import { isIgnored } from "./is-ignored";
+import { isIgnored } from "./is-included-accessibility-tree";
 
 const { and, not } = Predicate;
 const { isVisible } = Style;

--- a/packages/alfa-aria/src/dom/predicate/is-perceivable.ts
+++ b/packages/alfa-aria/src/dom/predicate/is-perceivable.ts
@@ -9,15 +9,17 @@ const { and } = Predicate;
 const { isVisible } = Style;
 
 /**
- * Check if a node is perceivable.
+ * Check if a node is perceivable for all users.
  *
  * @remarks
- * A node is considered perceivable if it's visible and has inclusive
+ * A node is considered perceivable for all if it's visible and has inclusive
  * descendants that are not ignored in the accessibility tree.
  *
  * @public
  */
-export function isPerceivable<T extends Node>(device: Device): Predicate<T> {
+export function isPerceivableForAll<T extends Node>(
+  device: Device
+): Predicate<T> {
   return and(isVisible(device), (node) =>
     node.inclusiveDescendants().some(isIncludedInTheAccessibilityTree(device))
   );

--- a/packages/alfa-aria/src/index.ts
+++ b/packages/alfa-aria/src/index.ts
@@ -34,6 +34,7 @@ export namespace DOM {
     hasNonEmptyAccessibleName,
     hasRole,
     isIgnored,
+    isIncludedInTheAccessibilityTree,
     isMarkedDecorative,
     isPerceivable,
     isProgrammaticallyHidden,

--- a/packages/alfa-aria/src/index.ts
+++ b/packages/alfa-aria/src/index.ts
@@ -36,7 +36,7 @@ export namespace DOM {
     isIgnored,
     isIncludedInTheAccessibilityTree,
     isMarkedDecorative,
-    isPerceivable,
+    isPerceivableForAll,
     isProgrammaticallyHidden,
     isSemanticallyDisabled,
   } = dom;

--- a/packages/alfa-aria/tsconfig.json
+++ b/packages/alfa-aria/tsconfig.json
@@ -16,7 +16,7 @@
     "src/dom/predicate/has-incorrect-role-without-name.ts",
     "src/dom/predicate/has-non-empty-accessible-name.ts",
     "src/dom/predicate/has-role.ts",
-    "src/dom/predicate/is-ignored.ts",
+    "src/dom/predicate/is-included-accessibility-tree.ts",
     "src/dom/predicate/is-marked-decorative.ts",
     "src/dom/predicate/is-perceivable.ts",
     "src/dom/predicate/is-programmatically-hidden.ts",

--- a/packages/alfa-rules/src/common/applicability/audio.ts
+++ b/packages/alfa-rules/src/common/applicability/audio.ts
@@ -8,7 +8,7 @@ import { Style } from "@siteimprove/alfa-style";
 
 import { Question } from "../act/question";
 
-const { isPerceivable } = DOM;
+const { isPerceivableForAll } = DOM;
 const { isElement, hasName, hasNamespace } = Element;
 const { and } = Predicate;
 const { isRendered } = Style;
@@ -33,7 +33,7 @@ export function audio(
               isPlaying
                 ? Option.of(element)
                 : Question.of("play-button", element).map((playButton) =>
-                    playButton.some(and(isElement, isPerceivable(device)))
+                    playButton.some(and(isElement, isPerceivableForAll(device)))
                       ? Option.of(element)
                       : None
                   )

--- a/packages/alfa-rules/src/common/expectation/media-text-alternative.ts
+++ b/packages/alfa-rules/src/common/expectation/media-text-alternative.ts
@@ -9,7 +9,7 @@ import * as act from "@siteimprove/alfa-act";
 import { expectation } from "../act/expectation";
 import { Question } from "../act/question";
 
-import { isPerceivable } from "../../../../alfa-aria/src/dom/predicate/is-perceivable";
+import { isPerceivableForAll } from "../../../../alfa-aria/src/dom/predicate/is-perceivable";
 
 function mediaTextAlternative(
   alt: act.Question<
@@ -37,7 +37,7 @@ function mediaTextAlternative(
         alt.isSome(),
         () =>
           expectation(
-            alt.some(isPerceivable(device)),
+            alt.some(isPerceivableForAll(device)),
             () => Outcomes.HasPerceivableAlternative(kind),
             () => Outcomes.HasNonPerceivableAlternative(kind)
           ),
@@ -49,7 +49,7 @@ function mediaTextAlternative(
         label.isSome(),
         () =>
           expectation(
-            label.some(isPerceivable(device)),
+            label.some(isPerceivableForAll(device)),
             () => Outcomes.HasPerceivableLabel(kind),
             () => Outcomes.HasNonPerceivableLabel(kind)
           ),

--- a/packages/alfa-rules/src/common/expectation/media-text-alternative.ts
+++ b/packages/alfa-rules/src/common/expectation/media-text-alternative.ts
@@ -1,4 +1,5 @@
 import { Diagnostic } from "@siteimprove/alfa-act";
+import { DOM } from "@siteimprove/alfa-aria";
 import { Device } from "@siteimprove/alfa-device";
 import { Element, Node } from "@siteimprove/alfa-dom";
 import { Option } from "@siteimprove/alfa-option";
@@ -9,7 +10,7 @@ import * as act from "@siteimprove/alfa-act";
 import { expectation } from "../act/expectation";
 import { Question } from "../act/question";
 
-import { isPerceivableForAll } from "../../../../alfa-aria/src/dom/predicate/is-perceivable";
+const { isPerceivableForAll } = DOM;
 
 function mediaTextAlternative(
   alt: act.Question<

--- a/packages/alfa-rules/src/common/expectation/media-transcript.ts
+++ b/packages/alfa-rules/src/common/expectation/media-transcript.ts
@@ -1,4 +1,5 @@
 import { Diagnostic } from "@siteimprove/alfa-act";
+import { DOM } from "@siteimprove/alfa-aria";
 import { Device } from "@siteimprove/alfa-device";
 import { Element, Node } from "@siteimprove/alfa-dom";
 import { Option } from "@siteimprove/alfa-option";
@@ -10,8 +11,7 @@ import * as act from "@siteimprove/alfa-act";
 import { expectation } from "../act/expectation";
 import { Question } from "../act/question";
 
-import { isPerceivableForAll } from "../../../../alfa-aria/src/dom/predicate/is-perceivable";
-
+const { isPerceivableForAll } = DOM;
 const { isElement } = Element;
 const { and } = Predicate;
 

--- a/packages/alfa-rules/src/common/expectation/media-transcript.ts
+++ b/packages/alfa-rules/src/common/expectation/media-transcript.ts
@@ -10,7 +10,7 @@ import * as act from "@siteimprove/alfa-act";
 import { expectation } from "../act/expectation";
 import { Question } from "../act/question";
 
-import { isPerceivable } from "../../../../alfa-aria/src/dom/predicate/is-perceivable";
+import { isPerceivableForAll } from "../../../../alfa-aria/src/dom/predicate/is-perceivable";
 
 const { isElement } = Element;
 const { and } = Predicate;
@@ -45,7 +45,7 @@ function mediaTranscript(
 
           if (
             transcriptLink
-              .filter(and(isElement, isPerceivable(device)))
+              .filter(and(isElement, isPerceivableForAll(device)))
               .isNone()
           ) {
             return Option.of(Outcomes.HasNonPerceivableLink(kind));
@@ -56,7 +56,7 @@ function mediaTranscript(
       }
 
       return expectation(
-        transcript.some(and(isElement, isPerceivable(device))),
+        transcript.some(and(isElement, isPerceivableForAll(device))),
         () => Outcomes.HasPerceivableTranscript(kind),
         () => Outcomes.HasNonPerceivableTranscript(kind)
       );

--- a/packages/alfa-rules/src/common/predicate/is-at-the-start.ts
+++ b/packages/alfa-rules/src/common/predicate/is-at-the-start.ts
@@ -1,9 +1,9 @@
+import { DOM } from "@siteimprove/alfa-aria";
 import { Device } from "@siteimprove/alfa-device";
 import { Element, Node } from "@siteimprove/alfa-dom";
 import { Predicate } from "@siteimprove/alfa-predicate";
 
-import { isPerceivableForAll } from "../../../../alfa-aria/src/dom/predicate/is-perceivable";
-
+const { isPerceivableForAll } = DOM;
 const { isContent } = Element;
 const { and } = Predicate;
 

--- a/packages/alfa-rules/src/common/predicate/is-at-the-start.ts
+++ b/packages/alfa-rules/src/common/predicate/is-at-the-start.ts
@@ -2,7 +2,7 @@ import { Device } from "@siteimprove/alfa-device";
 import { Element, Node } from "@siteimprove/alfa-dom";
 import { Predicate } from "@siteimprove/alfa-predicate";
 
-import { isPerceivable } from "../../../../alfa-aria/src/dom/predicate/is-perceivable";
+import { isPerceivableForAll } from "../../../../alfa-aria/src/dom/predicate/is-perceivable";
 
 const { isContent } = Element;
 const { and } = Predicate;
@@ -40,5 +40,5 @@ export function isAtTheStart(
     !Node.getNodesBetween(node1, node2, {
       includeFirst: true,
       includeSecond: false,
-    }).some(and(isPerceivable(device), isContent(Node.fullTree)));
+    }).some(and(isPerceivableForAll(device), isContent(Node.fullTree)));
 }

--- a/packages/alfa-rules/src/sia-r10/rule.ts
+++ b/packages/alfa-rules/src/sia-r10/rule.ts
@@ -14,7 +14,7 @@ import { normalize } from "../common/normalize";
 
 import { Scope } from "../tags";
 
-const { hasRole, isPerceivable } = DOM;
+const { hasRole, isPerceivableForAll } = DOM;
 const { hasAttribute, hasInputType, hasName, hasNamespace, isElement } =
   Element;
 const { and, or, not } = Predicate;
@@ -46,7 +46,7 @@ export default Rule.Atomic.of<Page, Attribute>({
                 isTabbable(device),
                 hasRole(device, (role) => role.isWidget())
               ),
-              isPerceivable(device),
+              isPerceivableForAll(device),
               (element) =>
                 Node.from(element, device)
                   .attribute("aria-disabled")

--- a/packages/alfa-rules/src/sia-r11/rule.ts
+++ b/packages/alfa-rules/src/sia-r11/rule.ts
@@ -10,9 +10,10 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { hasNonEmptyAccessibleName, hasRole, isIgnored } = DOM;
+const { hasNonEmptyAccessibleName, hasRole, isIncludedInTheAccessibilityTree } =
+  DOM;
 const { isElement, hasNamespace } = Element;
-const { and, not } = Predicate;
+const { and } = Predicate;
 
 export default Rule.Atomic.of<Page, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r11",
@@ -33,7 +34,7 @@ export default Rule.Atomic.of<Page, Element>({
             and(
               hasNamespace(Namespace.HTML),
               hasRole(device, (role) => role.is("link")),
-              not(isIgnored(device))
+              isIncludedInTheAccessibilityTree(device)
             )
           );
       },

--- a/packages/alfa-rules/src/sia-r12/rule.ts
+++ b/packages/alfa-rules/src/sia-r12/rule.ts
@@ -10,7 +10,8 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { hasNonEmptyAccessibleName, hasRole, isIgnored } = DOM;
+const { hasNonEmptyAccessibleName, hasRole, isIncludedInTheAccessibilityTree } =
+  DOM;
 const { isElement, hasInputType, hasNamespace } = Element;
 const { and, not } = Predicate;
 
@@ -29,7 +30,7 @@ export default Rule.Atomic.of<Page, Element>({
               not(hasInputType("image")),
               hasNamespace(Namespace.HTML),
               hasRole(device, "button"),
-              not(isIgnored(device))
+              isIncludedInTheAccessibilityTree(device)
             )
           );
       },

--- a/packages/alfa-rules/src/sia-r13/rule.ts
+++ b/packages/alfa-rules/src/sia-r13/rule.ts
@@ -12,7 +12,7 @@ import { Scope } from "../tags";
 
 const { hasNonEmptyAccessibleName, isIncludedInTheAccessibilityTree } = DOM;
 const { isElement, hasName, hasNamespace } = Element;
-const { and, not } = Predicate;
+const { and } = Predicate;
 
 export default Rule.Atomic.of<Page, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r13",

--- a/packages/alfa-rules/src/sia-r13/rule.ts
+++ b/packages/alfa-rules/src/sia-r13/rule.ts
@@ -10,7 +10,7 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { hasNonEmptyAccessibleName, isIgnored } = DOM;
+const { hasNonEmptyAccessibleName, isIncludedInTheAccessibilityTree } = DOM;
 const { isElement, hasName, hasNamespace } = Element;
 const { and, not } = Predicate;
 
@@ -28,7 +28,7 @@ export default Rule.Atomic.of<Page, Element>({
             and(
               hasNamespace(Namespace.HTML),
               hasName("iframe"),
-              not(isIgnored(device))
+              isIncludedInTheAccessibilityTree(device)
             )
           );
       },

--- a/packages/alfa-rules/src/sia-r14/rule.ts
+++ b/packages/alfa-rules/src/sia-r14/rule.ts
@@ -14,7 +14,7 @@ import { normalize } from "../common/normalize";
 import { isWhitespace } from "../common/predicate";
 import { Scope } from "../tags";
 
-const { hasAccessibleName, hasRole, isPerceivable } = DOM;
+const { hasAccessibleName, hasRole, isPerceivableForAll } = DOM;
 const { hasAttribute, hasNamespace, hasName, isElement } = Element;
 const { isText } = Text;
 const { hasDescendant } = Node;
@@ -45,7 +45,7 @@ export default Rule.Atomic.of<Page, Element>({
                 (role) => role.isWidget() && role.isNamedBy("contents")
               ),
               hasDescendant(
-                and(Text.isText, isPerceivable(device)),
+                and(Text.isText, isPerceivableForAll(device)),
                 Node.flatTree
               )
             )
@@ -91,12 +91,12 @@ function getPerceivableInnerTextFromTextNode(
   text: Text,
   device: Device
 ): string {
-  if (isPerceivable(device)(text)) {
+  if (isPerceivableForAll(device)(text)) {
     return text.data;
   }
 
   if (
-    and(not(isPerceivable(device)), isRendered(device))(text) &&
+    and(not(isPerceivableForAll(device)), isRendered(device))(text) &&
     isWhitespace(text.data)
   ) {
     return " ";

--- a/packages/alfa-rules/src/sia-r15/rule.ts
+++ b/packages/alfa-rules/src/sia-r15/rule.ts
@@ -17,9 +17,9 @@ import { Scope } from "../tags";
 
 import { normalize } from "../common/normalize";
 
-const { hasNonEmptyAccessibleName, isIgnored } = DOM;
+const { hasNonEmptyAccessibleName, isIncludedInTheAccessibilityTree } = DOM;
 const { isElement, hasName, hasNamespace } = Element;
-const { and, not } = Predicate;
+const { and } = Predicate;
 
 export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r15",
@@ -35,7 +35,7 @@ export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
             and(
               hasName("iframe"),
               hasNamespace(Namespace.HTML),
-              not(isIgnored(device)),
+              isIncludedInTheAccessibilityTree(device),
               hasNonEmptyAccessibleName(device)
             )
           )

--- a/packages/alfa-rules/src/sia-r16/rule.ts
+++ b/packages/alfa-rules/src/sia-r16/rule.ts
@@ -15,11 +15,11 @@ import * as aria from "@siteimprove/alfa-aria";
 import { expectation } from "../common/act/expectation";
 import { Scope } from "../tags";
 
-const { hasRole, isIgnored } = DOM;
+const { hasRole, isIncludedInTheAccessibilityTree } = DOM;
 const { hasAttribute, hasInputType, hasName, hasNamespace, isElement } =
   Element;
 const { isEmpty } = Iterable;
-const { and, not, property, test } = Predicate;
+const { and, property, test } = Predicate;
 const { isFocusable } = Style;
 
 export default Rule.Atomic.of<Page, Element>({
@@ -35,7 +35,7 @@ export default Rule.Atomic.of<Page, Element>({
           .filter(
             and(hasNamespace(Namespace.HTML, Namespace.SVG), hasRole(device))
           )
-          .filter(not(isIgnored(device)));
+          .filter(isIncludedInTheAccessibilityTree(device));
       },
 
       expectations(target) {

--- a/packages/alfa-rules/src/sia-r18/rule.ts
+++ b/packages/alfa-rules/src/sia-r18/rule.ts
@@ -14,7 +14,7 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { hasRole, isIgnored } = DOM;
+const { hasRole, isIncludedInTheAccessibilityTree } = DOM;
 const { hasDisplaySize, hasInputType, isElement } = Element;
 const { test, property } = Predicate;
 
@@ -30,7 +30,7 @@ export default Rule.Atomic.of<Page, Attribute>({
         return document
           .descendants(Node.fullTree)
           .filter(isElement)
-          .reject(isIgnored(device))
+          .filter(isIncludedInTheAccessibilityTree(device))
           .flatMap((element) =>
             Sequence.from(element.attributes).filter(
               property("name", aria.Attribute.isName)

--- a/packages/alfa-rules/src/sia-r2/rule.ts
+++ b/packages/alfa-rules/src/sia-r2/rule.ts
@@ -10,9 +10,10 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { hasNonEmptyAccessibleName, hasRole, isIgnored } = DOM;
+const { hasNonEmptyAccessibleName, hasRole, isIncludedInTheAccessibilityTree } =
+  DOM;
 const { isElement, hasNamespace } = Element;
-const { and, not } = Predicate;
+const { and } = Predicate;
 
 export default Rule.Atomic.of<Page, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r2",
@@ -32,7 +33,7 @@ export default Rule.Atomic.of<Page, Element>({
             and(
               hasNamespace(Namespace.HTML),
               hasRole(device, "img"),
-              not(isIgnored(device))
+              isIncludedInTheAccessibilityTree(device)
             )
           );
       },

--- a/packages/alfa-rules/src/sia-r28/rule.ts
+++ b/packages/alfa-rules/src/sia-r28/rule.ts
@@ -12,7 +12,7 @@ import { Scope } from "../tags";
 
 const { hasAccessibleName, isIncludedInTheAccessibilityTree } = DOM;
 const { isElement, hasInputType, hasNamespace } = Element;
-const { and, not, test } = Predicate;
+const { and, test } = Predicate;
 
 export default Rule.Atomic.of<Page, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r28",

--- a/packages/alfa-rules/src/sia-r28/rule.ts
+++ b/packages/alfa-rules/src/sia-r28/rule.ts
@@ -10,7 +10,7 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { hasAccessibleName, isIgnored } = DOM;
+const { hasAccessibleName, isIncludedInTheAccessibilityTree } = DOM;
 const { isElement, hasInputType, hasNamespace } = Element;
 const { and, not, test } = Predicate;
 
@@ -33,7 +33,7 @@ export default Rule.Atomic.of<Page, Element>({
             and(
               hasNamespace(Namespace.HTML),
               hasInputType("image"),
-              not(isIgnored(device))
+              isIncludedInTheAccessibilityTree(device)
             )
           );
       },

--- a/packages/alfa-rules/src/sia-r39/rule.ts
+++ b/packages/alfa-rules/src/sia-r39/rule.ts
@@ -11,9 +11,9 @@ import { Question } from "../common/act/question";
 
 import { Scope } from "../tags";
 
-const { hasAccessibleName, isIgnored } = DOM;
+const { hasAccessibleName, isIncludedInTheAccessibilityTree } = DOM;
 const { isElement, hasInputType, hasName, hasNamespace } = Element;
-const { and, or, not, test } = Predicate;
+const { and, or, test } = Predicate;
 
 export default Rule.Atomic.of<Page, Element, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r39",
@@ -33,7 +33,7 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
             and(
               hasNamespace(Namespace.HTML),
               or(hasName("img"), and(hasName("input"), hasInputType("image"))),
-              not(isIgnored(device)),
+              isIncludedInTheAccessibilityTree(device),
               (element) =>
                 test(
                   hasAccessibleName(device, (accessibleName) =>

--- a/packages/alfa-rules/src/sia-r40/rule.ts
+++ b/packages/alfa-rules/src/sia-r40/rule.ts
@@ -13,10 +13,10 @@ const {
   hasIncorrectRoleWithoutName,
   hasNonEmptyAccessibleName,
   hasRole,
-  isIgnored,
+  isIncludedInTheAccessibilityTree,
 } = DOM;
 const { isElement } = Element;
-const { and, not } = Predicate;
+const { and } = Predicate;
 
 export default Rule.Atomic.of<Page, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r40",
@@ -31,7 +31,7 @@ export default Rule.Atomic.of<Page, Element>({
             .filter(
               and(
                 hasRole(device, (role) => role.is("region")),
-                not(isIgnored(device))
+                isIncludedInTheAccessibilityTree(device)
               )
             )
             // circumventing https://github.com/Siteimprove/alfa/issues/298

--- a/packages/alfa-rules/src/sia-r41/rule.ts
+++ b/packages/alfa-rules/src/sia-r41/rule.ts
@@ -18,9 +18,10 @@ import { normalize } from "../common/normalize";
 
 import { Scope } from "../tags";
 
-const { hasNonEmptyAccessibleName, hasRole, isIgnored } = DOM;
+const { hasNonEmptyAccessibleName, hasRole, isIncludedInTheAccessibilityTree } =
+  DOM;
 const { isElement, hasNamespace } = Element;
-const { and, not } = Predicate;
+const { and } = Predicate;
 
 export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r41",
@@ -36,7 +37,7 @@ export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
             and(
               hasNamespace(Namespace.HTML, Namespace.SVG),
               hasRole(device, (role) => role.is("link")),
-              not(isIgnored(device)),
+              isIncludedInTheAccessibilityTree(device),
               hasNonEmptyAccessibleName(device)
             )
           )

--- a/packages/alfa-rules/src/sia-r42/rule.ts
+++ b/packages/alfa-rules/src/sia-r42/rule.ts
@@ -14,9 +14,9 @@ import { WithRole } from "../common/diagnostic/with-role";
 
 import { Scope } from "../tags";
 
-const { hasRole, isIgnored } = DOM;
+const { hasRole, isIncludedInTheAccessibilityTree } = DOM;
 const { isElement, hasNamespace } = Element;
-const { and, not } = Predicate;
+const { and } = Predicate;
 
 export default Rule.Atomic.of<Page, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r42",
@@ -31,7 +31,7 @@ export default Rule.Atomic.of<Page, Element>({
           .filter(
             and(
               hasNamespace(Namespace.HTML, Namespace.SVG),
-              not(isIgnored(device)),
+              isIncludedInTheAccessibilityTree(device),
               hasRole(device, (role) => role.hasRequiredParent())
             )
           );

--- a/packages/alfa-rules/src/sia-r43/rule.ts
+++ b/packages/alfa-rules/src/sia-r43/rule.ts
@@ -10,9 +10,13 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { hasExplicitRole, hasNonEmptyAccessibleName, isIgnored } = DOM;
+const {
+  hasExplicitRole,
+  hasNonEmptyAccessibleName,
+  isIncludedInTheAccessibilityTree,
+} = DOM;
 const { isElement, hasNamespace } = Element;
-const { and, not } = Predicate;
+const { and } = Predicate;
 
 export default Rule.Atomic.of<Page, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r43",
@@ -28,7 +32,7 @@ export default Rule.Atomic.of<Page, Element>({
             and(
               hasNamespace(Namespace.SVG),
               hasExplicitRole("img", "graphics-document", "graphics-symbol"),
-              not(isIgnored(device))
+              isIncludedInTheAccessibilityTree(device)
             )
           );
       },

--- a/packages/alfa-rules/src/sia-r45/rule.ts
+++ b/packages/alfa-rules/src/sia-r45/rule.ts
@@ -11,7 +11,7 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { hasRole, isPerceivable } = DOM;
+const { hasRole, isPerceivableForAll } = DOM;
 const { hasAttribute, hasId, hasName, hasNamespace, isElement } = Element;
 const { and, equals, not } = Predicate;
 
@@ -27,7 +27,7 @@ export default Rule.Atomic.of<Page, Attribute>({
         and(
           hasNamespace(Namespace.HTML),
           hasName("table"),
-          isPerceivable(device),
+          isPerceivableForAll(device),
           hasRole(
             device,
             not((role) => role.isPresentational())

--- a/packages/alfa-rules/src/sia-r46/rule.ts
+++ b/packages/alfa-rules/src/sia-r46/rule.ts
@@ -12,9 +12,9 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { hasRole, isIgnored, isPerceivable } = DOM;
+const { hasRole, isIncludedInTheAccessibilityTree, isPerceivable } = DOM;
 const { isElement, hasName, hasNamespace } = Element;
-const { and, not } = Predicate;
+const { and } = Predicate;
 
 export default Rule.Atomic.of<Page, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r46",
@@ -32,7 +32,7 @@ export default Rule.Atomic.of<Page, Element>({
             and(
               hasNamespace(Namespace.HTML),
               hasName("table"),
-              not(isIgnored(device))
+              isIncludedInTheAccessibilityTree(device)
             )
           );
 

--- a/packages/alfa-rules/src/sia-r46/rule.ts
+++ b/packages/alfa-rules/src/sia-r46/rule.ts
@@ -12,7 +12,7 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { hasRole, isIncludedInTheAccessibilityTree, isPerceivable } = DOM;
+const { hasRole, isIncludedInTheAccessibilityTree, isPerceivableForAll } = DOM;
 const { isElement, hasName, hasNamespace } = Element;
 const { and } = Predicate;
 
@@ -47,7 +47,7 @@ export default Rule.Atomic.of<Page, Element>({
                 hasNamespace(Namespace.HTML),
                 hasName("th"),
                 hasRole(device, "rowheader", "columnheader"),
-                isPerceivable(device)
+                isPerceivableForAll(device)
               )
             );
 

--- a/packages/alfa-rules/src/sia-r49/rule.ts
+++ b/packages/alfa-rules/src/sia-r49/rule.ts
@@ -13,7 +13,7 @@ import { Question } from "../common/act/question";
 
 import { Scope } from "../tags";
 
-const { hasNonEmptyAccessibleName, isPerceivable } = DOM;
+const { hasNonEmptyAccessibleName, isPerceivableForAll } = DOM;
 const { hasAttribute, hasName, hasNamespace, isElement } = Element;
 const { or, nor, equals } = Predicate;
 const { and } = Refinement;
@@ -80,7 +80,7 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
                       and(
                         isElement,
                         and(
-                          isPerceivable(device),
+                          isPerceivableForAll(device),
 
                           // The mechanism is either the applicable <video> or
                           // <audio> element itself, in which case we assume the

--- a/packages/alfa-rules/src/sia-r53/rule.ts
+++ b/packages/alfa-rules/src/sia-r53/rule.ts
@@ -9,9 +9,9 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { hasHeadingLevel, hasRole, isIgnored } = DOM;
+const { hasHeadingLevel, hasRole, isIncludedInTheAccessibilityTree } = DOM;
 const { isElement } = Element;
-const { equals } = Predicate;
+const { and, equals } = Predicate;
 
 export default Rule.Atomic.of<Page, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r53",
@@ -20,8 +20,12 @@ export default Rule.Atomic.of<Page, Element>({
     const headings = document
       .descendants(Node.flatTree)
       .filter(isElement)
-      .filter(hasRole(device, "heading"))
-      .reject(isIgnored(device));
+      .filter(
+        and(
+          hasRole(device, "heading"),
+          isIncludedInTheAccessibilityTree(device)
+        )
+      );
 
     return {
       applicability() {

--- a/packages/alfa-rules/src/sia-r54/rule.ts
+++ b/packages/alfa-rules/src/sia-r54/rule.ts
@@ -10,9 +10,9 @@ import * as dom from "@siteimprove/alfa-dom";
 import { expectation } from "../common/act/expectation";
 import { Scope } from "../tags";
 
-const { isIgnored } = DOM;
+const { isIncludedInTheAccessibilityTree } = DOM;
 const { isElement } = Element;
-const { and, not } = Predicate;
+const { and } = Predicate;
 
 export default Rule.Atomic.of<Page, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r54",
@@ -24,7 +24,7 @@ export default Rule.Atomic.of<Page, Element>({
           .descendants(dom.Node.fullTree)
           .filter(isElement)
           .filter(
-            and(not(isIgnored(device)), (element) =>
+            and(isIncludedInTheAccessibilityTree(device), (element) =>
               Node.from(element, device)
                 .attribute("aria-live")
                 .some((attribute) => attribute.value === "assertive")

--- a/packages/alfa-rules/src/sia-r55/rule.ts
+++ b/packages/alfa-rules/src/sia-r55/rule.ts
@@ -17,9 +17,13 @@ import { normalize } from "../common/normalize";
 
 import { Scope } from "../tags";
 
-const { hasIncorrectRoleWithoutName, hasRole, isIgnored } = DOM;
+const {
+  hasIncorrectRoleWithoutName,
+  hasRole,
+  isIncludedInTheAccessibilityTree,
+} = DOM;
 const { hasNamespace, isElement } = Element;
-const { and, equals, not } = Predicate;
+const { and, equals } = Predicate;
 
 export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r55",
@@ -34,7 +38,7 @@ export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
             .filter(
               and(
                 hasNamespace(equals(Namespace.HTML)),
-                not(isIgnored(device)),
+                isIncludedInTheAccessibilityTree(device),
                 hasRole(device, (role) => role.is("landmark"))
               )
             )

--- a/packages/alfa-rules/src/sia-r56/rule.ts
+++ b/packages/alfa-rules/src/sia-r56/rule.ts
@@ -17,9 +17,13 @@ import { normalize } from "../common/normalize";
 
 import { Scope } from "../tags";
 
-const { hasIncorrectRoleWithoutName, hasRole, isIgnored } = DOM;
+const {
+  hasIncorrectRoleWithoutName,
+  hasRole,
+  isIncludedInTheAccessibilityTree,
+} = DOM;
 const { hasNamespace, isElement } = Element;
-const { and, equals, not } = Predicate;
+const { and, equals } = Predicate;
 
 export default Rule.Atomic.of<Page, Group<Element>>({
   uri: "https://alfa.siteimprove.com/rules/sia-r56",
@@ -34,7 +38,7 @@ export default Rule.Atomic.of<Page, Group<Element>>({
             .filter(
               and(
                 hasNamespace(equals(Namespace.HTML)),
-                not(isIgnored(device)),
+                isIncludedInTheAccessibilityTree(device),
                 hasRole(device, (role) => role.is("landmark"))
               )
             )

--- a/packages/alfa-rules/src/sia-r57/rule.ts
+++ b/packages/alfa-rules/src/sia-r57/rule.ts
@@ -14,7 +14,7 @@ import { expectation } from "../common/act/expectation";
 import { isWhitespace } from "../common/predicate";
 import { Scope } from "../tags";
 
-const { hasRole, isIgnored } = DOM;
+const { hasRole, isIncludedInTheAccessibilityTree } = DOM;
 const { isElement } = Element;
 const { isEmpty } = Iterable;
 const { and, not, nor, property } = Predicate;
@@ -44,7 +44,7 @@ export default Rule.Atomic.of<Page, Text>({
             .filter(
               and(
                 property("data", nor(isEmpty, isWhitespace)),
-                not(isIgnored(device))
+                isIncludedInTheAccessibilityTree(device)
               )
             );
         }

--- a/packages/alfa-rules/src/sia-r57/rule.ts
+++ b/packages/alfa-rules/src/sia-r57/rule.ts
@@ -17,7 +17,7 @@ import { Scope } from "../tags";
 const { hasRole, isIncludedInTheAccessibilityTree } = DOM;
 const { isElement } = Element;
 const { isEmpty } = Iterable;
-const { and, not, nor, property } = Predicate;
+const { and, nor, property } = Predicate;
 const { isTabbable } = Style;
 const { isText } = Text;
 

--- a/packages/alfa-rules/src/sia-r60/rule.ts
+++ b/packages/alfa-rules/src/sia-r60/rule.ts
@@ -12,9 +12,9 @@ import { Map } from "@siteimprove/alfa-map";
 import { expectation } from "../common/act/expectation";
 import { Scope } from "../tags";
 
-const { hasNonEmptyAccessibleName, hasRole, isIgnored } = DOM;
+const { hasNonEmptyAccessibleName, hasRole, isIncludedInTheAccessibilityTree } =
+  DOM;
 const { isElement, hasNamespace } = Element;
-const { not } = Predicate;
 const { and } = Refinement;
 
 export default Rule.Atomic.of<Page, Element>({
@@ -31,7 +31,10 @@ export default Rule.Atomic.of<Page, Element>({
             // If the group is an input field, then its value has a +1
             if (
               group.isSome() &&
-              and(not(isIgnored(device)), isFormInput(device))(node)
+              and(
+                isIncludedInTheAccessibilityTree(device),
+                isFormInput(device)
+              )(node)
             ) {
               groups = groups.set(
                 group.get(),

--- a/packages/alfa-rules/src/sia-r61/rule.ts
+++ b/packages/alfa-rules/src/sia-r61/rule.ts
@@ -10,9 +10,9 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { hasHeadingLevel, hasRole, isIgnored } = DOM;
+const { hasHeadingLevel, hasRole, isIncludedInTheAccessibilityTree } = DOM;
 const { isDocumentElement, isElement } = Element;
-const { equals, not } = Predicate;
+const { equals } = Predicate;
 const { and } = Refinement;
 
 export default Rule.Atomic.of<Page, Document>({
@@ -21,7 +21,7 @@ export default Rule.Atomic.of<Page, Document>({
   evaluate({ device, document }) {
     const firstHeading = document
       .descendants(Node.flatTree)
-      .filter(and(isElement, not(isIgnored(device))))
+      .filter(and(isElement, isIncludedInTheAccessibilityTree(device)))
       .find(hasRole(device, "heading"));
 
     return {

--- a/packages/alfa-rules/src/sia-r63/rule.ts
+++ b/packages/alfa-rules/src/sia-r63/rule.ts
@@ -10,9 +10,9 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { hasNonEmptyAccessibleName, isIgnored } = DOM;
+const { hasNonEmptyAccessibleName, isIncludedInTheAccessibilityTree } = DOM;
 const { isElement, hasName, hasNamespace } = Element;
-const { and, not } = Predicate;
+const { and } = Predicate;
 
 export default Rule.Atomic.of<Page, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r63",
@@ -28,7 +28,7 @@ export default Rule.Atomic.of<Page, Element>({
             and(
               hasNamespace(Namespace.HTML),
               hasName("object"),
-              not(isIgnored(device))
+              isIncludedInTheAccessibilityTree(device)
             )
           );
       },

--- a/packages/alfa-rules/src/sia-r64/rule.ts
+++ b/packages/alfa-rules/src/sia-r64/rule.ts
@@ -10,9 +10,10 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { hasNonEmptyAccessibleName, hasRole, isIgnored } = DOM;
+const { hasNonEmptyAccessibleName, hasRole, isIncludedInTheAccessibilityTree } =
+  DOM;
 const { isElement, hasNamespace } = Element;
-const { and, not } = Predicate;
+const { and } = Predicate;
 
 export default Rule.Atomic.of<Page, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r64",
@@ -32,7 +33,7 @@ export default Rule.Atomic.of<Page, Element>({
             and(
               hasNamespace(Namespace.HTML),
               hasRole(device, "heading"),
-              not(isIgnored(device))
+              isIncludedInTheAccessibilityTree(device)
             )
           );
       },

--- a/packages/alfa-rules/src/sia-r66/rule.ts
+++ b/packages/alfa-rules/src/sia-r66/rule.ts
@@ -20,7 +20,7 @@ import { Contrast as Outcomes } from "../common/outcome/contrast";
 
 import { Scope } from "../tags";
 
-const { hasRole, isPerceivable, isSemanticallyDisabled } = DOM;
+const { hasRole, isPerceivableForAll, isSemanticallyDisabled } = DOM;
 const { hasNamespace, isElement } = Element;
 const { flatMap, map } = Iterable;
 const { max } = Math;
@@ -54,7 +54,7 @@ export default Rule.Atomic.of<Page, Text, Question.Metadata>({
             return;
           }
 
-          if (test(and(isText, isPerceivable(device)), node)) {
+          if (test(and(isText, isPerceivableForAll(device)), node)) {
             yield node;
           }
 

--- a/packages/alfa-rules/src/sia-r68/rule.ts
+++ b/packages/alfa-rules/src/sia-r68/rule.ts
@@ -15,9 +15,9 @@ import { WithRole } from "../common/diagnostic/with-role";
 
 import { Scope } from "../tags";
 
-const { hasRole, isIgnored } = DOM;
+const { hasRole, isIncludedInTheAccessibilityTree } = DOM;
 const { hasAttribute, hasNamespace, isElement } = Element;
-const { and, equals, not } = Refinement;
+const { and, equals } = Refinement;
 
 export default Rule.Atomic.of<Page, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r68",
@@ -111,8 +111,8 @@ function isRequiredChild(
 /**
  * Collect all descendants of the given node where the descendant:
  *
- * - is a non-ignored HTML or SVG element with a role requiring specific
- *   children; and
+ * - is a HTML or SVG element, included in the accessibility tree, with a role
+ *   requiring specific children; and
  * - does not have an `aria-busy` ancestor.
  */
 function* visit(node: Node, device: Device): Iterable<Element> {
@@ -125,7 +125,7 @@ function* visit(node: Node, device: Device): Iterable<Element> {
       isElement,
       and(
         hasNamespace(Namespace.HTML, Namespace.SVG),
-        not(isIgnored(device)),
+        isIncludedInTheAccessibilityTree(device),
         hasRole(device, (role) => role.hasRequiredChildren())
       )
     )(node)

--- a/packages/alfa-rules/src/sia-r69/rule.ts
+++ b/packages/alfa-rules/src/sia-r69/rule.ts
@@ -20,7 +20,7 @@ import { Contrast as Outcomes } from "../common/outcome/contrast";
 
 import { Scope } from "../tags";
 
-const { hasRole, isPerceivable, isSemanticallyDisabled } = DOM;
+const { hasRole, isPerceivableForAll, isSemanticallyDisabled } = DOM;
 const { hasNamespace, isElement } = Element;
 const { flatMap, map } = Iterable;
 const { max } = Math;
@@ -54,7 +54,7 @@ export default Rule.Atomic.of<Page, Text, Question.Metadata>({
             return;
           }
 
-          if (test(and(isText, isPerceivable(device)), node)) {
+          if (test(and(isText, isPerceivableForAll(device)), node)) {
             yield node;
           }
 

--- a/packages/alfa-rules/src/sia-r7/rule.ts
+++ b/packages/alfa-rules/src/sia-r7/rule.ts
@@ -23,7 +23,7 @@ import { expectation } from "../common/act/expectation";
 import { isWhitespace } from "../common/predicate";
 import { Scope } from "../tags";
 
-const { hasAccessibleName, isIgnored } = DOM;
+const { hasAccessibleName, isIncludedInTheAccessibilityTree } = DOM;
 const { hasAttribute, hasName, hasNamespace, isElement } = Element;
 const { isEmpty } = Iterable;
 const { not, or } = Predicate;
@@ -49,7 +49,7 @@ export default Rule.Atomic.of<Page, Attribute>({
             const isVisibleText = and(
               isText,
               and(
-                or(isVisible(device), not(isIgnored(device))),
+                or(isVisible(device), isIncludedInTheAccessibilityTree(device)),
                 (text: Text) => !isWhitespace(text.data)
               )
             );

--- a/packages/alfa-rules/src/sia-r76/rule.ts
+++ b/packages/alfa-rules/src/sia-r76/rule.ts
@@ -1,7 +1,6 @@
 import { Diagnostic, Rule } from "@siteimprove/alfa-act";
 import { DOM } from "@siteimprove/alfa-aria";
 import { Element, Namespace, Node } from "@siteimprove/alfa-dom";
-import { Predicate } from "@siteimprove/alfa-predicate";
 import { Refinement } from "@siteimprove/alfa-refinement";
 import { Err, Ok } from "@siteimprove/alfa-result";
 import { Criterion } from "@siteimprove/alfa-wcag";
@@ -10,9 +9,8 @@ import { Page } from "@siteimprove/alfa-web";
 import { expectation } from "../common/act/expectation";
 import { Scope } from "../tags";
 
-const { hasRole, isIgnored, isPerceivable } = DOM;
+const { hasRole, isIncludedInTheAccessibilityTree, isPerceivable } = DOM;
 const { isElement, hasName, hasNamespace } = Element;
-const { not } = Predicate;
 const { and, test } = Refinement;
 
 export default Rule.Atomic.of<Page, Element>({
@@ -31,7 +29,7 @@ export default Rule.Atomic.of<Page, Element>({
           if (test(and(isElement, hasNamespace(Namespace.HTML)), node)) {
             if (test(hasName("table"), node)) {
               // only collect cells of accessible tables
-              collect = test(not(isIgnored(device)), node);
+              collect = test(isIncludedInTheAccessibilityTree(device), node);
             }
 
             if (

--- a/packages/alfa-rules/src/sia-r76/rule.ts
+++ b/packages/alfa-rules/src/sia-r76/rule.ts
@@ -9,7 +9,7 @@ import { Page } from "@siteimprove/alfa-web";
 import { expectation } from "../common/act/expectation";
 import { Scope } from "../tags";
 
-const { hasRole, isIncludedInTheAccessibilityTree, isPerceivable } = DOM;
+const { hasRole, isIncludedInTheAccessibilityTree, isPerceivableForAll } = DOM;
 const { isElement, hasName, hasNamespace } = Element;
 const { and, test } = Refinement;
 
@@ -34,7 +34,7 @@ export default Rule.Atomic.of<Page, Element>({
 
             if (
               collect &&
-              test(and(hasName("th"), isPerceivable(device)), node)
+              test(and(hasName("th"), isPerceivableForAll(device)), node)
             ) {
               yield node;
             }

--- a/packages/alfa-rules/src/sia-r77/rule.ts
+++ b/packages/alfa-rules/src/sia-r77/rule.ts
@@ -12,7 +12,7 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { hasRole, isIncludedInTheAccessibilityTree, isPerceivable } = DOM;
+const { hasRole, isIncludedInTheAccessibilityTree, isPerceivableForAll } = DOM;
 const { isElement, hasName, hasNamespace } = Element;
 const { and } = Predicate;
 
@@ -51,7 +51,7 @@ export default Rule.Atomic.of<Page, Element>({
                 hasNamespace(Namespace.HTML),
                 hasName("td"),
                 hasRole(device, "cell", "gridcell"),
-                isPerceivable(device)
+                isPerceivableForAll(device)
               )
             );
 

--- a/packages/alfa-rules/src/sia-r77/rule.ts
+++ b/packages/alfa-rules/src/sia-r77/rule.ts
@@ -12,9 +12,9 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { hasRole, isIgnored, isPerceivable } = DOM;
+const { hasRole, isIncludedInTheAccessibilityTree, isPerceivable } = DOM;
 const { isElement, hasName, hasNamespace } = Element;
-const { and, not } = Predicate;
+const { and } = Predicate;
 
 export default Rule.Atomic.of<Page, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r77",
@@ -32,7 +32,7 @@ export default Rule.Atomic.of<Page, Element>({
             and(
               hasNamespace(Namespace.HTML),
               hasName("table"),
-              not(isIgnored(device))
+              isIncludedInTheAccessibilityTree(device)
             )
           );
 

--- a/packages/alfa-rules/src/sia-r78/rule.ts
+++ b/packages/alfa-rules/src/sia-r78/rule.ts
@@ -13,7 +13,7 @@ const {
   hasHeadingLevel,
   hasRole,
   isIncludedInTheAccessibilityTree,
-  isPerceivable,
+  isPerceivableForAll,
 } = DOM;
 const { hasNamespace, isContent, isElement } = Element;
 const { and } = Refinement;
@@ -77,7 +77,7 @@ export default Rule.Atomic.of<Page, Element>({
               // last node of the document is acceptable content; otherwise, the
               // next heading (of this level or less) is not acceptable content.
               includeSecond: end,
-            }).some(and(isPerceivable(device), isContent(Node.fullTree))),
+            }).some(and(isPerceivableForAll(device), isContent(Node.fullTree))),
             () => Outcomes.hasContent,
             () => Outcomes.hasNoContent
           ),

--- a/packages/alfa-rules/src/sia-r78/rule.ts
+++ b/packages/alfa-rules/src/sia-r78/rule.ts
@@ -1,7 +1,6 @@
 import { Diagnostic, Rule } from "@siteimprove/alfa-act";
 import { DOM, Node as ariaNode } from "@siteimprove/alfa-aria";
 import { Element, Namespace, Node } from "@siteimprove/alfa-dom";
-import { Predicate } from "@siteimprove/alfa-predicate";
 import { Refinement } from "@siteimprove/alfa-refinement";
 import { Err, Ok } from "@siteimprove/alfa-result";
 import { Sequence } from "@siteimprove/alfa-sequence";
@@ -10,9 +9,13 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { hasHeadingLevel, hasRole, isIgnored, isPerceivable } = DOM;
+const {
+  hasHeadingLevel,
+  hasRole,
+  isIncludedInTheAccessibilityTree,
+  isPerceivable,
+} = DOM;
 const { hasNamespace, isContent, isElement } = Element;
-const { not } = Predicate;
 const { and } = Refinement;
 
 export default Rule.Atomic.of<Page, Element>({
@@ -30,7 +33,7 @@ export default Rule.Atomic.of<Page, Element>({
               isElement,
               and(
                 hasNamespace(Namespace.HTML),
-                not(isIgnored(device)),
+                isIncludedInTheAccessibilityTree(device),
                 hasRole(device, "heading")
               )
             )

--- a/packages/alfa-rules/src/sia-r8/rule.ts
+++ b/packages/alfa-rules/src/sia-r8/rule.ts
@@ -10,9 +10,10 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { hasNonEmptyAccessibleName, hasRole, isIgnored } = DOM;
+const { hasNonEmptyAccessibleName, hasRole, isIncludedInTheAccessibilityTree } =
+  DOM;
 const { isElement, hasNamespace } = Element;
-const { and, not } = Predicate;
+const { and } = Predicate;
 
 export default Rule.Atomic.of<Page, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r8",
@@ -41,7 +42,7 @@ export default Rule.Atomic.of<Page, Element>({
                 "switch",
                 "textbox"
               ),
-              not(isIgnored(device))
+              isIncludedInTheAccessibilityTree(device)
             )
           );
       },

--- a/packages/alfa-rules/src/sia-r81/rule.ts
+++ b/packages/alfa-rules/src/sia-r81/rule.ts
@@ -20,9 +20,10 @@ import { normalize } from "../common/normalize";
 
 import { Scope } from "../tags";
 
-const { hasNonEmptyAccessibleName, hasRole, isIgnored } = DOM;
+const { hasNonEmptyAccessibleName, hasRole, isIncludedInTheAccessibilityTree } =
+  DOM;
 const { isElement, hasName, hasNamespace, hasId } = Element;
-const { and, not, equals } = Predicate;
+const { and, equals } = Predicate;
 
 export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
   uri: "https://alfa.siteimprove.com/rules/sia-r81",
@@ -38,7 +39,7 @@ export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
             and(
               hasNamespace(Namespace.HTML, Namespace.SVG),
               hasRole(device, (role) => role.is("link")),
-              not(isIgnored(device)),
+              isIncludedInTheAccessibilityTree(device),
               hasNonEmptyAccessibleName(device)
             )
           )

--- a/packages/alfa-rules/src/sia-r82/rule.ts
+++ b/packages/alfa-rules/src/sia-r82/rule.ts
@@ -13,7 +13,7 @@ import { Question } from "../common/act/question";
 
 import { Scope, Stability } from "../tags";
 
-const { hasRole, isPerceivable } = DOM;
+const { hasRole, isPerceivableForAll } = DOM;
 const { isElement, hasNamespace } = Element;
 const { and, test } = Predicate;
 
@@ -144,7 +144,7 @@ const identifiesTarget = (
         () => Outcomes.NoErrorIndicatorIdentifiesTarget,
         () =>
           expectation(
-            test(isPerceivable(device), indicator.get()),
+            test(isPerceivableForAll(device), indicator.get()),
             () => Outcomes.ErrorIndicatorIdentifiesTarget,
             () => Outcomes.ErrorIndicatorIdentifiesTargetButIsNotPerceivable
           )
@@ -163,7 +163,7 @@ const describesResolution = (
         () => Outcomes.NoErrorIndicatorDescribesResolution,
         () =>
           expectation(
-            test(isPerceivable(device), indicator.get()),
+            test(isPerceivableForAll(device), indicator.get()),
             () => Outcomes.ErrorIndicatorDescribesResolution,
             () => Outcomes.ErrorIndicatorDescribesResolutionButIsNotPerceivable
           )

--- a/packages/alfa-rules/src/sia-r86/rule.ts
+++ b/packages/alfa-rules/src/sia-r86/rule.ts
@@ -8,7 +8,7 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { isIgnored, isMarkedDecorative } = DOM;
+const { isIncludedInTheAccessibilityTree, isMarkedDecorative } = DOM;
 const { isElement } = Element;
 
 export default Rule.Atomic.of<Page, Element>({
@@ -26,9 +26,9 @@ export default Rule.Atomic.of<Page, Element>({
       expectations(target) {
         return {
           1: expectation(
-            isIgnored(device)(target),
-            () => Outcomes.IsNotExposed,
-            () => Outcomes.IsExposed
+            isIncludedInTheAccessibilityTree(device)(target),
+            () => Outcomes.IsExposed,
+            () => Outcomes.IsNotExposed
           ),
         };
       },

--- a/packages/alfa-rules/src/sia-r94/rule.ts
+++ b/packages/alfa-rules/src/sia-r94/rule.ts
@@ -10,9 +10,10 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { hasNonEmptyAccessibleName, hasRole, isIgnored } = DOM;
+const { hasNonEmptyAccessibleName, hasRole, isIncludedInTheAccessibilityTree } =
+  DOM;
 const { isElement, hasNamespace } = Element;
-const { and, not } = Predicate;
+const { and } = Predicate;
 
 export default Rule.Atomic.of<Page, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r94",
@@ -28,7 +29,7 @@ export default Rule.Atomic.of<Page, Element>({
             and(
               hasNamespace(Namespace.HTML),
               hasRole(device, "menuitem"),
-              not(isIgnored(device))
+              isIncludedInTheAccessibilityTree(device)
             )
           );
       },


### PR DESCRIPTION
Side work on #1039 and #1138.
This is only renaming two predicates and cascading the changes in rules.

* `isIgnored` was mostly used negatively to check that things are "included in the accessibility tree" (in ACT / Sanshikan terms), clearing that by creating and using `isIncludedInTheAccessibilityTree` directly.
* `isPerceivable` conflicts with ACT / Sanshikan definition of "Perceivable content". `isPerceivable` was checking "visible **and** included in the accessibility tree" (and is renamed `isPerceivableForAll`). "Perceivable content" is currently not used (will be needed for rules that are not there yet); is checking "visible **or** included in the accessibility tree" and is intended to be name `isPerceivableForSome`.