### PR TITLE
Record outcome mode (automatic / semi-automatic)

### DIFF
--- a/packages/alfa-act/package.json
+++ b/packages/alfa-act/package.json
@@ -40,7 +40,8 @@
     "@siteimprove/alfa-sarif": "workspace:^0.56.0",
     "@siteimprove/alfa-sequence": "workspace:^0.56.0",
     "@siteimprove/alfa-thunk": "workspace:^0.56.0",
-    "@siteimprove/alfa-trilean": "workspace:^0.56.0"
+    "@siteimprove/alfa-trilean": "workspace:^0.56.0",
+    "@siteimprove/alfa-tuple": "workspace:^0.56.0"
   },
   "devDependencies": {
     "@siteimprove/alfa-test": "workspace:^0.56.0"

--- a/packages/alfa-act/src/interview.ts
+++ b/packages/alfa-act/src/interview.ts
@@ -72,12 +72,12 @@ export namespace Interview {
    *  Oracles must return Futures, because the full interview process is essentially
    *  async (e.g., asking through a CLI).
    *
-   *  The final result of the interview is either a final answer, or a diagnostic
-   *  explaining why a final answer couldn't be found. Final answer will be turned
-   *  into Passed/Failed outcomes, and diagnostic into Can't tell; the diagnostic
-   *  is provided by the last unanswered question.
+   *  The final result of the interview is either a final answer (Left), or
+   *  a diagnostic (Right) explaining why a final answer couldn't be found.
+   *  Final answer will be turned into Passed/Failed outcomes, and diagnostic
+   *  into Can't tell; the diagnostic is provided by the last unanswered question.
    *
-   *  In both case, we also record whether the oracle was actually used or not;
+   *  In both cases, we also record whether the oracle was actually used;
    *  this is useful to record the mode (auto/semi-auto) of the outcome.
    */
   export function conduct<

--- a/packages/alfa-act/src/outcome.ts
+++ b/packages/alfa-act/src/outcome.ts
@@ -126,8 +126,6 @@ export namespace Outcome {
 
   /**
    * {@link https://www.w3.org/TR/EARL10-Schema/#TestMode}
-   *
-   * @public
    */
   export enum Mode {
     Automatic = "automatic",

--- a/packages/alfa-act/tsconfig.json
+++ b/packages/alfa-act/tsconfig.json
@@ -86,6 +86,9 @@
     },
     {
       "path": "../alfa-trilean"
+    },
+    {
+      "path": "../alfa-tuple"
     }
   ]
 }

--- a/packages/alfa-rules/test/common/outcome.ts
+++ b/packages/alfa-rules/test/common/outcome.ts
@@ -7,37 +7,43 @@ import { Page } from "@siteimprove/alfa-web";
 export function passed<T extends Hashable, Q, S>(
   rule: Rule<Page, T, Q, S>,
   target: T,
-  expectations: { [id: string]: Result<Diagnostic> }
+  expectations: { [id: string]: Result<Diagnostic> },
+  mode: Outcome.Mode = Outcome.Mode.Automatic
 ): Outcome.Passed.JSON<T> {
   return Outcome.Passed.of(
     rule,
     target,
-    Record.from(Object.entries(expectations))
+    Record.from(Object.entries(expectations)),
+    mode
   ).toJSON();
 }
 
 export function failed<T extends Hashable, Q, S>(
   rule: Rule<Page, T, Q, S>,
   target: T,
-  expectations: { [id: string]: Result<Diagnostic> }
+  expectations: { [id: string]: Result<Diagnostic> },
+  mode: Outcome.Mode = Outcome.Mode.Automatic
 ): Outcome.Failed.JSON<T> {
   return Outcome.Failed.of(
     rule,
     target,
-    Record.from(Object.entries(expectations))
+    Record.from(Object.entries(expectations)),
+    mode
   ).toJSON();
 }
 
 export function inapplicable<T extends Hashable, Q, S>(
-  rule: Rule<Page, T, Q, S>
+  rule: Rule<Page, T, Q, S>,
+  mode: Outcome.Mode = Outcome.Mode.Automatic
 ): Outcome.Inapplicable.JSON {
-  return Outcome.Inapplicable.of(rule).toJSON();
+  return Outcome.Inapplicable.of(rule, mode).toJSON();
 }
 
 export function cantTell<T extends Hashable, Q, S>(
   rule: Rule<Page, T, Q, S>,
   target: T,
-  diagnostic: Diagnostic = Diagnostic.empty
+  diagnostic: Diagnostic = Diagnostic.empty,
+  mode: Outcome.Mode = Outcome.Mode.Automatic
 ): Outcome.CantTell.JSON<T> {
-  return Outcome.CantTell.of(rule, target, diagnostic).toJSON();
+  return Outcome.CantTell.of(rule, target, diagnostic, mode).toJSON();
 }

--- a/packages/alfa-rules/test/sia-er66/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-er66/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -349,15 +350,20 @@ test("evaluate() passes when a background color with sufficient contrast is inpu
       })
     ),
     [
-      passed(R66, target, {
-        1: Outcomes.HasSufficientContrast(21, 7, [
-          Diagnostic.Pairing.of(
-            ["foreground", rgb(0, 0, 0)],
-            ["background", rgb(1, 1, 1)],
-            21
-          ),
-        ]),
-      }),
+      passed(
+        R66,
+        target,
+        {
+          1: Outcomes.HasSufficientContrast(21, 7, [
+            Diagnostic.Pairing.of(
+              ["foreground", rgb(0, 0, 0)],
+              ["background", rgb(1, 1, 1)],
+              21
+            ),
+          ]),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -380,15 +386,20 @@ test("evaluate() fails when a background color with insufficient contrast is inp
       })
     ),
     [
-      failed(R66, target, {
-        1: Outcomes.HasInsufficientContrast(1, 7, [
-          Diagnostic.Pairing.of(
-            ["foreground", rgb(0, 0, 0)],
-            ["background", rgb(0, 0, 0)],
-            1
-          ),
-        ]),
-      }),
+      failed(
+        R66,
+        target,
+        {
+          1: Outcomes.HasInsufficientContrast(1, 7, [
+            Diagnostic.Pairing.of(
+              ["foreground", rgb(0, 0, 0)],
+              ["background", rgb(0, 0, 0)],
+              1
+            ),
+          ]),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });

--- a/packages/alfa-rules/test/sia-er66/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-er66/rule.spec.tsx
@@ -4,7 +4,7 @@ import { test } from "@siteimprove/alfa-test";
 
 import { RGB, Percentage, Keyword } from "@siteimprove/alfa-css";
 
-import R66 from "../../src/sia-r66/rule";
+import R66 from "../../src/sia-er66/rule";
 import { Contrast as Diagnostic } from "../../src/common/diagnostic/contrast";
 import { Contrast as Outcomes } from "../../src/common/outcome/contrast";
 

--- a/packages/alfa-rules/test/sia-er69/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-er69/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -415,15 +416,20 @@ test("evaluate() passes when a background color with sufficient contrast is inpu
       })
     ),
     [
-      passed(R69, target, {
-        1: Outcomes.HasSufficientContrast(21, 4.5, [
-          Diagnostic.Pairing.of(
-            ["foreground", rgb(0, 0, 0)],
-            ["background", rgb(1, 1, 1)],
-            21
-          ),
-        ]),
-      }),
+      passed(
+        R69,
+        target,
+        {
+          1: Outcomes.HasSufficientContrast(21, 4.5, [
+            Diagnostic.Pairing.of(
+              ["foreground", rgb(0, 0, 0)],
+              ["background", rgb(1, 1, 1)],
+              21
+            ),
+          ]),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -451,15 +457,20 @@ test("evaluate() fails when a background color with insufficient contrast is inp
       })
     ),
     [
-      failed(R69, target, {
-        1: Outcomes.HasInsufficientContrast(1, 4.5, [
-          Diagnostic.Pairing.of(
-            ["foreground", rgb(0, 0, 0)],
-            ["background", rgb(0, 0, 0)],
-            1
-          ),
-        ]),
-      }),
+      failed(
+        R69,
+        target,
+        {
+          1: Outcomes.HasInsufficientContrast(1, 4.5, [
+            Diagnostic.Pairing.of(
+              ["foreground", rgb(0, 0, 0)],
+              ["background", rgb(0, 0, 0)],
+              1
+            ),
+          ]),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -641,7 +652,7 @@ test(`evaluate() cannot tell when encountering a non-ignored interposed
       { document },
       oracle({ "ignored-interposed-elements": [] })
     ),
-    [cantTell(R69, target, diagnostic)]
+    [cantTell(R69, target, diagnostic, Outcome.Mode.SemiAuto)]
   );
 
   // It should be ignored, resolve automatically.
@@ -652,15 +663,20 @@ test(`evaluate() cannot tell when encountering a non-ignored interposed
       oracle({ "ignored-interposed-elements": [interposed] })
     ),
     [
-      passed(R69, target, {
-        1: Outcomes.HasSufficientContrast(21, 4.5, [
-          Diagnostic.Pairing.of(
-            ["foreground", rgb(0, 0, 0)],
-            ["background", rgb(1, 1, 1)],
-            21
-          ),
-        ]),
-      }),
+      passed(
+        R69,
+        target,
+        {
+          1: Outcomes.HasSufficientContrast(21, 4.5, [
+            Diagnostic.Pairing.of(
+              ["foreground", rgb(0, 0, 0)],
+              ["background", rgb(1, 1, 1)],
+              21
+            ),
+          ]),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });

--- a/packages/alfa-rules/test/sia-er87/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-er87/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -47,9 +48,14 @@ test(`evaluate() passes a document whose first tabbable link references an
       })
     ),
     [
-      passed(ER87, document, {
-        1: Outcomes.FirstTabbableIsLinkToContent,
-      }),
+      passed(
+        ER87,
+        document,
+        {
+          1: Outcomes.FirstTabbableIsLinkToContent,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -76,9 +82,14 @@ test(`evaluate() fails a document whose first tabbable link does not
       })
     ),
     [
-      failed(ER87, document, {
-        1: Outcomes.FirstTabbableIsNotInternalLink,
-      }),
+      failed(
+        ER87,
+        document,
+        {
+          1: Outcomes.FirstTabbableIsNotInternalLink,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -101,9 +112,14 @@ test(`evaluate() passes a document whose first tabbable link references an
       })
     ),
     [
-      passed(ER87, document, {
-        1: Outcomes.FirstTabbableIsLinkToContent,
-      }),
+      passed(
+        ER87,
+        document,
+        {
+          1: Outcomes.FirstTabbableIsLinkToContent,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -131,9 +147,14 @@ test(`evaluate() passes a document whose first tabbable link references an
       })
     ),
     [
-      passed(ER87, document, {
-        1: Outcomes.FirstTabbableIsLinkToContent,
-      }),
+      passed(
+        ER87,
+        document,
+        {
+          1: Outcomes.FirstTabbableIsLinkToContent,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -249,9 +270,14 @@ test(`evaluate() fails a document whose first tabbable link is not visible`, asy
       })
     ),
     [
-      failed(ER87, document, {
-        1: Outcomes.FirstTabbableIsNotVisible,
-      }),
+      failed(
+        ER87,
+        document,
+        {
+          1: Outcomes.FirstTabbableIsNotVisible,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -282,9 +308,14 @@ test(`evaluate() passes a document whose first tabbable link is visible`, async 
       })
     ),
     [
-      passed(ER87, document, {
-        1: Outcomes.FirstTabbableIsLinkToContent,
-      }),
+      passed(
+        ER87,
+        document,
+        {
+          1: Outcomes.FirstTabbableIsLinkToContent,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });

--- a/packages/alfa-rules/test/sia-r109/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r109/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -24,9 +25,14 @@ test("evaluate() passes documents whose lang attribute matches the main language
   t.deepEqual(
     await evaluate(R109, { document }, oracle({ "document-language": "en" })),
     [
-      passed(R109, document, {
-        1: Outcomes.HasCorrectLang(english, english),
-      }),
+      passed(
+        R109,
+        document,
+        {
+          1: Outcomes.HasCorrectLang(english, english),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -45,9 +51,14 @@ test("evaluate() passes documents whose lang primary attribute matches the main 
       oracle({ "document-language": "en-us" })
     ),
     [
-      passed(R109, document, {
-        1: Outcomes.HasCorrectLang(british, american),
-      }),
+      passed(
+        R109,
+        document,
+        {
+          1: Outcomes.HasCorrectLang(british, american),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -61,7 +72,14 @@ test("evaluate() fails documents whose lang attribute does not match the main la
 
   t.deepEqual(
     await evaluate(R109, { document }, oracle({ "document-language": "en" })),
-    [failed(R109, document, { 1: Outcomes.HasIncorrectLang(french, english) })]
+    [
+      failed(
+        R109,
+        document,
+        { 1: Outcomes.HasIncorrectLang(french, english) },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -78,7 +96,14 @@ test("evaluate() fails documents without main language", async (t) => {
       { document },
       oracle({ "document-language": "gibberish" })
     ),
-    [failed(R109, document, { 1: Outcomes.HasNoLanguage(english) })]
+    [
+      failed(
+        R109,
+        document,
+        { 1: Outcomes.HasNoLanguage(english) },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 

--- a/packages/alfa-rules/test/sia-r15/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r15/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -57,9 +58,14 @@ test("evaluate() passes when two iframes embed equivalent resources", async (t) 
       oracle({ "reference-equivalent-resources": true })
     ),
     [
-      passed(R15, Group.of(target), {
-        1: Outcomes.EmbedEquivalentResources,
-      }),
+      passed(
+        R15,
+        Group.of(target),
+        {
+          1: Outcomes.EmbedEquivalentResources,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -97,9 +103,14 @@ test("evaluate() fails when two iframes embed different resources", async (t) =>
       oracle({ "reference-equivalent-resources": false })
     ),
     [
-      failed(R15, Group.of(target), {
-        1: Outcomes.EmbedDifferentResources,
-      }),
+      failed(
+        R15,
+        Group.of(target),
+        {
+          1: Outcomes.EmbedDifferentResources,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });

--- a/packages/alfa-rules/test/sia-r22/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r22/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -22,7 +23,7 @@ test(`evaluate() passes a video with captions`, async (t) => {
         "has-captions": true,
       })
     ),
-    [passed(R22, target, { 1: Outcomes.HasCaptions })]
+    [passed(R22, target, { 1: Outcomes.HasCaptions }, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -41,7 +42,7 @@ test(`evaluate() fails a video without captions`, async (t) => {
         "has-captions": false,
       })
     ),
-    [failed(R22, target, { 1: Outcomes.HasNoCaptions })]
+    [failed(R22, target, { 1: Outcomes.HasNoCaptions }, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -56,7 +57,7 @@ test(`evaluate() cannot tell if questions are left unanswered`, async (t) => {
       { document },
       oracle({ "is-video-streaming": false, "has-audio": true })
     ),
-    [cantTell(R22, target)]
+    [cantTell(R22, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -79,6 +80,6 @@ test(`evaluate() is inapplicable to audio-less videos`, async (t) => {
       { document },
       oracle({ "is-video-streaming": false, "has-audio": false })
     ),
-    [inapplicable(R22)]
+    [inapplicable(R22, Outcome.Mode.SemiAuto)]
   );
 });

--- a/packages/alfa-rules/test/sia-r23/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r23/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { None, Option } from "@siteimprove/alfa-option";
 import { test } from "@siteimprove/alfa-test";
@@ -25,7 +26,14 @@ test(`evaluate() passes an audio with perceivable transcript`, async (t) => {
         transcript: Option.of(transcript),
       })
     ),
-    [passed(R23, target, { 1: Outcomes.HasPerceivableTranscript("<audio>") })]
+    [
+      passed(
+        R23,
+        target,
+        { 1: Outcomes.HasPerceivableTranscript("<audio>") },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -47,7 +55,14 @@ test(`evaluate() passes an audio with a link to a transcript`, async (t) => {
         "transcript-perceivable": true,
       })
     ),
-    [passed(R23, target, { 1: Outcomes.HasPerceivableLink("<audio>") })]
+    [
+      passed(
+        R23,
+        target,
+        { 1: Outcomes.HasPerceivableLink("<audio>") },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -67,7 +82,14 @@ test(`evaluate() fails an audio with no transcript`, async (t) => {
         "transcript-link": None,
       })
     ),
-    [failed(R23, target, { 1: Outcomes.HasNoTranscriptLink("<audio>") })]
+    [
+      failed(
+        R23,
+        target,
+        { 1: Outcomes.HasNoTranscriptLink("<audio>") },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -88,9 +110,14 @@ test(`evaluates() fails an audio with non-perceivable transcript`, async (t) => 
       })
     ),
     [
-      failed(R23, target, {
-        1: Outcomes.HasNonPerceivableTranscript("<audio>"),
-      }),
+      failed(
+        R23,
+        target,
+        {
+          1: Outcomes.HasNonPerceivableTranscript("<audio>"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -109,13 +136,18 @@ test(`evaluate fails an audio with link to non-perceivable transcript`, async (t
         "is-audio-streaming": false,
         "is-playing": true,
         transcript: None,
-        "transcript-link": Option.of(transcript)
+        "transcript-link": Option.of(transcript),
       })
     ),
     [
-      passed(R23, target, {
-        1: Outcomes.HasPerceivableLink("<audio>"),
-      }),
+      passed(
+        R23,
+        target,
+        {
+          1: Outcomes.HasPerceivableLink("<audio>"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -142,9 +174,14 @@ test(`evaluate fails an audio with non-perceivable link to transcript`, async (t
       })
     ),
     [
-      failed(R23, target, {
-        1: Outcomes.HasNonPerceivableLink("<audio>"),
-      }),
+      failed(
+        R23,
+        target,
+        {
+          1: Outcomes.HasNonPerceivableLink("<audio>"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -160,7 +197,7 @@ test(`evaluate() cannot tell if questions are left unanswered`, async (t) => {
       { document },
       oracle({ "is-audio-streaming": false, "is-playing": true })
     ),
-    [cantTell(R23, target)]
+    [cantTell(R23, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -179,6 +216,6 @@ test(`evaluate() is inapplicable to streaming audios`, async (t) => {
 
   t.deepEqual(
     await evaluate(R23, { document }, oracle({ "is-audio-streaming": true })),
-    [inapplicable(R23)]
+    [inapplicable(R23, Outcome.Mode.SemiAuto)]
   );
 });

--- a/packages/alfa-rules/test/sia-r24/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r24/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -34,9 +35,14 @@ test(`evaluate() passes when non-streaming video elements have all audio and
       })
     ),
     [
-      passed(R24, target, {
-        1: Outcomes.HasPerceivableTranscript("<video>"),
-      }),
+      passed(
+        R24,
+        target,
+        {
+          1: Outcomes.HasPerceivableTranscript("<video>"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -64,9 +70,14 @@ test(`evaluate() fails when non-streaming video elements have no audio and
       })
     ),
     [
-      failed(R24, target, {
-        1: Outcomes.HasNoTranscriptLink("<video>"),
-      }),
+      failed(
+        R24,
+        target,
+        {
+          1: Outcomes.HasNoTranscriptLink("<video>"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -91,7 +102,7 @@ test("evaluate() can't tell when some questions are left unanswered", async (t) 
         transcript: None,
       })
     ),
-    [cantTell(R24, target)]
+    [cantTell(R24, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 

--- a/packages/alfa-rules/test/sia-r25/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r25/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -22,7 +23,14 @@ test(`evaluate() passes video with descriptive audio`, async (t) => {
         "has-description": true,
       })
     ),
-    [passed(R25, target, { 1: Outcomes.HasInformativeAudio })]
+    [
+      passed(
+        R25,
+        target,
+        { 1: Outcomes.HasInformativeAudio },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -41,7 +49,14 @@ test(`evaluate() fails video without descriptive audio`, async (t) => {
         "has-description": false,
       })
     ),
-    [failed(R25, target, { 1: Outcomes.HasNoInformativeAudio })]
+    [
+      failed(
+        R25,
+        target,
+        { 1: Outcomes.HasNoInformativeAudio },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -56,7 +71,7 @@ test(`evaluate() cannot tell if questions are left unanswered`, async (t) => {
       { document },
       oracle({ "is-video-streaming": false, "has-audio": true })
     ),
-    [cantTell(R25, target)]
+    [cantTell(R25, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -79,6 +94,6 @@ test(`evaluate() is inapplicable to audio-less videos`, async (t) => {
       { document },
       oracle({ "is-video-streaming": false, "has-audio": false })
     ),
-    [inapplicable(R25)]
+    [inapplicable(R25, Outcome.Mode.SemiAuto)]
   );
 });

--- a/packages/alfa-rules/test/sia-r26/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r26/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { None, Option } from "@siteimprove/alfa-option";
 import { test } from "@siteimprove/alfa-test";
@@ -28,10 +29,15 @@ test(`evaluate() passes a video that is labelled as alternative for text`, async
       })
     ),
     [
-      passed(R26, target, {
-        1: Outcomes.HasPerceivableAlternative("<video>"),
-        2: Outcomes.HasPerceivableLabel("<video>"),
-      }),
+      passed(
+        R26,
+        target,
+        {
+          1: Outcomes.HasPerceivableAlternative("<video>"),
+          2: Outcomes.HasPerceivableLabel("<video>"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -54,10 +60,15 @@ test(`evaluate() fails a video that is not alternative for text`, async (t) => {
       })
     ),
     [
-      failed(R26, target, {
-        1: Outcomes.HasNoAlternative("<video>"),
-        2: Outcomes.HasPerceivableLabel("<video>"),
-      }),
+      failed(
+        R26,
+        target,
+        {
+          1: Outcomes.HasNoAlternative("<video>"),
+          2: Outcomes.HasPerceivableLabel("<video>"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -80,10 +91,15 @@ test(`evaluate() fails a video that is not labelled as alternative for text`, as
       })
     ),
     [
-      failed(R26, target, {
-        1: Outcomes.HasPerceivableAlternative("<video>"),
-        2: Outcomes.HasNoLabel("<video>"),
-      }),
+      failed(
+        R26,
+        target,
+        {
+          1: Outcomes.HasPerceivableAlternative("<video>"),
+          2: Outcomes.HasNoLabel("<video>"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -107,10 +123,15 @@ test(`evaluate() fails a video alternative for invisible text`, async (t) => {
       })
     ),
     [
-      failed(R26, target, {
-        1: Outcomes.HasNonPerceivableAlternative("<video>"),
-        2: Outcomes.HasPerceivableLabel("<video>"),
-      }),
+      failed(
+        R26,
+        target,
+        {
+          1: Outcomes.HasNonPerceivableAlternative("<video>"),
+          2: Outcomes.HasPerceivableLabel("<video>"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -136,10 +157,15 @@ test(`evaluate() fails a video that is invisibly labelled as alternative for tex
       })
     ),
     [
-      failed(R26, target, {
-        1: Outcomes.HasPerceivableAlternative("<video>"),
-        2: Outcomes.HasNonPerceivableLabel("<video>"),
-      }),
+      failed(
+        R26,
+        target,
+        {
+          1: Outcomes.HasPerceivableAlternative("<video>"),
+          2: Outcomes.HasNonPerceivableLabel("<video>"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -155,7 +181,7 @@ test(`evaluate() cannot tell if questions are left unanswered`, async (t) => {
       { document },
       oracle({ "is-video-streaming": false, "has-audio": false })
     ),
-    [cantTell(R26, target)]
+    [cantTell(R26, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -178,6 +204,6 @@ test(`evaluate() is inapplicable to videos with audio`, async (t) => {
       { document },
       oracle({ "is-video-streaming": false, "has-audio": true })
     ),
-    [inapplicable(R26)]
+    [inapplicable(R26, Outcome.Mode.SemiAuto)]
   );
 });

--- a/packages/alfa-rules/test/sia-r27/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r27/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { None, Option } from "@siteimprove/alfa-option";
 import { test } from "@siteimprove/alfa-test";
@@ -24,7 +25,14 @@ test(`evaluate() passes when R22 passes`, async (t) => {
         "has-captions": true,
       })
     ),
-    [passed(R27, target, { 1: Outcomes.HasTextAlternative })]
+    [
+      passed(
+        R27,
+        target,
+        { 1: Outcomes.HasTextAlternative },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -47,7 +55,14 @@ test(`evaluate() passes when R31 passes`, async (t) => {
         label: Option.of(label),
       })
     ),
-    [passed(R27, target, { 1: Outcomes.HasTextAlternative })]
+    [
+      passed(
+        R27,
+        target,
+        { 1: Outcomes.HasTextAlternative },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -70,7 +85,14 @@ test(`evaluate() fails when all input rules fail`, async (t) => {
         label: None,
       })
     ),
-    [failed(R27, target, { 1: Outcomes.HasNoTextAlternative })]
+    [
+      failed(
+        R27,
+        target,
+        { 1: Outcomes.HasNoTextAlternative },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -85,7 +107,7 @@ test(`evaluate() cannot tell if no input rule can tell`, async (t) => {
       { document },
       oracle({ "is-video-streaming": false, "has-audio": true })
     ),
-    [cantTell(R27, target)]
+    [cantTell(R27, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -106,7 +128,7 @@ test(`evaluate() cannot tell when some input rule cannot tell and no input rule 
         // R31
       })
     ),
-    [cantTell(R27, target)]
+    [cantTell(R27, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -129,6 +151,6 @@ test(`evaluate() is inapplicable to videos without audio`, async (t) => {
       { document },
       oracle({ "is-video-streaming": false, "has-audio": false })
     ),
-    [inapplicable(R27)]
+    [inapplicable(R27, Outcome.Mode.SemiAuto)]
   );
 });

--- a/packages/alfa-rules/test/sia-r29/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r29/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { None, Option } from "@siteimprove/alfa-option";
 import { test } from "@siteimprove/alfa-test";
@@ -28,10 +29,15 @@ test(`evaluate() passes an audio that is labelled as alternative for text`, asyn
       })
     ),
     [
-      passed(R29, target, {
-        1: Outcomes.HasPerceivableAlternative("<audio>"),
-        2: Outcomes.HasPerceivableLabel("<audio>"),
-      }),
+      passed(
+        R29,
+        target,
+        {
+          1: Outcomes.HasPerceivableAlternative("<audio>"),
+          2: Outcomes.HasPerceivableLabel("<audio>"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -54,10 +60,15 @@ test(`evaluate() fails an audio that is not alternative for text`, async (t) => 
       })
     ),
     [
-      failed(R29, target, {
-        1: Outcomes.HasNoAlternative("<audio>"),
-        2: Outcomes.HasPerceivableLabel("<audio>"),
-      }),
+      failed(
+        R29,
+        target,
+        {
+          1: Outcomes.HasNoAlternative("<audio>"),
+          2: Outcomes.HasPerceivableLabel("<audio>"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -80,10 +91,15 @@ test(`evaluate() fails an audio that is not labelled as alternative for text`, a
       })
     ),
     [
-      failed(R29, target, {
-        1: Outcomes.HasPerceivableAlternative("<audio>"),
-        2: Outcomes.HasNoLabel("<audio>"),
-      }),
+      failed(
+        R29,
+        target,
+        {
+          1: Outcomes.HasPerceivableAlternative("<audio>"),
+          2: Outcomes.HasNoLabel("<audio>"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -107,10 +123,15 @@ test(`evaluate() fails an audio alternative for invisible text`, async (t) => {
       })
     ),
     [
-      failed(R29, target, {
-        1: Outcomes.HasNonPerceivableAlternative("<audio>"),
-        2: Outcomes.HasPerceivableLabel("<audio>"),
-      }),
+      failed(
+        R29,
+        target,
+        {
+          1: Outcomes.HasNonPerceivableAlternative("<audio>"),
+          2: Outcomes.HasPerceivableLabel("<audio>"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -138,10 +159,15 @@ test(`evaluate() fails an audio that is invisibly labelled as alternative for te
       })
     ),
     [
-      failed(R29, target, {
-        1: Outcomes.HasPerceivableAlternative("<audio>"),
-        2: Outcomes.HasNonPerceivableLabel("<audio>"),
-      }),
+      failed(
+        R29,
+        target,
+        {
+          1: Outcomes.HasPerceivableAlternative("<audio>"),
+          2: Outcomes.HasNonPerceivableLabel("<audio>"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -157,7 +183,7 @@ test(`evaluate() cannot tell if questions are left unanswered`, async (t) => {
       { document },
       oracle({ "is-audio-streaming": false, "is-playing": true })
     ),
-    [cantTell(R29, target)]
+    [cantTell(R29, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -176,6 +202,6 @@ test(`evaluate() is inapplicable to streaming audios`, async (t) => {
 
   t.deepEqual(
     await evaluate(R29, { document }, oracle({ "is-audio-streaming": true })),
-    [inapplicable(R29)]
+    [inapplicable(R29, Outcome.Mode.SemiAuto)]
   );
 });

--- a/packages/alfa-rules/test/sia-r30/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r30/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { None, Option } from "@siteimprove/alfa-option";
 import { test } from "@siteimprove/alfa-test";
@@ -25,7 +26,14 @@ test(`evaluate() passes when R23 passes`, async (t) => {
         transcript: Option.of(transcript),
       })
     ),
-    [passed(R30, target, { 1: Outcomes.HasTextAlternative })]
+    [
+      passed(
+        R30,
+        target,
+        { 1: Outcomes.HasTextAlternative },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -48,7 +56,14 @@ test(`evaluate() passes when R29 passes`, async (t) => {
         label: Option.of(label),
       })
     ),
-    [passed(R30, target, { 1: Outcomes.HasTextAlternative })]
+    [
+      passed(
+        R30,
+        target,
+        { 1: Outcomes.HasTextAlternative },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -73,7 +88,14 @@ test(`evaluate() fails when all input rules fail`, async (t) => {
         label: Option.of(label),
       })
     ),
-    [failed(R30, target, { 1: Outcomes.HasNoTextAlternative })]
+    [
+      failed(
+        R30,
+        target,
+        { 1: Outcomes.HasNoTextAlternative },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -88,7 +110,7 @@ test(`evaluate() cannot tell if no input rule can tell`, async (t) => {
       { document },
       oracle({ "is-audio-streaming": false, "is-playing": true })
     ),
-    [cantTell(R30, target)]
+    [cantTell(R30, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -110,7 +132,7 @@ test(`evaluate() cannot tell when some input rule cannot tell and no input rule 
         // R29
       })
     ),
-    [cantTell(R30, target)]
+    [cantTell(R30, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -125,7 +147,7 @@ test(`evaluate() cannot tell if questions are left unanswered`, async (t) => {
       { document },
       oracle({ "is-audio-streaming": false, "is-playing": true })
     ),
-    [cantTell(R30, target)]
+    [cantTell(R30, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -144,6 +166,6 @@ test(`evaluate() is inapplicable to streaming audios`, async (t) => {
 
   t.deepEqual(
     await evaluate(R30, { document }, oracle({ "is-audio-streaming": true })),
-    [inapplicable(R30)]
+    [inapplicable(R30, Outcome.Mode.SemiAuto)]
   );
 });

--- a/packages/alfa-rules/test/sia-r31/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r31/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { None, Option } from "@siteimprove/alfa-option";
 import { test } from "@siteimprove/alfa-test";
@@ -28,10 +29,15 @@ test(`evaluate() passes a video that is labelled as alternative for text`, async
       })
     ),
     [
-      passed(R31, target, {
-        1: Outcomes.HasPerceivableAlternative("<video>"),
-        2: Outcomes.HasPerceivableLabel("<video>"),
-      }),
+      passed(
+        R31,
+        target,
+        {
+          1: Outcomes.HasPerceivableAlternative("<video>"),
+          2: Outcomes.HasPerceivableLabel("<video>"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -54,10 +60,15 @@ test(`evaluate() fails a video that is not alternative for text`, async (t) => {
       })
     ),
     [
-      failed(R31, target, {
-        1: Outcomes.HasNoAlternative("<video>"),
-        2: Outcomes.HasPerceivableLabel("<video>"),
-      }),
+      failed(
+        R31,
+        target,
+        {
+          1: Outcomes.HasNoAlternative("<video>"),
+          2: Outcomes.HasPerceivableLabel("<video>"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -80,10 +91,15 @@ test(`evaluate() fails a video that is not labelled as alternative for text`, as
       })
     ),
     [
-      failed(R31, target, {
-        1: Outcomes.HasPerceivableAlternative("<video>"),
-        2: Outcomes.HasNoLabel("<video>"),
-      }),
+      failed(
+        R31,
+        target,
+        {
+          1: Outcomes.HasPerceivableAlternative("<video>"),
+          2: Outcomes.HasNoLabel("<video>"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -107,10 +123,15 @@ test(`evaluate() fails a video alternative for invisible text`, async (t) => {
       })
     ),
     [
-      failed(R31, target, {
-        1: Outcomes.HasNonPerceivableAlternative("<video>"),
-        2: Outcomes.HasPerceivableLabel("<video>"),
-      }),
+      failed(
+        R31,
+        target,
+        {
+          1: Outcomes.HasNonPerceivableAlternative("<video>"),
+          2: Outcomes.HasPerceivableLabel("<video>"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -136,10 +157,15 @@ test(`evaluate() fails a video that is invisibly labelled as alternative for tex
       })
     ),
     [
-      failed(R31, target, {
-        1: Outcomes.HasPerceivableAlternative("<video>"),
-        2: Outcomes.HasNonPerceivableLabel("<video>"),
-      }),
+      failed(
+        R31,
+        target,
+        {
+          1: Outcomes.HasPerceivableAlternative("<video>"),
+          2: Outcomes.HasNonPerceivableLabel("<video>"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -155,7 +181,7 @@ test(`evaluate() cannot tell if questions are left unanswered`, async (t) => {
       { document },
       oracle({ "is-video-streaming": false, "has-audio": true })
     ),
-    [cantTell(R31, target)]
+    [cantTell(R31, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -178,6 +204,6 @@ test(`evaluate() is inapplicable to videos without audio`, async (t) => {
       { document },
       oracle({ "is-video-streaming": false, "has-audio": false })
     ),
-    [inapplicable(R31)]
+    [inapplicable(R31, Outcome.Mode.SemiAuto)]
   );
 });

--- a/packages/alfa-rules/test/sia-r32/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r32/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -22,7 +23,14 @@ test(`evaluate() passes a video with a descriptive audio track`, async (t) => {
         "has-audio-track": true,
       })
     ),
-    [passed(R32, target, { 1: Outcomes.HasDescriptiveAudio })]
+    [
+      passed(
+        R32,
+        target,
+        { 1: Outcomes.HasDescriptiveAudio },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -41,7 +49,14 @@ test(`evaluate() fails a video without descriptive audio track`, async (t) => {
         "has-audio-track": false,
       })
     ),
-    [failed(R32, target, { 1: Outcomes.HasNoDescriptiveAudio })]
+    [
+      failed(
+        R32,
+        target,
+        { 1: Outcomes.HasNoDescriptiveAudio },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -56,7 +71,7 @@ test(`evaluate() cannot tell if questions are left unanswered`, async (t) => {
       { document },
       oracle({ "is-video-streaming": false, "has-audio": false })
     ),
-    [cantTell(R32, target)]
+    [cantTell(R32, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -79,6 +94,6 @@ test(`evaluate() is inapplicable to videos with audio`, async (t) => {
       { document },
       oracle({ "is-video-streaming": false, "has-audio": true })
     ),
-    [inapplicable(R32)]
+    [inapplicable(R32, Outcome.Mode.SemiAuto)]
   );
 });

--- a/packages/alfa-rules/test/sia-r33/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r33/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -27,7 +28,14 @@ test(`evaluate() passes when non-streaming video-only elements have all visual i
         transcript: Option.of(transcript),
       })
     ),
-    [passed(R33, target, { 1: Outcomes.HasPerceivableTranscript("<video>") })]
+    [
+      passed(
+        R33,
+        target,
+        { 1: Outcomes.HasPerceivableTranscript("<video>") },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -47,7 +55,14 @@ test(`evaluate() fails when non-streaming video-only elements have no visual inf
         "transcript-link": None,
       })
     ),
-    [failed(R33, target, { 1: Outcomes.HasNoTranscriptLink("<video>") })]
+    [
+      failed(
+        R33,
+        target,
+        { 1: Outcomes.HasNoTranscriptLink("<video>") },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -66,7 +81,7 @@ test("evaluate() can't tell when some questions are left unanswered", async (t) 
         transcript: None,
       })
     ),
-    [cantTell(R33, target)]
+    [cantTell(R33, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -98,6 +113,6 @@ test("evaluate() is inapplicable to videos with audio", async (t) => {
       { document },
       oracle({ "is-video-streaming": false, "has-audio": true })
     ),
-    [inapplicable(R33)]
+    [inapplicable(R33, Outcome.Mode.SemiAuto)]
   );
 });

--- a/packages/alfa-rules/test/sia-r34/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r34/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -27,7 +28,14 @@ test(`evaluate() passes video with accurate descriptions track`, async (t) => {
         "track-describes-video": true,
       })
     ),
-    [passed(R34, target, { 1: Outcomes.HasDescriptionTrack })]
+    [
+      passed(
+        R34,
+        target,
+        { 1: Outcomes.HasDescriptionTrack },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -50,7 +58,14 @@ test(`evaluate() fails video with inaccurate descriptions track`, async (t) => {
         "track-describes-video": false,
       })
     ),
-    [failed(R34, target, { 1: Outcomes.HasNoDescriptionTrack })]
+    [
+      failed(
+        R34,
+        target,
+        { 1: Outcomes.HasNoDescriptionTrack },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -69,7 +84,7 @@ test(`evaluate() cannot tell if questions are left unanswered`, async (t) => {
       { document },
       oracle({ "is-video-streaming": false, "has-audio": false })
     ),
-    [cantTell(R34, target)]
+    [cantTell(R34, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -100,7 +115,7 @@ test(`evaluate() is inapplicable to videos with audio`, async (t) => {
       { document },
       oracle({ "is-video-streaming": false, "has-audio": true })
     ),
-    [inapplicable(R34)]
+    [inapplicable(R34, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -109,12 +124,5 @@ test(`evaluate() is inapplicable to videos without description track`, async (t)
 
   const document = h.document([target]);
 
-  t.deepEqual(
-    await evaluate(
-      R34,
-      { document },
-      oracle({ "is-video-streaming": false, "has-audio": false })
-    ),
-    [inapplicable(R34)]
-  );
+  t.deepEqual(await evaluate(R34, { document }), [inapplicable(R34)]);
 });

--- a/packages/alfa-rules/test/sia-r35/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r35/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { None, Option } from "@siteimprove/alfa-option";
 import { test } from "@siteimprove/alfa-test";
@@ -24,7 +25,7 @@ test(`evaluate() passes when R32 passes`, async (t) => {
         "has-audio-track": true,
       })
     ),
-    [passed(R35, target, { 1: Outcomes.HasAlternative })]
+    [passed(R35, target, { 1: Outcomes.HasAlternative }, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -47,7 +48,7 @@ test(`evaluate() passes when R26 passes`, async (t) => {
         label: Option.of(label),
       })
     ),
-    [passed(R35, target, { 1: Outcomes.HasAlternative })]
+    [passed(R35, target, { 1: Outcomes.HasAlternative }, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -74,7 +75,14 @@ test(`evaluate() fails when no input rule passes`, async (t) => {
         "transcript-link": None,
       })
     ),
-    [failed(R35, target, { 1: Outcomes.HasNoAlternative })]
+    [
+      failed(
+        R35,
+        target,
+        { 1: Outcomes.HasNoAlternative },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -89,7 +97,7 @@ test(`evaluate() cannot tell if no input rule can tell`, async (t) => {
       { document },
       oracle({ "is-video-streaming": false, "has-audio": false })
     ),
-    [cantTell(R35, target)]
+    [cantTell(R35, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -109,7 +117,7 @@ test(`evaluate() cannot tell when some input rule cannot tell and no input rule 
         "has-audio-track": false,
       })
     ),
-    [cantTell(R35, target)]
+    [cantTell(R35, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -132,6 +140,6 @@ test(`evaluate() is inapplicable to videos with audio`, async (t) => {
       { document },
       oracle({ "is-video-streaming": false, "has-audio": true })
     ),
-    [inapplicable(R35)]
+    [inapplicable(R35, Outcome.Mode.SemiAuto)]
   );
 });

--- a/packages/alfa-rules/test/sia-r36/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r36/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -27,7 +28,14 @@ test(`evaluate() passes video with accurate descriptions track`, async (t) => {
         "track-describes-video": true,
       })
     ),
-    [passed(R36, target, { 1: Outcomes.HasDescriptionTrack })]
+    [
+      passed(
+        R36,
+        target,
+        { 1: Outcomes.HasDescriptionTrack },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -50,7 +58,14 @@ test(`evaluate() fails video with inaccurate descriptions track`, async (t) => {
         "track-describes-video": false,
       })
     ),
-    [failed(R36, target, { 1: Outcomes.HasNoDescriptionTrack })]
+    [
+      failed(
+        R36,
+        target,
+        { 1: Outcomes.HasNoDescriptionTrack },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -69,7 +84,7 @@ test(`evaluate() cannot tell if questions are left unanswered`, async (t) => {
       { document },
       oracle({ "is-video-streaming": false, "has-audio": true })
     ),
-    [cantTell(R36, target)]
+    [cantTell(R36, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -100,7 +115,7 @@ test(`evaluate() is inapplicable to videos without audio`, async (t) => {
       { document },
       oracle({ "is-video-streaming": false, "has-audio": false })
     ),
-    [inapplicable(R36)]
+    [inapplicable(R36, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -109,12 +124,5 @@ test(`evaluate() is inapplicable to videos without description track`, async (t)
 
   const document = h.document([target]);
 
-  t.deepEqual(
-    await evaluate(
-      R36,
-      { document },
-      oracle({ "is-video-streaming": false, "has-audio": true })
-    ),
-    [inapplicable(R36)]
-  );
+  t.deepEqual(await evaluate(R36, { document }), [inapplicable(R36)]);
 });

--- a/packages/alfa-rules/test/sia-r37/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r37/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { None, Option } from "@siteimprove/alfa-option";
 import { test } from "@siteimprove/alfa-test";
@@ -24,7 +25,14 @@ test(`evaluate() passes when R25 passes`, async (t) => {
         "has-description": true,
       })
     ),
-    [passed(R37, target, { 1: Outcomes.HasAudioDescription })]
+    [
+      passed(
+        R37,
+        target,
+        { 1: Outcomes.HasAudioDescription },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -47,7 +55,14 @@ test(`evaluate() passes when R31 passes`, async (t) => {
         label: Option.of(label),
       })
     ),
-    [passed(R37, target, { 1: Outcomes.HasAudioDescription })]
+    [
+      passed(
+        R37,
+        target,
+        { 1: Outcomes.HasAudioDescription },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -71,7 +86,14 @@ test(`evaluate() fails when no input rule passes`, async (t) => {
         label: None,
       })
     ),
-    [failed(R37, target, { 1: Outcomes.HasNoAudioDescription })]
+    [
+      failed(
+        R37,
+        target,
+        { 1: Outcomes.HasNoAudioDescription },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -86,7 +108,7 @@ test(`evaluate() cannot tell if no input rule can tell`, async (t) => {
       { document },
       oracle({ "is-video-streaming": false, "has-audio": true })
     ),
-    [cantTell(R37, target)]
+    [cantTell(R37, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -106,7 +128,7 @@ test(`evaluate() cannot tell when some input rule cannot tell and no input rule 
         "has-description": false,
       })
     ),
-    [cantTell(R37, target)]
+    [cantTell(R37, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -129,6 +151,6 @@ test(`evaluate() is inapplicable to videos without audio`, async (t) => {
       { document },
       oracle({ "is-video-streaming": false, "has-audio": false })
     ),
-    [inapplicable(R37)]
+    [inapplicable(R37, Outcome.Mode.SemiAuto)]
   );
 });

--- a/packages/alfa-rules/test/sia-r38/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r38/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -35,9 +36,14 @@ test("evaluate() passes when some atomic rules are passing", async (t) => {
       })
     ),
     [
-      passed(R38, target, {
-        1: Outcomes.HasAlternative,
-      }),
+      passed(
+        R38,
+        target,
+        {
+          1: Outcomes.HasAlternative,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -61,6 +67,6 @@ test("evaluate() can't tell when there are not enough answers to expectation", a
         "has-audio": true,
       })
     ),
-    [cantTell(R38, target)]
+    [cantTell(R38, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });

--- a/packages/alfa-rules/test/sia-r39/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r39/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -18,7 +19,14 @@ test("evaluate() passes images whose name is descriptive", async (t) => {
       { document },
       oracle({ "name-describes-purpose": true })
     ),
-    [passed(R39, target, { 1: Outcomes.NameIsDescriptive("img") })]
+    [
+      passed(
+        R39,
+        target,
+        { 1: Outcomes.NameIsDescriptive("img") },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 
@@ -33,7 +41,14 @@ test("evaluate() passes images whose name is not descriptive", async (t) => {
       { document },
       oracle({ "name-describes-purpose": false })
     ),
-    [failed(R39, target, { 1: Outcomes.NameIsNotDescriptive("img") })]
+    [
+      failed(
+        R39,
+        target,
+        { 1: Outcomes.NameIsNotDescriptive("img") },
+        Outcome.Mode.SemiAuto
+      ),
+    ]
   );
 });
 

--- a/packages/alfa-rules/test/sia-r41/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r41/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -39,9 +40,14 @@ test(`evaluate() fails two links that have the same name, but reference
       })
     ),
     [
-      failed(R41, Group.of(target), {
-        1: Outcomes.ResolveDifferentResource,
-      }),
+      failed(
+        R41,
+        Group.of(target),
+        {
+          1: Outcomes.ResolveDifferentResource,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -61,9 +67,14 @@ test(`evaluate() passes two links that have the same name and reference
       })
     ),
     [
-      passed(R41, Group.of(target), {
-        1: Outcomes.ResolveEquivalentResource,
-      }),
+      passed(
+        R41,
+        Group.of(target),
+        {
+          1: Outcomes.ResolveEquivalentResource,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });

--- a/packages/alfa-rules/test/sia-r48/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r48/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -17,15 +18,20 @@ test("evaluate() passes videos with less than 3 second of audio", async (t) => {
       R48,
       { document },
       oracle({
-        "is-above-duration-threshold": true,
         "has-audio": true,
+        "is-above-duration-threshold": true,
         "is-below-audio-duration-threshold": true,
       })
     ),
     [
-      passed(R48, target, {
-        1: Outcomes.DurationBelowThreshold("video"),
-      }),
+      passed(
+        R48,
+        target,
+        {
+          1: Outcomes.DurationBelowThreshold("video"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -40,15 +46,20 @@ test("evaluate() fails videos with more than 3 second of audio", async (t) => {
       R48,
       { document },
       oracle({
-        "is-above-duration-threshold": true,
         "has-audio": true,
+        "is-above-duration-threshold": true,
         "is-below-audio-duration-threshold": false,
       })
     ),
     [
-      failed(R48, target, {
-        1: Outcomes.DurationAboveThreshold("video"),
-      }),
+      failed(
+        R48,
+        target,
+        {
+          1: Outcomes.DurationAboveThreshold("video"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -64,9 +75,9 @@ test("evaluate() can't tell when questions are left unanswered", async (t) => {
     await evaluate(
       R48,
       { document },
-      oracle({ "is-above-duration-threshold": true, "has-audio": true })
+      oracle({ "has-audio": true, "is-above-duration-threshold": true })
     ),
-    [cantTell(R48, target)]
+    [cantTell(R48, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -83,9 +94,9 @@ test("evaluate() is inapplicable to short videos", async (t) => {
     await evaluate(
       R48,
       { document },
-      oracle({ "is-above-duration-threshold": false })
+      oracle({ "has-audio": true, "is-above-duration-threshold": false })
     ),
-    [inapplicable(R48)]
+    [inapplicable(R48, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -93,12 +104,8 @@ test("evaluate() is inapplicable to audio-less videos", async (t) => {
   const document = h.document([<video autoplay src="foo.mp4" />]);
 
   t.deepEqual(
-    await evaluate(
-      R48,
-      { document },
-      oracle({ "is-above-duration-threshold": true, "has-audio": false })
-    ),
-    [inapplicable(R48)]
+    await evaluate(R48, { document }, oracle({ "has-audio": false })),
+    [inapplicable(R48, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -109,14 +116,7 @@ test("evaluate() is inapplicable to videos that don't autoplay", async (t) => {
 
   const document = h.document([target, controls]);
 
-  t.deepEqual(
-    await evaluate(
-      R48,
-      { document },
-      oracle({ "is-above-duration-threshold": true, "has-audio": true })
-    ),
-    [inapplicable(R48)]
-  );
+  t.deepEqual(await evaluate(R48, { document }), [inapplicable(R48)]);
 });
 
 test("evaluate() is inapplicable to paused videos", async (t) => {
@@ -126,14 +126,7 @@ test("evaluate() is inapplicable to paused videos", async (t) => {
 
   const document = h.document([target, controls]);
 
-  t.deepEqual(
-    await evaluate(
-      R48,
-      { document },
-      oracle({ "is-above-duration-threshold": true, "has-audio": true })
-    ),
-    [inapplicable(R48)]
-  );
+  t.deepEqual(await evaluate(R48, { document }), [inapplicable(R48)]);
 });
 
 test("evaluate() is inapplicable to muted videos", async (t) => {
@@ -143,12 +136,5 @@ test("evaluate() is inapplicable to muted videos", async (t) => {
 
   const document = h.document([target, controls]);
 
-  t.deepEqual(
-    await evaluate(
-      R48,
-      { document },
-      oracle({ "is-above-duration-threshold": true, "has-audio": true })
-    ),
-    [inapplicable(R48)]
-  );
+  t.deepEqual(await evaluate(R48, { document }), [inapplicable(R48)]);
 });

--- a/packages/alfa-rules/test/sia-r49/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r49/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -20,14 +21,19 @@ test(`evaluate() passes an autoplaying <video> element that lasts more than 3
       R49,
       { document },
       oracle({
-        "is-above-duration-threshold": true,
         "has-audio": true,
+        "is-above-duration-threshold": true,
       })
     ),
     [
-      passed(R49, target, {
-        1: Outcomes.HasPerceivablePauseMechanism("video"),
-      }),
+      passed(
+        R49,
+        target,
+        {
+          1: Outcomes.HasPerceivablePauseMechanism("video"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -45,15 +51,20 @@ test(`evaluate() passes an autoplaying <video> element that lasts more than 3
       R49,
       { document },
       oracle({
-        "is-above-duration-threshold": true,
         "has-audio": true,
+        "is-above-duration-threshold": true,
         "audio-control-mechanism": Option.of(controls),
       })
     ),
     [
-      passed(R49, target, {
-        1: Outcomes.HasPerceivablePauseMechanism("video"),
-      }),
+      passed(
+        R49,
+        target,
+        {
+          1: Outcomes.HasPerceivablePauseMechanism("video"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -69,15 +80,20 @@ test(`evaluate() fails an autoplaying <video> element that lasts more than 3
       R49,
       { document },
       oracle({
-        "is-above-duration-threshold": true,
         "has-audio": true,
+        "is-above-duration-threshold": true,
         "audio-control-mechanism": None,
       })
     ),
     [
-      failed(R49, target, {
-        1: Outcomes.HasNoPauseMechanism("video"),
-      }),
+      failed(
+        R49,
+        target,
+        {
+          1: Outcomes.HasNoPauseMechanism("video"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -95,15 +111,20 @@ test(`evaluate() fails an autoplaying <video> element that lasts more than 3
       R49,
       { document },
       oracle({
-        "is-above-duration-threshold": true,
         "has-audio": true,
+        "is-above-duration-threshold": true,
         "audio-control-mechanism": Option.of(controls),
       })
     ),
     [
-      failed(R49, target, {
-        1: Outcomes.HasNonPerceivablePauseMechanism("video"),
-      }),
+      failed(
+        R49,
+        target,
+        {
+          1: Outcomes.HasNonPerceivablePauseMechanism("video"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -121,15 +142,20 @@ test(`evaluate() fails an autoplaying <video> element that lasts more than 3
       R49,
       { document },
       oracle({
-        "is-above-duration-threshold": true,
         "has-audio": true,
+        "is-above-duration-threshold": true,
         "audio-control-mechanism": Option.of(controls),
       })
     ),
     [
-      failed(R49, target, {
-        1: Outcomes.HasNonPerceivablePauseMechanism("video"),
-      }),
+      failed(
+        R49,
+        target,
+        {
+          1: Outcomes.HasNonPerceivablePauseMechanism("video"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -145,9 +171,9 @@ test("evaluate() can't tell when questions are left unanswered", async (t) => {
     await evaluate(
       R49,
       { document },
-      oracle({ "is-above-duration-threshold": true, "has-audio": true })
+      oracle({ "has-audio": true, "is-above-duration-threshold": true })
     ),
-    [cantTell(R49, target)]
+    [cantTell(R49, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -164,9 +190,9 @@ test("evaluate() is inapplicable to short videos", async (t) => {
     await evaluate(
       R49,
       { document },
-      oracle({ "is-above-duration-threshold": false })
+      oracle({ "has-audio": true, "is-above-duration-threshold": false })
     ),
-    [inapplicable(R49)]
+    [inapplicable(R49, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -174,12 +200,8 @@ test("evaluate() is inapplicable to audio-less videos", async (t) => {
   const document = h.document([<video autoplay src="foo.mp4" />]);
 
   t.deepEqual(
-    await evaluate(
-      R49,
-      { document },
-      oracle({ "is-above-duration-threshold": true, "has-audio": false })
-    ),
-    [inapplicable(R49)]
+    await evaluate(R49, { document }, oracle({ "has-audio": false })),
+    [inapplicable(R49, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -190,14 +212,7 @@ test("evaluate() is inapplicable to videos that don't autoplay", async (t) => {
 
   const document = h.document([target, controls]);
 
-  t.deepEqual(
-    await evaluate(
-      R49,
-      { document },
-      oracle({ "is-above-duration-threshold": true, "has-audio": true })
-    ),
-    [inapplicable(R49)]
-  );
+  t.deepEqual(await evaluate(R49, { document }), [inapplicable(R49)]);
 });
 
 test("evaluate() is inapplicable to paused videos", async (t) => {
@@ -207,14 +222,7 @@ test("evaluate() is inapplicable to paused videos", async (t) => {
 
   const document = h.document([target, controls]);
 
-  t.deepEqual(
-    await evaluate(
-      R49,
-      { document },
-      oracle({ "is-above-duration-threshold": true, "has-audio": true })
-    ),
-    [inapplicable(R49)]
-  );
+  t.deepEqual(await evaluate(R49, { document }), [inapplicable(R49)]);
 });
 
 test("evaluate() is inapplicable to muted videos", async (t) => {
@@ -224,12 +232,5 @@ test("evaluate() is inapplicable to muted videos", async (t) => {
 
   const document = h.document([target, controls]);
 
-  t.deepEqual(
-    await evaluate(
-      R49,
-      { document },
-      oracle({ "is-above-duration-threshold": true, "has-audio": true })
-    ),
-    [inapplicable(R49)]
-  );
+  t.deepEqual(await evaluate(R49, { document }), [inapplicable(R49)]);
 });

--- a/packages/alfa-rules/test/sia-r50/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r50/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { None, Option } from "@siteimprove/alfa-option";
 import { test } from "@siteimprove/alfa-test";
@@ -20,13 +21,13 @@ test(`evaluate() passes when R48 passes`, async (t) => {
       R50,
       { document },
       oracle({
-        "is-above-duration-threshold": true,
         "has-audio": true,
+        "is-above-duration-threshold": true,
         // R48
         "is-below-audio-duration-threshold": true,
       })
     ),
-    [passed(R50, target, { 1: Outcomes.AutoplayGood })]
+    [passed(R50, target, { 1: Outcomes.AutoplayGood }, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -42,13 +43,13 @@ test(`evaluate() passes when R49 passes`, async (t) => {
       R50,
       { document },
       oracle({
-        "is-above-duration-threshold": true,
         "has-audio": true,
+        "is-above-duration-threshold": true,
         // R49
         "audio-control-mechanism": Option.of(controls),
       })
     ),
-    [passed(R50, target, { 1: Outcomes.AutoplayGood })]
+    [passed(R50, target, { 1: Outcomes.AutoplayGood }, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -62,15 +63,15 @@ test(`evaluate() fails when all input rules fail`, async (t) => {
       R50,
       { document },
       oracle({
-        "is-above-duration-threshold": true,
         "has-audio": true,
+        "is-above-duration-threshold": true,
         // R48
         "is-below-audio-duration-threshold": false,
         // R49
         "audio-control-mechanism": None,
       })
     ),
-    [failed(R50, target, { 1: Outcomes.AutoplayBad })]
+    [failed(R50, target, { 1: Outcomes.AutoplayBad }, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -85,9 +86,9 @@ test(`evaluate() cannot tell if no input rule can tell`, async (t) => {
     await evaluate(
       R50,
       { document },
-      oracle({ "is-above-duration-threshold": true, "has-audio": true })
+      oracle({ "has-audio": true, "is-above-duration-threshold": true })
     ),
-    [cantTell(R50, target)]
+    [cantTell(R50, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -103,14 +104,14 @@ test(`evaluate() cannot tell when some input rule cannot tell and no input rule 
       R50,
       { document },
       oracle({
-        "is-above-duration-threshold": true,
         "has-audio": true,
+        "is-above-duration-threshold": true,
         // R48
         "is-below-audio-duration-threshold": false,
         // R49
       })
     ),
-    [cantTell(R50, target)]
+    [cantTell(R50, target, undefined, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -127,9 +128,9 @@ test("evaluate() is inapplicable to short videos", async (t) => {
     await evaluate(
       R50,
       { document },
-      oracle({ "is-above-duration-threshold": false })
+      oracle({ "has-audio": true, "is-above-duration-threshold": false })
     ),
-    [inapplicable(R50)]
+    [inapplicable(R50, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -137,12 +138,8 @@ test("evaluate() is inapplicable to audio-less videos", async (t) => {
   const document = h.document([<video autoplay src="foo.mp4" />]);
 
   t.deepEqual(
-    await evaluate(
-      R50,
-      { document },
-      oracle({ "is-above-duration-threshold": true, "has-audio": false })
-    ),
-    [inapplicable(R50)]
+    await evaluate(R50, { document }, oracle({ "has-audio": false })),
+    [inapplicable(R50, Outcome.Mode.SemiAuto)]
   );
 });
 
@@ -153,14 +150,7 @@ test("evaluate() is inapplicable to videos that don't autoplay", async (t) => {
 
   const document = h.document([target, controls]);
 
-  t.deepEqual(
-    await evaluate(
-      R50,
-      { document },
-      oracle({ "is-above-duration-threshold": true, "has-audio": true })
-    ),
-    [inapplicable(R50)]
-  );
+  t.deepEqual(await evaluate(R50, { document }), [inapplicable(R50)]);
 });
 
 test("evaluate() is inapplicable to paused videos", async (t) => {
@@ -170,14 +160,7 @@ test("evaluate() is inapplicable to paused videos", async (t) => {
 
   const document = h.document([target, controls]);
 
-  t.deepEqual(
-    await evaluate(
-      R50,
-      { document },
-      oracle({ "is-above-duration-threshold": true, "has-audio": true })
-    ),
-    [inapplicable(R50)]
-  );
+  t.deepEqual(await evaluate(R50, { document }), [inapplicable(R50)]);
 });
 
 test("evaluate() is inapplicable to muted videos", async (t) => {
@@ -187,12 +170,5 @@ test("evaluate() is inapplicable to muted videos", async (t) => {
 
   const document = h.document([target, controls]);
 
-  t.deepEqual(
-    await evaluate(
-      R50,
-      { document },
-      oracle({ "is-above-duration-threshold": true, "has-audio": true })
-    ),
-    [inapplicable(R50)]
-  );
+  t.deepEqual(await evaluate(R50, { document }), [inapplicable(R50)]);
 });

--- a/packages/alfa-rules/test/sia-r55/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r55/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -43,9 +44,14 @@ test("evaluate() passes when same landmarks have same names and content", async 
       oracle({ "is-content-equivalent": true })
     ),
     [
-      passed(R55, target, {
-        1: Outcomes.SameResource("complementary", "More information"),
-      }),
+      passed(
+        R55,
+        target,
+        {
+          1: Outcomes.SameResource("complementary", "More information"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -64,9 +70,14 @@ test("evaluate() fails when same landmarks have same names but different content
       oracle({ "is-content-equivalent": false })
     ),
     [
-      failed(R55, target, {
-        1: Outcomes.DifferentResources("complementary", "More information"),
-      }),
+      failed(
+        R55,
+        target,
+        {
+          1: Outcomes.DifferentResources("complementary", "More information"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -85,9 +96,14 @@ test("evaluate() fails when same sections have same names", async (t) => {
       oracle({ "is-content-equivalent": false })
     ),
     [
-      failed(R55, target, {
-        1: Outcomes.DifferentResources("region", "More information"),
-      }),
+      failed(
+        R55,
+        target,
+        {
+          1: Outcomes.DifferentResources("region", "More information"),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });

--- a/packages/alfa-rules/test/sia-r65/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r65/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -67,9 +68,14 @@ test(`evaluate() fails an <a> element that removes the default focus outline and
       })
     ),
     [
-      failed(R65, target, {
-        1: Outcomes.HasNoFocusIndicator(noMatches, noMatches),
-      }),
+      failed(
+        R65,
+        target,
+        {
+          1: Outcomes.HasNoFocusIndicator(noMatches, noMatches),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -98,9 +104,14 @@ test(`evaluate() passes an <a> element that removes the default focus outline
       })
     ),
     [
-      passed(R65, target, {
-        1: Outcomes.HasFocusIndicator(noMatches, noMatches),
-      }),
+      passed(
+        R65,
+        target,
+        {
+          1: Outcomes.HasFocusIndicator(noMatches, noMatches),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -239,9 +250,14 @@ test(`evaluate() fails an <a> element that removes the default focus outline
       })
     ),
     [
-      failed(R65, target, {
-        1: Outcomes.HasNoFocusIndicator(noMatches, noMatches),
-      }),
+      failed(
+        R65,
+        target,
+        {
+          1: Outcomes.HasNoFocusIndicator(noMatches, noMatches),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });

--- a/packages/alfa-rules/test/sia-r66/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r66/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -349,15 +350,20 @@ test("evaluate() passes when a background color with sufficient contrast is inpu
       })
     ),
     [
-      passed(R66, target, {
-        1: Outcomes.HasSufficientContrast(21, 7, [
-          Diagnostic.Pairing.of(
-            ["foreground", rgb(0, 0, 0)],
-            ["background", rgb(1, 1, 1)],
-            21
-          ),
-        ]),
-      }),
+      passed(
+        R66,
+        target,
+        {
+          1: Outcomes.HasSufficientContrast(21, 7, [
+            Diagnostic.Pairing.of(
+              ["foreground", rgb(0, 0, 0)],
+              ["background", rgb(1, 1, 1)],
+              21
+            ),
+          ]),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -380,15 +386,20 @@ test("evaluate() fails when a background color with insufficient contrast is inp
       })
     ),
     [
-      failed(R66, target, {
-        1: Outcomes.HasInsufficientContrast(1, 7, [
-          Diagnostic.Pairing.of(
-            ["foreground", rgb(0, 0, 0)],
-            ["background", rgb(0, 0, 0)],
-            1
-          ),
-        ]),
-      }),
+      failed(
+        R66,
+        target,
+        {
+          1: Outcomes.HasInsufficientContrast(1, 7, [
+            Diagnostic.Pairing.of(
+              ["foreground", rgb(0, 0, 0)],
+              ["background", rgb(0, 0, 0)],
+              1
+            ),
+          ]),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });

--- a/packages/alfa-rules/test/sia-r69/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r69/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -415,15 +416,20 @@ test("evaluate() passes when a background color with sufficient contrast is inpu
       })
     ),
     [
-      passed(R69, target, {
-        1: Outcomes.HasSufficientContrast(21, 4.5, [
-          Diagnostic.Pairing.of(
-            ["foreground", rgb(0, 0, 0)],
-            ["background", rgb(1, 1, 1)],
-            21
-          ),
-        ]),
-      }),
+      passed(
+        R69,
+        target,
+        {
+          1: Outcomes.HasSufficientContrast(21, 4.5, [
+            Diagnostic.Pairing.of(
+              ["foreground", rgb(0, 0, 0)],
+              ["background", rgb(1, 1, 1)],
+              21
+            ),
+          ]),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -451,15 +457,20 @@ test("evaluate() fails when a background color with insufficient contrast is inp
       })
     ),
     [
-      failed(R69, target, {
-        1: Outcomes.HasInsufficientContrast(1, 4.5, [
-          Diagnostic.Pairing.of(
-            ["foreground", rgb(0, 0, 0)],
-            ["background", rgb(0, 0, 0)],
-            1
-          ),
-        ]),
-      }),
+      failed(
+        R69,
+        target,
+        {
+          1: Outcomes.HasInsufficientContrast(1, 4.5, [
+            Diagnostic.Pairing.of(
+              ["foreground", rgb(0, 0, 0)],
+              ["background", rgb(0, 0, 0)],
+              1
+            ),
+          ]),
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });

--- a/packages/alfa-rules/test/sia-r81/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r81/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -53,9 +54,14 @@ test(`evaluate() fails two links that have the same name, but reference
       })
     ),
     [
-      failed(R81, Group.of(target), {
-        1: Outcomes.ResolveDifferentResource,
-      }),
+      failed(
+        R81,
+        Group.of(target),
+        {
+          1: Outcomes.ResolveDifferentResource,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -82,9 +88,14 @@ test(`evaluate() passes two links that have the same name and reference
       })
     ),
     [
-      passed(R81, Group.of(target), {
-        1: Outcomes.ResolveEquivalentResource,
-      }),
+      passed(
+        R81,
+        Group.of(target),
+        {
+          1: Outcomes.ResolveEquivalentResource,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });

--- a/packages/alfa-rules/test/sia-r82/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r82/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { None, Option } from "@siteimprove/alfa-option";
 import { test } from "@siteimprove/alfa-test";
@@ -38,10 +39,15 @@ test("evaluate() passes when a form field has no error indicator", async (t) => 
       })
     ),
     [
-      passed(R82, target, {
-        1: Outcomes.HasNoErrorIndicator,
-        2: Outcomes.HasNoErrorIndicator,
-      }),
+      passed(
+        R82,
+        target,
+        {
+          1: Outcomes.HasNoErrorIndicator,
+          2: Outcomes.HasNoErrorIndicator,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -60,10 +66,15 @@ test(`evaluate() passes when a form field has an error indicator that identifies
       })
     ),
     [
-      passed(R82, target, {
-        1: Outcomes.ErrorIndicatorIdentifiesTarget,
-        2: Outcomes.ErrorIndicatorDescribesResolution,
-      }),
+      passed(
+        R82,
+        target,
+        {
+          1: Outcomes.ErrorIndicatorIdentifiesTarget,
+          2: Outcomes.ErrorIndicatorDescribesResolution,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -82,10 +93,15 @@ test(`evaluate() fails when a form field has an error indicator that does not
       })
     ),
     [
-      failed(R82, target, {
-        1: Outcomes.NoErrorIndicatorIdentifiesTarget,
-        2: Outcomes.NoErrorIndicatorDescribesResolution,
-      }),
+      failed(
+        R82,
+        target,
+        {
+          1: Outcomes.NoErrorIndicatorIdentifiesTarget,
+          2: Outcomes.NoErrorIndicatorDescribesResolution,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -104,10 +120,15 @@ test(`evaluate() fails when a form field has an error indicator that identifies
       })
     ),
     [
-      failed(R82, target, {
-        1: Outcomes.ErrorIndicatorIdentifiesTargetButIsNotPerceivable,
-        2: Outcomes.ErrorIndicatorDescribesResolutionButIsNotPerceivable,
-      }),
+      failed(
+        R82,
+        target,
+        {
+          1: Outcomes.ErrorIndicatorIdentifiesTargetButIsNotPerceivable,
+          2: Outcomes.ErrorIndicatorDescribesResolutionButIsNotPerceivable,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -126,10 +147,15 @@ test(`evaluate() fails when a form field has an error indicator that identifies
       })
     ),
     [
-      failed(R82, target, {
-        1: Outcomes.ErrorIndicatorIdentifiesTargetButIsNotPerceivable,
-        2: Outcomes.ErrorIndicatorDescribesResolutionButIsNotPerceivable,
-      }),
+      failed(
+        R82,
+        target,
+        {
+          1: Outcomes.ErrorIndicatorIdentifiesTargetButIsNotPerceivable,
+          2: Outcomes.ErrorIndicatorDescribesResolutionButIsNotPerceivable,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });

--- a/packages/alfa-rules/test/sia-r87/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r87/rule.spec.tsx
@@ -1,3 +1,4 @@
+import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -48,9 +49,14 @@ test(`evaluate() passes a document whose first tabbable link references an
       })
     ),
     [
-      passed(R87, document, {
-        1: Outcomes.FirstTabbableIsLinkToContent,
-      }),
+      passed(
+        R87,
+        document,
+        {
+          1: Outcomes.FirstTabbableIsLinkToContent,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -73,9 +79,14 @@ test(`evaluate() passes a document whose first tabbable link references an
       })
     ),
     [
-      passed(R87, document, {
-        1: Outcomes.FirstTabbableIsLinkToContent,
-      }),
+      passed(
+        R87,
+        document,
+        {
+          1: Outcomes.FirstTabbableIsLinkToContent,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -104,9 +115,14 @@ test(`evaluate() passes a document whose first tabbable link references an
       })
     ),
     [
-      passed(R87, document, {
-        1: Outcomes.FirstTabbableIsLinkToContent,
-      }),
+      passed(
+        R87,
+        document,
+        {
+          1: Outcomes.FirstTabbableIsLinkToContent,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -222,9 +238,14 @@ test(`evaluate() fails a document whose first tabbable link is not visible`, asy
       })
     ),
     [
-      failed(R87, document, {
-        1: Outcomes.FirstTabbableIsNotVisible,
-      }),
+      failed(
+        R87,
+        document,
+        {
+          1: Outcomes.FirstTabbableIsNotVisible,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });
@@ -255,9 +276,14 @@ test(`evaluate() passes a document whose first tabbable link is not visible`, as
       })
     ),
     [
-      passed(R87, document, {
-        1: Outcomes.FirstTabbableIsLinkToContent,
-      }),
+      passed(
+        R87,
+        document,
+        {
+          1: Outcomes.FirstTabbableIsLinkToContent,
+        },
+        Outcome.Mode.SemiAuto
+      ),
     ]
   );
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1018,6 +1018,7 @@ __metadata:
     "@siteimprove/alfa-test": "workspace:^0.56.0"
     "@siteimprove/alfa-thunk": "workspace:^0.56.0"
     "@siteimprove/alfa-trilean": "workspace:^0.56.0"
+    "@siteimprove/alfa-tuple": "workspace:^0.56.0"
   languageName: unknown
   linkType: soft
 
@@ -2421,7 +2422,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@siteimprove/alfa-tuple@workspace:packages/alfa-tuple":
+"@siteimprove/alfa-tuple@workspace:^0.56.0, @siteimprove/alfa-tuple@workspace:packages/alfa-tuple":
   version: 0.0.0-use.local
   resolution: "@siteimprove/alfa-tuple@workspace:packages/alfa-tuple"
   dependencies:


### PR DESCRIPTION
* `Outcome` has a `mode` parameter.
* `Interview.conduct` records whether the Oracle produced a non-`None` answer.
* Rule evaluation records in its outcome whether the oracle was used.
* Update many rules test cases when oracle is used 🙈 

---
* Refactor the outcome value (passed/failed/…)
