### PR TITLE
SIA-R64: Remove mapping to 2.4.6

### DIFF
--- a/packages/alfa-rules/src/sia-r64/rule.ts
+++ b/packages/alfa-rules/src/sia-r64/rule.ts
@@ -17,11 +17,7 @@ const { and } = Predicate;
 
 export default Rule.Atomic.of<Page, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r64",
-  requirements: [
-    Criterion.of("1.3.1"),
-    Criterion.of("2.4.6"),
-    Technique.of("H42"),
-  ],
+  requirements: [Criterion.of("1.3.1"), Technique.of("H42")],
   tags: [Scope.Component],
   evaluate({ device, document }) {
     return {


### PR DESCRIPTION
Following https://github.com/act-rules/act-rules.github.io/pull/1640
