### PR TITLE
Allow formatters to be synchronous

### DIFF
--- a/docs/review/api/alfa-formatter.api.md
+++ b/docs/review/api/alfa-formatter.api.md
@@ -4,12 +4,13 @@
 
 ```ts
 
+import { Future } from '@siteimprove/alfa-future';
 import { Outcome } from '@siteimprove/alfa-act';
 import { Result } from '@siteimprove/alfa-result';
 import { Rule } from '@siteimprove/alfa-act';
 
 // @public (undocumented)
-export type Formatter<I = unknown, T = unknown, Q = never, S = T> = (input: I, rules: Iterable<Rule<I, T, Q, S>>, outcomes: Iterable<Outcome<I, T, Q, S>>) => Promise<string>;
+export type Formatter<I = unknown, T = unknown, Q = never, S = T> = (input: I, rules: Iterable<Rule<I, T, Q, S>>, outcomes: Iterable<Outcome<I, T, Q, S>>) => Future.Maybe<string>;
 
 // @public (undocumented)
 export namespace Formatter {

--- a/packages/alfa-formatter-earl/package.json
+++ b/packages/alfa-formatter-earl/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@siteimprove/alfa-earl": "workspace:^0.41.0",
     "@siteimprove/alfa-formatter": "workspace:^0.41.0",
+    "@siteimprove/alfa-future": "workspace:^0.41.0",
     "jsonld": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/alfa-formatter-earl/src/earl.ts
+++ b/packages/alfa-formatter-earl/src/earl.ts
@@ -1,5 +1,6 @@
 import { Serializable, EARL } from "@siteimprove/alfa-earl";
 import { Formatter } from "@siteimprove/alfa-formatter";
+import { Future } from "@siteimprove/alfa-future";
 
 import * as jsonld from "jsonld";
 
@@ -11,7 +12,7 @@ const { stringify } = JSON;
  * @public
  */
 export default function <I, T, Q, S>(): Formatter<I, T, Q, S> {
-  return async function EARL(input, rules, outcomes) {
+  return function EARL(input, rules, outcomes) {
     const subject = Serializable.toEARL(input);
 
     let earl = {
@@ -38,9 +39,9 @@ export default function <I, T, Q, S>(): Formatter<I, T, Q, S> {
       ],
     } as jsonld.JsonLdDocument;
 
-    const compact = await jsonld.compact(earl, ACTContext);
-
-    return stringify(compact, null, 2);
+    return Future.from(jsonld.compact(earl, ACTContext)).map((compact) =>
+      stringify(compact, null, 2)
+    );
   };
 }
 

--- a/packages/alfa-formatter-earl/tsconfig.json
+++ b/packages/alfa-formatter-earl/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../alfa-formatter"
     },
     {
+      "path": "../alfa-future"
+    },
+    {
       "path": "../alfa-test"
     }
   ]

--- a/packages/alfa-formatter-json/src/json.ts
+++ b/packages/alfa-formatter-json/src/json.ts
@@ -7,7 +7,7 @@ const { stringify } = JSON;
  * @public
  */
 export default function <I, T, Q, S>(): Formatter<I, T, Q, S> {
-  return async function JSON(input, rules, outcomes) {
+  return function JSON(input, rules, outcomes) {
     return stringify(
       {
         input: Serializable.toJSON(input),

--- a/packages/alfa-formatter-sarif/src/sarif.ts
+++ b/packages/alfa-formatter-sarif/src/sarif.ts
@@ -9,7 +9,7 @@ const { stringify } = JSON;
  * @public
  */
 export default function <I, T, Q, S>(): Formatter<I, T, Q, S> {
-  return async function SARIF(input, rules, outcomes) {
+  return function SARIF(input, rules, outcomes) {
     const log: Log = {
       $schema: "https://json.schemastore.org/sarif-2.1.0.json",
       version: "2.1.0",

--- a/packages/alfa-formatter/package.json
+++ b/packages/alfa-formatter/package.json
@@ -19,6 +19,7 @@
   ],
   "dependencies": {
     "@siteimprove/alfa-act": "workspace:^0.41.0",
+    "@siteimprove/alfa-future": "workspace:^0.41.0",
     "@siteimprove/alfa-result": "workspace:^0.41.0"
   },
   "devDependencies": {

--- a/packages/alfa-formatter/src/formatter.ts
+++ b/packages/alfa-formatter/src/formatter.ts
@@ -1,4 +1,5 @@
 import { Outcome, Rule } from "@siteimprove/alfa-act";
+import { Future } from "@siteimprove/alfa-future";
 import { Result, Err } from "@siteimprove/alfa-result";
 
 /**
@@ -8,7 +9,7 @@ export type Formatter<I = unknown, T = unknown, Q = never, S = T> = (
   input: I,
   rules: Iterable<Rule<I, T, Q, S>>,
   outcomes: Iterable<Outcome<I, T, Q, S>>
-) => Promise<string>;
+) => Future.Maybe<string>;
 
 /**
  * @public

--- a/packages/alfa-formatter/tsconfig.json
+++ b/packages/alfa-formatter/tsconfig.json
@@ -7,6 +7,9 @@
       "path": "../alfa-act"
     },
     {
+      "path": "../alfa-future"
+    },
+    {
       "path": "../alfa-result"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1447,6 +1447,7 @@ __metadata:
   dependencies:
     "@siteimprove/alfa-earl": "workspace:^0.41.0"
     "@siteimprove/alfa-formatter": "workspace:^0.41.0"
+    "@siteimprove/alfa-future": "workspace:^0.41.0"
     "@siteimprove/alfa-test": "workspace:^0.41.0"
     jsonld: ^6.0.0
   languageName: unknown
@@ -1477,6 +1478,7 @@ __metadata:
   resolution: "@siteimprove/alfa-formatter@workspace:packages/alfa-formatter"
   dependencies:
     "@siteimprove/alfa-act": "workspace:^0.41.0"
+    "@siteimprove/alfa-future": "workspace:^0.41.0"
     "@siteimprove/alfa-result": "workspace:^0.41.0"
     "@siteimprove/alfa-test": "workspace:^0.41.0"
   languageName: unknown


### PR DESCRIPTION
In #1167 we were a bit too eager in making the formatter asynchronous, plus using a `Promise` rather than a `Future` prevented the formatters to be used as `Handler` in an `Assertion` 🙈 

This allow both synchronous and asynchronous (with `Future`) formatters.