### PR TITLE
Keep subtype in collections with .sortWith

### DIFF
--- a/docs/review/api/alfa-array.api.md
+++ b/docs/review/api/alfa-array.api.md
@@ -126,6 +126,8 @@ namespace Array_2 {
     // (undocumented)
     function sort<T extends Comparable<T>>(array: Array_2<T>): Array_2<T>;
     // (undocumented)
+    function sortWith<T>(array: Array_2<T>, comparer: Comparer<T>): Array_2<T>;
+    // (undocumented)
     function sortWith<T, U extends T = T>(array: Array_2<U>, comparer: Comparer<T>): Array_2<U>;
     // (undocumented)
     function subtract<T>(array: ReadonlyArray<T>, ...iterables: Array_2<Iterable_2<T>>): Array_2<T>;

--- a/docs/review/api/alfa-collection.api.md
+++ b/docs/review/api/alfa-collection.api.md
@@ -169,6 +169,8 @@ export namespace Collection {
         // (undocumented)
         sortWith(comparer: Comparer<T>): Indexed<T>;
         // (undocumented)
+        sortWith<T, U extends T = T>(this: Indexed<U>, comparer: Comparer<T>): Indexed<U>;
+        // (undocumented)
         subtract(iterable: Iterable_2<T>): Indexed<T>;
         // (undocumented)
         take(count: number): Indexed<T>;

--- a/docs/review/api/alfa-iterable.api.md
+++ b/docs/review/api/alfa-iterable.api.md
@@ -136,6 +136,8 @@ namespace Iterable_2 {
     // (undocumented)
     function sortWith<T>(iterable: Iterable_2<T>, comparer: Comparer<T>): Iterable_2<T>;
     // (undocumented)
+    function sortWith<T, U extends T = T>(iterable: Iterable_2<U>, comparer: Comparer<T>): Iterable_2<U>;
+    // (undocumented)
     function subtract<T>(iterable: Iterable_2<T>, ...iterables: Array<Iterable_2<T>>): Iterable_2<T>;
     // (undocumented)
     function take<T>(iterable: Iterable_2<T>, count: number): Iterable_2<T>;

--- a/docs/review/api/alfa-list.api.md
+++ b/docs/review/api/alfa-list.api.md
@@ -197,6 +197,8 @@ export class List<T> implements Collection.Indexed<T> {
     // (undocumented)
     sortWith(comparer: Comparer<T>): List<T>;
     // (undocumented)
+    sortWith<T, U extends T = T>(this: List<U>, comparer: Comparer<T>): List<U>;
+    // (undocumented)
     subtract(iterable: Iterable_2<T>): List<T>;
     // (undocumented)
     take(count: number): List<T>;

--- a/docs/review/api/alfa-sequence.api.md
+++ b/docs/review/api/alfa-sequence.api.md
@@ -142,6 +142,8 @@ export class Cons<T> implements Sequence<T> {
     // (undocumented)
     sortWith(comparer: Comparer<T>): Sequence<T>;
     // (undocumented)
+    sortWith<T, U extends T = T>(this: Sequence<U>, comparer: Comparer<T>): Sequence<U>;
+    // (undocumented)
     subtract(iterable: Iterable_2<T>): Sequence<T>;
     // (undocumented)
     take(count: number): Sequence<T>;
@@ -298,6 +300,8 @@ export interface Sequence<T> extends Collection.Indexed<T> {
     sort<T extends Comparable<T>>(this: Sequence<T>): Sequence<T>;
     // (undocumented)
     sortWith(comparer: Comparer<T>): Sequence<T>;
+    // (undocumented)
+    sortWith<T, U extends T = T>(this: Sequence<U>, comparer: Comparer<T>): Sequence<U>;
     // (undocumented)
     subtract(iterable: Iterable<T>): Sequence<T>;
     // (undocumented)

--- a/docs/review/api/alfa-slice.api.md
+++ b/docs/review/api/alfa-slice.api.md
@@ -138,6 +138,8 @@ export class Slice<T> implements Collection.Indexed<T> {
     // (undocumented)
     sortWith(comparer: Comparer<T>): Slice<T>;
     // (undocumented)
+    sortWith<T, U extends T = T>(this: Slice<U>, comparer: Comparer<T>): Slice<U>;
+    // (undocumented)
     subtract(iterable: Iterable_2<T>): Slice<T>;
     // (undocumented)
     take(count: number): Slice<T>;

--- a/packages/alfa-array/src/array.ts
+++ b/packages/alfa-array/src/array.ts
@@ -440,13 +440,20 @@ export namespace Array {
   }
 
   export function sort<T extends Comparable<T>>(array: Array<T>): Array<T> {
-    return sortWith<T>(array, compareComparable);
+    return sortWith(array, compareComparable);
   }
+
+  export function sortWith<T>(array: Array<T>, comparer: Comparer<T>): Array<T>;
 
   export function sortWith<T, U extends T = T>(
     array: Array<U>,
     comparer: Comparer<T>
-  ): Array<U> {
+  ): Array<U>;
+
+  export function sortWith<T>(
+    array: Array<T>,
+    comparer: Comparer<T>
+  ): Array<T> {
     return array.sort(comparer);
   }
 

--- a/packages/alfa-collection/src/collection.ts
+++ b/packages/alfa-collection/src/collection.ts
@@ -211,6 +211,10 @@ export namespace Collection {
     join(separator: string): string;
     sort<T extends Comparable<T>>(this: Indexed<T>): Indexed<T>;
     sortWith(comparer: Comparer<T>): Indexed<T>;
+    sortWith<T, U extends T = T>(
+      this: Indexed<U>,
+      comparer: Comparer<T>
+    ): Indexed<U>;
     compare<T>(this: Indexed<Comparable<T>>, iterable: Iterable<T>): Comparison;
     compareWith<U = T>(
       iterable: Iterable<U>,

--- a/packages/alfa-iterable/src/iterable.ts
+++ b/packages/alfa-iterable/src/iterable.ts
@@ -740,6 +740,16 @@ export namespace Iterable {
     return sortWith(iterable, compareComparable);
   }
 
+  export function sortWith<T>(
+    iterable: Iterable<T>,
+    comparer: Comparer<T>
+  ): Iterable<T>;
+
+  export function sortWith<T, U extends T = T>(
+    iterable: Iterable<U>,
+    comparer: Comparer<T>
+  ): Iterable<U>;
+
   export function* sortWith<T>(
     iterable: Iterable<T>,
     comparer: Comparer<T>

--- a/packages/alfa-list/src/list.ts
+++ b/packages/alfa-list/src/list.ts
@@ -403,6 +403,13 @@ export class List<T> implements Collection.Indexed<T> {
     return this.sortWith(compareComparable);
   }
 
+  public sortWith(comparer: Comparer<T>): List<T>;
+
+  public sortWith<T, U extends T = T>(
+    this: List<U>,
+    comparer: Comparer<T>
+  ): List<U>;
+
   public sortWith(comparer: Comparer<T>): List<T> {
     return List.from(Iterable.sortWith(this, comparer));
   }

--- a/packages/alfa-sequence/src/cons.ts
+++ b/packages/alfa-sequence/src/cons.ts
@@ -670,6 +670,13 @@ export class Cons<T> implements Sequence<T> {
     return this.sortWith(compareComparable);
   }
 
+  public sortWith(comparer: Comparer<T>): Sequence<T>;
+
+  public sortWith<T, U extends T = T>(
+    this: Sequence<U>,
+    comparer: Comparer<T>
+  ): Sequence<U>;
+
   public sortWith(comparer: Comparer<T>): Sequence<T> {
     return Sequence.fromArray(Array.sortWith(this.toArray(), comparer));
   }

--- a/packages/alfa-sequence/src/sequence.ts
+++ b/packages/alfa-sequence/src/sequence.ts
@@ -91,6 +91,10 @@ export interface Sequence<T> extends Collection.Indexed<T> {
   join(separator: string): string;
   sort<T extends Comparable<T>>(this: Sequence<T>): Sequence<T>;
   sortWith(comparer: Comparer<T>): Sequence<T>;
+  sortWith<T, U extends T = T>(
+    this: Sequence<U>,
+    comparer: Comparer<T>
+  ): Sequence<U>;
   compare<T>(this: Sequence<Comparable<T>>, iterable: Iterable<T>): Comparison;
   compareWith<U = T>(
     iterable: Iterable<U>,

--- a/packages/alfa-slice/src/slice.ts
+++ b/packages/alfa-slice/src/slice.ts
@@ -405,6 +405,13 @@ export class Slice<T> implements Collection.Indexed<T> {
     return this.sortWith(compareComparable);
   }
 
+  public sortWith(comparer: Comparer<T>): Slice<T>;
+
+  public sortWith<T, U extends T = T>(
+    this: Slice<U>,
+    comparer: Comparer<T>
+  ): Slice<U>;
+
   public sortWith(comparer: Comparer<T>): Slice<T> {
     const array = Array.sortWith(this.toArray(), comparer);
 


### PR DESCRIPTION
```typescript
type Foo = { foo: number };

type Bar = { foo: number; bar: string };

function FooComparer(a: Foo, b: Foo): Comparison {
  return Comparable.compareNumber(a.foo, b.foo);
}

function sortFoo(array: Array<Foo>): Array<Foo> {
  return Array.sortWith(array, (a, b) => FooComparer(a, b));
}

function sortBar(array: Array<Bar>): Array<Bar> {
  return Array.sortWith(array, (a, b) => FooComparer(a, b));
}
```
Before #1189, `sortBar` wasn't typable because `sortWith` was always returning the type of the comparer (`Array<Foo>`).
After #1189, `sortFoo` becomes untypable because `sortWith` was always expecting a type parameter `T` and would here infer it as `unknown` so `a` and `b` would be typed as `unknown`.

This let `sortWith` default to the older version and thus accept both types.
