### PR TITLE
Downgrade SIA-R21, introduce SIA-R110

### DIFF
--- a/docs/review/api/alfa-rules.api.md
+++ b/docs/review/api/alfa-rules.api.md
@@ -63,6 +63,9 @@ const _default_100: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 // @public (undocumented)
 const _default_101: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 
+// @public (undocumented)
+const _default_102: Rule.Atomic<Page, Attribute<string>, never, Attribute<string>>;
+
 // @public @deprecated (undocumented)
 const _default_11: Rule.Atomic<Page, Element<string>, never, Element<string>>;
 

--- a/packages/alfa-rules/src/rules.ts
+++ b/packages/alfa-rules/src/rules.ts
@@ -88,3 +88,4 @@ export { default as R93 } from "./sia-r93/rule";
 export { default as R94 } from "./sia-r94/rule";
 export { default as R95 } from "./sia-r95/rule";
 export { default as R96 } from "./sia-r96/rule";
+export { default as R110 } from "./sia-r110/rule";

--- a/packages/alfa-rules/src/sia-r110/rule.ts
+++ b/packages/alfa-rules/src/sia-r110/rule.ts
@@ -15,7 +15,7 @@ const { hasAttribute, hasNamespace, isElement } = Element;
 const { and, not } = Predicate;
 
 export default Rule.Atomic.of<Page, Attribute>({
-  uri: "https://alfa.siteimprove.com/rules/sia-r21",
+  uri: "https://alfa.siteimprove.com/rules/sia-r110",
   requirements: [
     Criterion.of("1.3.1"),
     Technique.of("ARIA4"),
@@ -46,7 +46,7 @@ export default Rule.Atomic.of<Page, Attribute>({
           1: expectation(
             target
               .tokens()
-              .every(
+              .some(
                 (token) => Role.isName(token) && Role.of(token).isConcrete()
               ),
             () => Outcomes.HasValidRole,
@@ -60,7 +60,7 @@ export default Rule.Atomic.of<Page, Attribute>({
 
 export namespace Outcomes {
   export const HasValidRole = Ok.of(
-    Diagnostic.of(`The element has a valid role`)
+    Diagnostic.of(`The element has a at least one valid role`)
   );
 
   export const HasNoValidRole = Err.of(

--- a/packages/alfa-rules/src/sia-r110/rule.ts
+++ b/packages/alfa-rules/src/sia-r110/rule.ts
@@ -1,0 +1,69 @@
+import { Rule, Diagnostic } from "@siteimprove/alfa-act";
+import { DOM, Role } from "@siteimprove/alfa-aria";
+import { Attribute, Element, Namespace, Node } from "@siteimprove/alfa-dom";
+import { Predicate } from "@siteimprove/alfa-predicate";
+import { Err, Ok } from "@siteimprove/alfa-result";
+import { Criterion, Technique } from "@siteimprove/alfa-wcag";
+import { Page } from "@siteimprove/alfa-web";
+
+import { expectation } from "../common/act/expectation";
+
+import { Scope } from "../tags";
+
+const { isProgrammaticallyHidden } = DOM;
+const { hasAttribute, hasNamespace, isElement } = Element;
+const { and, not } = Predicate;
+
+export default Rule.Atomic.of<Page, Attribute>({
+  uri: "https://alfa.siteimprove.com/rules/sia-r21",
+  requirements: [
+    Criterion.of("1.3.1"),
+    Technique.of("ARIA4"),
+    Technique.of("G108"),
+  ],
+  tags: [Scope.Component],
+  evaluate({ device, document }) {
+    return {
+      applicability() {
+        return (
+          document
+            .descendants(Node.fullTree)
+            .filter(isElement)
+            .filter(
+              and(
+                hasNamespace(Namespace.HTML, Namespace.SVG),
+                hasAttribute("role", (value) => value.trim().length > 0),
+                not(isProgrammaticallyHidden(device))
+              )
+            )
+            // The previous filter ensures the existence of role.
+            .map((element) => element.attribute("role").getUnsafe())
+        );
+      },
+
+      expectations(target) {
+        return {
+          1: expectation(
+            target
+              .tokens()
+              .every(
+                (token) => Role.isName(token) && Role.of(token).isConcrete()
+              ),
+            () => Outcomes.HasValidRole,
+            () => Outcomes.HasNoValidRole
+          ),
+        };
+      },
+    };
+  },
+});
+
+export namespace Outcomes {
+  export const HasValidRole = Ok.of(
+    Diagnostic.of(`The element has a valid role`)
+  );
+
+  export const HasNoValidRole = Err.of(
+    Diagnostic.of(`The element does not have a valid role`)
+  );
+}

--- a/packages/alfa-rules/src/sia-r21/rule.ts
+++ b/packages/alfa-rules/src/sia-r21/rule.ts
@@ -16,11 +16,7 @@ const { and, not } = Predicate;
 
 export default Rule.Atomic.of<Page, Attribute>({
   uri: "https://alfa.siteimprove.com/rules/sia-r21",
-  requirements: [
-    Criterion.of("1.3.1"),
-    Technique.of("ARIA4"),
-    Technique.of("G108"),
-  ],
+  requirements: [Technique.of("ARIA4"), Technique.of("G108")],
   tags: [Scope.Component],
   evaluate({ device, document }) {
     return {

--- a/packages/alfa-rules/src/sia-r21/rule.ts
+++ b/packages/alfa-rules/src/sia-r21/rule.ts
@@ -56,10 +56,10 @@ export default Rule.Atomic.of<Page, Attribute>({
 
 export namespace Outcomes {
   export const HasValidRole = Ok.of(
-    Diagnostic.of(`The element has a valid role`)
+    Diagnostic.of(`The element has only valid roles`)
   );
 
   export const HasNoValidRole = Err.of(
-    Diagnostic.of(`The element does not have a valid role`)
+    Diagnostic.of(`The element does not have at least one valid role`)
   );
 }

--- a/packages/alfa-rules/test/sia-r110/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r110/rule.spec.tsx
@@ -1,0 +1,89 @@
+import { h } from "@siteimprove/alfa-dom";
+import { test } from "@siteimprove/alfa-test";
+
+import R21, { Outcomes } from "../../src/sia-r21/rule";
+
+import { evaluate } from "../common/evaluate";
+import { passed, failed, inapplicable } from "../common/outcome";
+
+test("evaluates() passes an element with a single valid role", async (t) => {
+  const target = h.attribute("role", "button");
+
+  const document = h.document([h("button", [target])]);
+
+  t.deepEqual(await evaluate(R21, { document }), [
+    passed(R21, target, {
+      1: Outcomes.HasValidRole,
+    }),
+  ]);
+});
+
+test("evaluates() passes an element with multiple valid roles", async (t) => {
+  const target = h.attribute("role", "button link");
+
+  const document = h.document([h("button", [target])]);
+
+  t.deepEqual(await evaluate(R21, { document }), [
+    passed(R21, target, {
+      1: Outcomes.HasValidRole,
+    }),
+  ]);
+});
+
+test("evaluates() fails an element with an invalid role", async (t) => {
+  const target = h.attribute("role", "btn");
+
+  const document = h.document([h("button", [target])]);
+
+  t.deepEqual(await evaluate(R21, { document }), [
+    failed(R21, target, {
+      1: Outcomes.HasNoValidRole,
+    }),
+  ]);
+});
+
+test("evaluates() fails an element with both a valid and an invalid role", async (t) => {
+  const target = h.attribute("role", "btn link");
+
+  const document = h.document([h("button", [target])]);
+
+  t.deepEqual(await evaluate(R21, { document }), [
+    failed(R21, target, {
+      1: Outcomes.HasNoValidRole,
+    }),
+  ]);
+});
+
+test("evaluates() fails an element with an invalid role and not included in the accessibility tree by default", async (t) => {
+  const span = <span role="invalid">Foo</span>;
+  const target = span.attribute("role").getUnsafe();
+
+  const document = h.document([span]);
+
+  t.deepEqual(await evaluate(R21, { document }), [
+    failed(R21, target, {
+      1: Outcomes.HasNoValidRole,
+    }),
+  ]);
+});
+
+test("evaluates() is inapplicable to a hidden element", async (t) => {
+  const button = (
+    <button hidden role="invalid">
+      Hello
+    </button>
+  );
+  const document = h.document([button]);
+  t.deepEqual(await evaluate(R21, { document }), [inapplicable(R21)]);
+});
+test("evaluate() is inapplicable when there is no role attribute", async (t) => {
+  const document = h.document([<button />]);
+
+  t.deepEqual(await evaluate(R21, { document }), [inapplicable(R21)]);
+});
+
+test("evaluate() is inapplicable when a role attribute is only whitespace", async (t) => {
+  const document = h.document([<button role=" " />]);
+
+  t.deepEqual(await evaluate(R21, { document }), [inapplicable(R21)]);
+});

--- a/packages/alfa-rules/test/sia-r110/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r110/rule.spec.tsx
@@ -1,7 +1,7 @@
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
-import R21, { Outcomes } from "../../src/sia-r21/rule";
+import R110, { Outcomes } from "../../src/sia-r110/rule";
 
 import { evaluate } from "../common/evaluate";
 import { passed, failed, inapplicable } from "../common/outcome";
@@ -11,8 +11,8 @@ test("evaluates() passes an element with a single valid role", async (t) => {
 
   const document = h.document([h("button", [target])]);
 
-  t.deepEqual(await evaluate(R21, { document }), [
-    passed(R21, target, {
+  t.deepEqual(await evaluate(R110, { document }), [
+    passed(R110, target, {
       1: Outcomes.HasValidRole,
     }),
   ]);
@@ -23,8 +23,20 @@ test("evaluates() passes an element with multiple valid roles", async (t) => {
 
   const document = h.document([h("button", [target])]);
 
-  t.deepEqual(await evaluate(R21, { document }), [
-    passed(R21, target, {
+  t.deepEqual(await evaluate(R110, { document }), [
+    passed(R110, target, {
+      1: Outcomes.HasValidRole,
+    }),
+  ]);
+});
+
+test("evaluates() passes an element with both a valid and an invalid role", async (t) => {
+  const target = h.attribute("role", "btn link");
+
+  const document = h.document([h("button", [target])]);
+
+  t.deepEqual(await evaluate(R110, { document }), [
+    passed(R110, target, {
       1: Outcomes.HasValidRole,
     }),
   ]);
@@ -35,20 +47,20 @@ test("evaluates() fails an element with an invalid role", async (t) => {
 
   const document = h.document([h("button", [target])]);
 
-  t.deepEqual(await evaluate(R21, { document }), [
-    failed(R21, target, {
+  t.deepEqual(await evaluate(R110, { document }), [
+    failed(R110, target, {
       1: Outcomes.HasNoValidRole,
     }),
   ]);
 });
 
-test("evaluates() fails an element with both a valid and an invalid role", async (t) => {
-  const target = h.attribute("role", "btn link");
+test("evaluates() fails an element with several invalid roles", async (t) => {
+  const target = h.attribute("role", "btn foo");
 
   const document = h.document([h("button", [target])]);
 
-  t.deepEqual(await evaluate(R21, { document }), [
-    failed(R21, target, {
+  t.deepEqual(await evaluate(R110, { document }), [
+    failed(R110, target, {
       1: Outcomes.HasNoValidRole,
     }),
   ]);
@@ -60,8 +72,8 @@ test("evaluates() fails an element with an invalid role and not included in the 
 
   const document = h.document([span]);
 
-  t.deepEqual(await evaluate(R21, { document }), [
-    failed(R21, target, {
+  t.deepEqual(await evaluate(R110, { document }), [
+    failed(R110, target, {
       1: Outcomes.HasNoValidRole,
     }),
   ]);
@@ -74,16 +86,17 @@ test("evaluates() is inapplicable to a hidden element", async (t) => {
     </button>
   );
   const document = h.document([button]);
-  t.deepEqual(await evaluate(R21, { document }), [inapplicable(R21)]);
+  t.deepEqual(await evaluate(R110, { document }), [inapplicable(R110)]);
 });
+
 test("evaluate() is inapplicable when there is no role attribute", async (t) => {
   const document = h.document([<button />]);
 
-  t.deepEqual(await evaluate(R21, { document }), [inapplicable(R21)]);
+  t.deepEqual(await evaluate(R110, { document }), [inapplicable(R110)]);
 });
 
 test("evaluate() is inapplicable when a role attribute is only whitespace", async (t) => {
   const document = h.document([<button role=" " />]);
 
-  t.deepEqual(await evaluate(R21, { document }), [inapplicable(R21)]);
+  t.deepEqual(await evaluate(R110, { document }), [inapplicable(R110)]);
 });

--- a/packages/alfa-rules/test/sia-r21/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r21/rule.spec.tsx
@@ -76,6 +76,7 @@ test("evaluates() is inapplicable to a hidden element", async (t) => {
   const document = h.document([button]);
   t.deepEqual(await evaluate(R21, { document }), [inapplicable(R21)]);
 });
+
 test("evaluate() is inapplicable when there is no role attribute", async (t) => {
   const document = h.document([<button />]);
 

--- a/packages/alfa-rules/tsconfig.json
+++ b/packages/alfa-rules/tsconfig.json
@@ -152,6 +152,7 @@
     "src/sia-r95/rule.ts",
     "src/sia-r96/rule.ts",
     "src/sia-r109/rule.ts",
+    "src/sia-r110/rule.ts",
     "src/tags/index.ts",
     "src/tags/stability.ts",
     "src/tags/scope.ts",
@@ -267,7 +268,8 @@
     "test/sia-r94/rule.spec.tsx",
     "test/sia-r95/rule.spec.tsx",
     "test/sia-r96/rule.spec.tsx",
-    "test/sia-r109/rule.spec.tsx"
+    "test/sia-r109/rule.spec.tsx",
+    "test/sia-r110/rule.spec.tsx"
   ],
   "references": [
     {


### PR DESCRIPTION
Following https://github.com/Siteimprove/sanshikan/pull/276

R21 is now only a best practice, since `role="btn button"` is not a WCAG failure but definitely a code smell.
R110 is the less strict version, requiring at least one valid token (rather than only valid tokens).
