### PR TITLE
Export previous heading in R53 diagnostic

### DIFF
--- a/docs/review/api/alfa-rules.api.md
+++ b/docs/review/api/alfa-rules.api.md
@@ -392,6 +392,10 @@ export namespace Diagnostic {
     //
     // (undocumented)
     isWithDeclaration: typeof WithDeclaration.isWithDeclaration;
+    const // Warning: (ae-forgotten-export) The symbol "WithPreviousHeading" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    isWithPreviousHeading: typeof WithPreviousHeading.isWithPreviousHeading;
     const // Warning: (ae-forgotten-export) The symbol "WithRole" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)

--- a/packages/alfa-rules/src/common/act/diagnostic.ts
+++ b/packages/alfa-rules/src/common/act/diagnostic.ts
@@ -1,13 +1,14 @@
-import { DistinguishingStyles } from "../../sia-r62/diagnostics";
-import { Languages } from "../../sia-r109/rule";
 import { LabelAndName } from "../../sia-r14/rule";
 import { RoleAndRequiredAttributes } from "../../sia-r16/rule";
+import { WithPreviousHeading } from "../../sia-r53/rule";
 import { SameNames } from "../../sia-r56/rule";
-import { MatchingClasses } from "../../sia-r65/diagnostics";
+import { DistinguishingStyles } from "../../sia-r62/diagnostics";
 import { DistinguishingStyles as DeprecatedDistinguishingStyles } from "../../sia-dr62/rule";
+import { MatchingClasses } from "../../sia-r65/diagnostics";
 import { DeprecatedElements } from "../../sia-r70/rule";
 import { WithDeclaration } from "../../sia-r75/rule";
 import { ClippingAncestors } from "../../sia-r83/rule";
+import { Languages } from "../../sia-r109/rule";
 
 // R66, R69
 import { Contrast } from "../diagnostic/contrast";
@@ -49,6 +50,8 @@ export namespace Diagnostic {
   export const { isSameNames } = SameNames;
 
   export const { isWithDeclaration } = WithDeclaration;
+
+  export const { isWithPreviousHeading } = WithPreviousHeading;
 
   export const { isWithRole } = WithRole;
 }

--- a/packages/alfa-rules/test/sia-r53/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r53/rule.spec.tsx
@@ -7,12 +7,13 @@ import { evaluate } from "../common/evaluate";
 import { passed, failed, inapplicable } from "../common/outcome";
 
 test("evaluate() passes when the document headings are structured", async (t) => {
+  const first = <h1>Part one</h1>;
   const target1 = <h2>Chapter one</h2>;
   const target2 = <h3>Section one</h3>;
 
   const document = h.document([
     <html>
-      <h1>Part one</h1>
+      {first}
       {target1}
       {target2}
     </html>,
@@ -20,22 +21,23 @@ test("evaluate() passes when the document headings are structured", async (t) =>
 
   t.deepEqual(await evaluate(R53, { document }), [
     passed(R53, target1, {
-      1: Outcomes.IsStructured,
+      1: Outcomes.IsStructured(first),
     }),
     passed(R53, target2, {
-      1: Outcomes.IsStructured,
+      1: Outcomes.IsStructured(target1),
     }),
   ]);
 });
 
 test("evaluate() fails when the document headings are not properly structured", async (t) => {
+  const first = <h1>Part one</h1>;
   const target1 = <h3>Chapter one</h3>;
   const target2 = <h2>Part two</h2>;
   const target3 = <h6>Chapter one</h6>;
 
   const document = h.document([
     <html>
-      <h1>Part one</h1>
+      {first}
       {target1}
       {target2}
       {target3}
@@ -44,13 +46,13 @@ test("evaluate() fails when the document headings are not properly structured", 
 
   t.deepEqual(await evaluate(R53, { document }), [
     failed(R53, target1, {
-      1: Outcomes.IsNotStructured,
+      1: Outcomes.IsNotStructured(first),
     }),
     passed(R53, target2, {
-      1: Outcomes.IsStructured,
+      1: Outcomes.IsStructured(target1),
     }),
     failed(R53, target3, {
-      1: Outcomes.IsNotStructured,
+      1: Outcomes.IsNotStructured(target2),
     }),
   ]);
 });
@@ -66,12 +68,13 @@ test("evaluate() is inapplicable when the document has only one heading", async 
 });
 
 test("evaluate() ignore headings that are not exposed", async (t) => {
+  const first = <h1>Part one</h1>;
   const target1 = <h2>Chapter one</h2>;
   const target2 = <h2>Chapter two</h2>;
 
   const document = h.document([
     <html>
-      <h1>Part one</h1>
+      {first}
       <h3 hidden>I'm not here</h3>
       {target1}
       {target2}
@@ -80,10 +83,10 @@ test("evaluate() ignore headings that are not exposed", async (t) => {
 
   t.deepEqual(await evaluate(R53, { document }), [
     passed(R53, target1, {
-      1: Outcomes.IsStructured,
+      1: Outcomes.IsStructured(first),
     }),
     passed(R53, target2, {
-      1: Outcomes.IsStructured,
+      1: Outcomes.IsStructured(target1),
     }),
   ]);
 });


### PR DESCRIPTION
Resolves #1187 

So far, only for storing in diagnostic for easier investigation.
