### PR TITLE
Cache `:hover` and `:focus-within` selector matching

### DIFF
--- a/docs/review/api/alfa-selector.api.md
+++ b/docs/review/api/alfa-selector.api.md
@@ -55,6 +55,8 @@ export class Context {
     visit(element: Element): Context;
     // (undocumented)
     static visit(element: Element): Context;
+    // (undocumented)
+    withState(state: Context.State): Iterable<Element>;
 }
 
 // @public (undocumented)

--- a/packages/alfa-selector/package.json
+++ b/packages/alfa-selector/package.json
@@ -19,6 +19,7 @@
   ],
   "dependencies": {
     "@siteimprove/alfa-array": "workspace:^0.46.0",
+    "@siteimprove/alfa-cache": "workspace:^0.46.0",
     "@siteimprove/alfa-css": "workspace:^0.46.0",
     "@siteimprove/alfa-dom": "workspace:^0.46.0",
     "@siteimprove/alfa-equatable": "workspace:^0.46.0",
@@ -29,6 +30,7 @@
     "@siteimprove/alfa-parser": "workspace:^0.46.0",
     "@siteimprove/alfa-predicate": "workspace:^0.46.0",
     "@siteimprove/alfa-result": "workspace:^0.46.0",
+    "@siteimprove/alfa-sequence": "workspace:^0.46.0",
     "@siteimprove/alfa-slice": "workspace:^0.46.0"
   },
   "devDependencies": {

--- a/packages/alfa-selector/src/context.ts
+++ b/packages/alfa-selector/src/context.ts
@@ -37,6 +37,10 @@ export class Context {
     return this.setState(element, this.getState(element) | state);
   }
 
+  public *withState(state: Context.State): Iterable<Element> {
+    yield* this._state.filter((found) => (found & state) !== 0).keys();
+  }
+
   public hover(element: Element): Context {
     return this.addState(element, Context.State.Hover);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2179,6 +2179,7 @@ __metadata:
   resolution: "@siteimprove/alfa-selector@workspace:packages/alfa-selector"
   dependencies:
     "@siteimprove/alfa-array": "workspace:^0.46.0"
+    "@siteimprove/alfa-cache": "workspace:^0.46.0"
     "@siteimprove/alfa-css": "workspace:^0.46.0"
     "@siteimprove/alfa-dom": "workspace:^0.46.0"
     "@siteimprove/alfa-equatable": "workspace:^0.46.0"
@@ -2189,6 +2190,7 @@ __metadata:
     "@siteimprove/alfa-parser": "workspace:^0.46.0"
     "@siteimprove/alfa-predicate": "workspace:^0.46.0"
     "@siteimprove/alfa-result": "workspace:^0.46.0"
+    "@siteimprove/alfa-sequence": "workspace:^0.46.0"
     "@siteimprove/alfa-slice": "workspace:^0.46.0"
     "@siteimprove/alfa-test": "workspace:^0.46.0"
   languageName: unknown


### PR DESCRIPTION
Both of these selectors need to look into the full sub-tree to decide a match, so caching the computation.
Extra optimisation by adding an early escape break if nothing is hovered/focused in the context, since this is by far the most frequent case.
