### PR TITLE
Fix `isVisible` check on `visibility` property

### DIFF
--- a/packages/alfa-style/src/node/predicate/is-visible.ts
+++ b/packages/alfa-style/src/node/predicate/is-visible.ts
@@ -16,8 +16,8 @@ import { isRendered } from "./is-rendered";
 import { isTransparent } from "./is-transparent";
 
 const { hasName, isElement, isReplaced } = Element;
-const { nor, not, or, test } = Predicate;
-const { and } = Refinement;
+const { nor, not, test } = Predicate;
+const { and, or } = Refinement;
 const { isText } = Text;
 
 /**
@@ -58,9 +58,9 @@ function isInvisible(device: Device, context?: Context): Predicate<Node> {
                 context
               )
             ),
-            // Element with visibility != "visible"
+            // Element or Text with visibility != "visible"
             and(
-              isElement,
+              or(isElement, isText),
               hasComputedStyle(
                 "visibility",
                 (visibility) => visibility.value !== "visible",

--- a/packages/alfa-style/test/node/predicate/is-visible.spec.tsx
+++ b/packages/alfa-style/test/node/predicate/is-visible.spec.tsx
@@ -53,11 +53,13 @@ test(`isVisible() returns false when a div element is child of an iframe element
   t.equal(isVisible(div), false);
 });
 
-test(`isVisible() returns false when an element is hidden using the
+test(`isVisible() returns false when an element or text is hidden using the
       \`visibility: hidden\` property`, (t) => {
-  const element = <div style={{ visibility: "hidden" }}>Hello World</div>;
+  const text = h.text("Hello World");
+  const element = <div style={{ visibility: "hidden" }}>{text}</div>;
 
   t.equal(isVisible(element), false);
+  t.equal(isVisible(text), false);
 });
 
 test(`isVisible() returns false when an element is hidden by reducing its size


### PR DESCRIPTION
The test was only made for `Element`, not `Text`, resulting in `Text` whose parent has `visibility: hidden` to be considered visible 🙈 
