### PR TITLE
Fix CSS variable substitution inheritance

### DIFF
--- a/packages/alfa-style/src/style.ts
+++ b/packages/alfa-style/src/style.ts
@@ -491,9 +491,7 @@ function resolve(
       // value. We therefore reject the value of the variable if it's the
       // keyword `initial`.
       // https://drafts.csswg.org/css-variables/#guaranteed-invalid
-      .flatMap((tokens) =>
-        Option.of(tokens).reject((tokens) => parseInitial(tokens).isOk())
-      )
+      .reject((tokens) => parseInitial(tokens).isOk())
 
       // If the value of the variable is invalid, as indicated by it being
       // `None`, we instead use the fallback value, if available.

--- a/packages/alfa-style/src/style.ts
+++ b/packages/alfa-style/src/style.ts
@@ -460,13 +460,39 @@ function resolve(
   visited = Set.empty<string>()
 ): Option<Slice<Token>> {
   return (
+    // First, we search the value of the variable (custom property). The value
+    // is inherited, so if the variable doesn't exist in the current mapping,
+    // we search for it in its parent
     Option.from(variables.get(name))
-      .map((value) =>
-        // The initial value of a custom property is the "guaranteed-invalid"
-        // value. We therefore reject the value of the variable if it's the
-        // keyword `initial`.
-        // https://drafts.csswg.org/css-variables/#guaranteed-invalid
-        Option.of(value.value).reject((tokens) => parseInitial(tokens).isOk())
+      .map((value) => value.value)
+
+      // If no substitution found on the element, search on ancestors
+      .orElse(() =>
+        parent.flatMap((parent) => {
+          const variables = parent.variables;
+
+          const grandparent =
+            parent.parent === Style.empty() ? None : Option.of(parent.parent);
+
+          return (
+            resolve(name, variables, grandparent)
+              // Substitute any additional cascading variables within the inherited
+              // value.
+              .flatMap((tokens) =>
+                substitute(tokens, variables, grandparent).map(
+                  ([tokens]) => tokens
+                )
+              )
+          );
+        })
+      )
+
+      // The initial value of a custom property is the "guaranteed-invalid"
+      // value. We therefore reject the value of the variable if it's the
+      // keyword `initial`.
+      // https://drafts.csswg.org/css-variables/#guaranteed-invalid
+      .flatMap((tokens) =>
+        Option.of(tokens).reject((tokens) => parseInitial(tokens).isOk())
       )
 
       // If the value of the variable is invalid, as indicated by it being
@@ -476,24 +502,11 @@ function resolve(
         fallback
           // Substitute any additional cascading variables within the fallback
           // value.
-          .map((tokens) =>
+          .flatMap((tokens) =>
             substitute(tokens, variables, parent, visited.add(name)).map(
               ([tokens]) => tokens
             )
           )
-      )
-
-      .getOrElse(() =>
-        parent.flatMap((parent) => {
-          const variables = parent.variables;
-
-          const grandparent =
-            parent.parent === Style.empty() ? None : Option.of(parent.parent);
-
-          return resolve(name, variables, grandparent).flatMap((tokens) =>
-            substitute(tokens, variables, grandparent).map(([tokens]) => tokens)
-          );
-        })
       )
   );
 }

--- a/packages/alfa-style/test/style.spec.tsx
+++ b/packages/alfa-style/test/style.spec.tsx
@@ -249,6 +249,33 @@ test(`#cascaded() expands a var() function with an inherited value`, (t) => {
   });
 });
 
+test(`#cascaded() prefers inheriting var() function over using fallback`, (t) => {
+  const element = <div />;
+
+  h.document(
+    [<main>{element}</main>],
+    [
+      h.sheet([
+        h.rule.style("main", {
+          "--hidden": "var(--invalid, hidden)",
+        }),
+
+        h.rule.style("div", {
+          overflowX: "var(--hidden, visible)",
+        }),
+      ]),
+    ]
+  );
+
+  t.deepEqual(cascaded(element, "overflow-x"), {
+    value: {
+      type: "keyword",
+      value: "hidden",
+    },
+    source: h.declaration("overflow-x", "var(--hidden, visible)").toJSON(),
+  });
+});
+
 test(`#cascaded() expands a var() function with an overridden value`, (t) => {
   const element = <div />;
 


### PR DESCRIPTION
Resolves DEV-13646

When encountering CSS variables with a fallback `var(--variable-name, fallback)`, we were incorrectly using the fallback before searching whether the variable is defined on an ancestor. This swaps the order of the operations.