### PR TITLE
SIA-R78: Only accept accessible content between accessible headings

### DIFF
--- a/packages/alfa-rules/src/sia-r78/rule.ts
+++ b/packages/alfa-rules/src/sia-r78/rule.ts
@@ -74,7 +74,7 @@ export default Rule.Atomic.of<Page, Element>({
               // last node of the document is acceptable content; otherwise, the
               // next heading (of this level or less) is not acceptable content.
               includeSecond: end,
-            }).some(and(isPerceivable(device), isContent(Node.fullTree))),
+            }).some(not(isIgnored(device))),
             () => Outcomes.hasContent,
             () => Outcomes.hasNoContent
           ),

--- a/packages/alfa-rules/src/sia-r78/rule.ts
+++ b/packages/alfa-rules/src/sia-r78/rule.ts
@@ -9,11 +9,7 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const {
-  hasHeadingLevel,
-  hasRole,
-  isIncludedInTheAccessibilityTree,
-} = DOM;
+const { hasHeadingLevel, hasRole, isIncludedInTheAccessibilityTree } = DOM;
 const { hasNamespace, isContent, isElement } = Element;
 const { and } = Refinement;
 
@@ -76,7 +72,12 @@ export default Rule.Atomic.of<Page, Element>({
               // last node of the document is acceptable content; otherwise, the
               // next heading (of this level or less) is not acceptable content.
               includeSecond: end,
-            }).some(and(isIncludedInTheAccessibilityTree(device), isContent(Node.fullTree))),
+            }).some(
+              and(
+                isIncludedInTheAccessibilityTree(device),
+                isContent(Node.fullTree)
+              )
+            ),
             () => Outcomes.hasContent,
             () => Outcomes.hasNoContent
           ),

--- a/packages/alfa-rules/src/sia-r78/rule.ts
+++ b/packages/alfa-rules/src/sia-r78/rule.ts
@@ -10,7 +10,7 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { hasHeadingLevel, hasRole, isIgnored, isPerceivable } = DOM;
+const { hasHeadingLevel, hasRole, isIgnored } = DOM;
 const { hasNamespace, isContent, isElement } = Element;
 const { not } = Predicate;
 const { and } = Refinement;
@@ -74,7 +74,7 @@ export default Rule.Atomic.of<Page, Element>({
               // last node of the document is acceptable content; otherwise, the
               // next heading (of this level or less) is not acceptable content.
               includeSecond: end,
-            }).some(not(isIgnored(device))),
+            }).some(and(not(isIgnored(device)), isContent(Node.fullTree))),
             () => Outcomes.hasContent,
             () => Outcomes.hasNoContent
           ),

--- a/packages/alfa-rules/test/sia-r78/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r78/rule.spec.tsx
@@ -94,7 +94,7 @@ test("evaluates() fails a heading with only structure before the next heading", 
 
   const document = h.document([
     part1,
-    <nav>
+    <nav aria-label="site">
       {part2}
       <a href="#">Foo</a>
     </nav>,

--- a/packages/alfa-rules/test/sia-r78/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r78/rule.spec.tsx
@@ -88,6 +88,24 @@ test("evaluates() passes headings with only non-visible content", async (t) => {
   ]);
 });
 
+test("evaluates() fails a heading with only structure before the next heading", async (t) => {
+  const part1 = <h1>Hello</h1>;
+  const part2 = <h2>Site navigation</h2>;
+
+  const document = h.document([
+    part1,
+    <nav>
+      {part2}
+      <a href="#">Foo</a>
+    </nav>,
+  ]);
+
+  t.deepEqual(await evaluate(R78, { document }), [
+    failed(R78, part1, { 1: Outcomes.hasNoContent }),
+    passed(R78, part2, { 1: Outcomes.hasContent }),
+  ]);
+});
+
 test(`evaluate() is inapplicable when there is no headings`, async (t) => {
   const document = h.document([<div></div>]);
 

--- a/packages/alfa-rules/test/sia-r78/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r78/rule.spec.tsx
@@ -90,7 +90,7 @@ test("evaluates() passes headings with only non-visible content", async (t) => {
 
 test("evaluates() fails a heading with only structure before the next heading", async (t) => {
   const part1 = <h1>Hello</h1>;
-  const part2 = <h2>Site navigation</h2>;
+  const part2 = <h1>Site navigation</h1>;
 
   const document = h.document([
     part1,

--- a/packages/alfa-rules/test/sia-r78/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r78/rule.spec.tsx
@@ -69,6 +69,25 @@ test(`evaluate() fails headings with no content`, async (t) => {
   ]);
 });
 
+test("evaluates() passes headings with only non-visible content", async (t) => {
+  const part1 = <h1>Lorem</h1>;
+  const part2 = <h1>Ipsum</h1>;
+
+  const document = h.document([
+    part1,
+    <div style={{ height: "0px", width: "0px", overflow: "hidden" }}>
+      Hello
+    </div>,
+    part2,
+    <div>world</div>,
+  ]);
+
+  t.deepEqual(await evaluate(R78, { document }), [
+    passed(R78, part1, { 1: Outcomes.hasContent }),
+    passed(R78, part2, { 1: Outcomes.hasContent }),
+  ]);
+});
+
 test(`evaluate() is inapplicable when there is no headings`, async (t) => {
   const document = h.document([<div></div>]);
 


### PR DESCRIPTION
Resolves #1039, resolves #1138 

Adapt to the latest Sanshikan version.