### PR TITLE
Lower typescript target to es2019 from es2020

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "module": "commonjs",
     "sourceMap": true,
     "strict": true,
-    "target": "es2020",
+    "target": "ES2019",
     "types": []
   },
   "files": [],


### PR DESCRIPTION
alfa-cypress was causing errors due to nullish coalescing operator (??).
By lowering the typescript build target to es2019, the issue goes away.

Was able to test it locally, by cloning and building alfa with the lowered build target, and then copy the files to my cypress project.

The first instance of the error is thrown from alfa-css `src/value.js`. 
It is therefor not enough to just lower the build target for just alfa-cypress.

Is there any danger for other projects in lowering the build target to es2019?