### PR TITLE
Improve typing of `Array.sortWith`

### DIFF
--- a/docs/review/api/alfa-array.api.md
+++ b/docs/review/api/alfa-array.api.md
@@ -126,7 +126,7 @@ namespace Array_2 {
     // (undocumented)
     function sort<T extends Comparable<T>>(array: Array_2<T>): Array_2<T>;
     // (undocumented)
-    function sortWith<T>(array: Array_2<T>, comparer: Comparer<T>): Array_2<T>;
+    function sortWith<T, U extends T = T>(array: Array_2<U>, comparer: Comparer<T>): Array_2<U>;
     // (undocumented)
     function subtract<T>(array: ReadonlyArray<T>, ...iterables: Array_2<Iterable_2<T>>): Array_2<T>;
     // (undocumented)

--- a/packages/alfa-array/src/array.ts
+++ b/packages/alfa-array/src/array.ts
@@ -440,13 +440,13 @@ export namespace Array {
   }
 
   export function sort<T extends Comparable<T>>(array: Array<T>): Array<T> {
-    return sortWith(array, compareComparable);
+    return sortWith<T>(array, compareComparable);
   }
 
-  export function sortWith<T>(
-    array: Array<T>,
+  export function sortWith<T, U extends T = T>(
+    array: Array<U>,
     comparer: Comparer<T>
-  ): Array<T> {
+  ): Array<U> {
     return array.sort(comparer);
   }
 

--- a/packages/alfa-rules/src/sia-r62/diagnostics.ts
+++ b/packages/alfa-rules/src/sia-r62/diagnostics.ts
@@ -1,6 +1,5 @@
 import { Diagnostic } from "@siteimprove/alfa-act";
 import { Array } from "@siteimprove/alfa-array";
-import { Comparable } from "@siteimprove/alfa-comparable";
 import { Device } from "@siteimprove/alfa-device";
 import { Element } from "@siteimprove/alfa-dom";
 import { Equatable } from "@siteimprove/alfa-equatable";

--- a/packages/alfa-rules/src/sia-r62/diagnostics.ts
+++ b/packages/alfa-rules/src/sia-r62/diagnostics.ts
@@ -1,5 +1,6 @@
 import { Diagnostic } from "@siteimprove/alfa-act";
 import { Array } from "@siteimprove/alfa-array";
+import { Comparable } from "@siteimprove/alfa-comparable";
 import { Device } from "@siteimprove/alfa-device";
 import { Element } from "@siteimprove/alfa-dom";
 import { Equatable } from "@siteimprove/alfa-equatable";
@@ -174,7 +175,7 @@ export namespace ElementDistinguishable {
         ["text-decoration", Serialise.textDecoration(style)] as const,
         ["box-shadow", Serialise.boxShadow(style)] as const,
       ].filter(([_, value]) => value !== ""),
-      Array.sortWith([...pairings], (a, b) => a.compare(b))
+      Array.sort(Array.from(pairings))
     );
   }
 }


### PR DESCRIPTION
```typescript
type Foo: {foo: number}
type Bar: {bar: string}

const comparer: Comparer<Foo> = (a, b) => Comparable.compareNumber(a.foo, b.foo);

const source: Array<Foo & Bar> = []

const dest = source.sortWith(comparer);
```
This used to lost the fact that the array contains `Foo & Bar` and only return an `Array<Foo>` because the same type was used for the array and the comparer. Now we can use a comparer on a super-type and keep the narrow type on the array.
