### PR TITLE
Revert `Outcome` property (and JSON) accessor from `value` back to `outcome`.

### DIFF
--- a/docs/review/api/alfa-act.api.md
+++ b/docs/review/api/alfa-act.api.md
@@ -99,7 +99,7 @@ export type Oracle<INPUT, TARGET extends Hashable, QUESTION, SUBJECT> = (rule: R
 
 // @public
 export abstract class Outcome<I, T extends Hashable, Q = never, S = T, V extends Outcome.Value = Outcome.Value> implements Equatable, Hashable, json.Serializable<Outcome.JSON<V>>, earl.Serializable<Outcome.EARL>, sarif.Serializable<sarif.Result> {
-    protected constructor(value: V, rule: Rule<I, T, Q, S>, mode: Outcome.Mode);
+    protected constructor(outcome: V, rule: Rule<I, T, Q, S>, mode: Outcome.Mode);
     // (undocumented)
     equals<I, T extends Hashable, Q, S, V extends Outcome.Value = Outcome.Value>(value: Outcome<I, T, Q, S, V>): boolean;
     // (undocumented)
@@ -113,8 +113,8 @@ export abstract class Outcome<I, T extends Hashable, Q = never, S = T, V extends
     // (undocumented)
     protected readonly _mode: Outcome.Mode;
     // (undocumented)
+    get outcome(): V;
     get rule(): Rule<I, T, Q, S>;
-    // (undocumented)
     protected readonly _rule: Rule<I, T, Q, S>;
     // (undocumented)
     get target(): T | undefined;
@@ -124,8 +124,6 @@ export abstract class Outcome<I, T extends Hashable, Q = never, S = T, V extends
     toJSON(): Outcome.JSON<V>;
     // (undocumented)
     abstract toSARIF(): sarif.Result;
-    // (undocumented)
-    get value(): V;
 }
 
 // @public (undocumented)
@@ -318,9 +316,9 @@ export namespace Outcome {
         // (undocumented)
         mode: Mode;
         // (undocumented)
-        rule: Rule.JSON;
+        outcome: V;
         // (undocumented)
-        value: V;
+        rule: Rule.JSON;
     }
     // (undocumented)
     export enum Mode {

--- a/packages/alfa-act/src/outcome.ts
+++ b/packages/alfa-act/src/outcome.ts
@@ -35,18 +35,15 @@ export abstract class Outcome<
 {
   /**
    * {@link https://www.w3.org/TR/EARL10-Schema/#outcome}
-   * @private
    */
   private readonly _outcome: V;
   /**
    * {@link https://www.w3.org/TR/EARL10-Schema/#test}
    * While this is called a "test" in EARL, in Alfa this is always a "rule".
-   * @protected
    */
   protected readonly _rule: Rule<I, T, Q, S>;
   /**
    * {@link https://www.w3.org/TR/EARL10-Schema/#mode}
-   * @protected
    */
   protected readonly _mode: Outcome.Mode;
 
@@ -60,14 +57,24 @@ export abstract class Outcome<
     this._mode = mode;
   }
 
+  /**
+   * {@link https://www.w3.org/TR/EARL10-Schema/#outcome}
+   */
   public get outcome(): V {
     return this._outcome;
   }
 
+  /**
+   * {@link https://www.w3.org/TR/EARL10-Schema/#test}
+   * While this is called a "test" in EARL, in Alfa this is always a "rule".
+   */
   public get rule(): Rule<I, T, Q, S> {
     return this._rule;
   }
 
+  /**
+   * {@link https://www.w3.org/TR/EARL10-Schema/#mode}
+   */
   public get mode(): Outcome.Mode {
     return this._mode;
   }

--- a/packages/alfa-act/src/outcome.ts
+++ b/packages/alfa-act/src/outcome.ts
@@ -33,18 +33,35 @@ export abstract class Outcome<
     earl.Serializable<Outcome.EARL>,
     sarif.Serializable<sarif.Result>
 {
-  private readonly _value: V;
+  /**
+   * {@link https://www.w3.org/TR/EARL10-Schema/#outcome}
+   * @private
+   */
+  private readonly _outcome: V;
+  /**
+   * {@link https://www.w3.org/TR/EARL10-Schema/#test}
+   * While this is called a "test" in EARL, in Alfa this is always a "rule".
+   * @protected
+   */
   protected readonly _rule: Rule<I, T, Q, S>;
+  /**
+   * {@link https://www.w3.org/TR/EARL10-Schema/#mode}
+   * @protected
+   */
   protected readonly _mode: Outcome.Mode;
 
-  protected constructor(value: V, rule: Rule<I, T, Q, S>, mode: Outcome.Mode) {
-    this._value = value;
+  protected constructor(
+    outcome: V,
+    rule: Rule<I, T, Q, S>,
+    mode: Outcome.Mode
+  ) {
+    this._outcome = outcome;
     this._rule = rule;
     this._mode = mode;
   }
 
-  public get value(): V {
-    return this._value;
+  public get outcome(): V {
+    return this._outcome;
   }
 
   public get rule(): Rule<I, T, Q, S> {
@@ -77,19 +94,23 @@ export abstract class Outcome<
     return (
       value instanceof Outcome &&
       value._rule.equals(this._rule) &&
-      value._value === this._value &&
+      value._outcome === this._outcome &&
       value._mode === this._mode
     );
   }
 
   public hash(hash: Hash): void {
     this._rule.hash(hash);
-    hash.writeString(this._value);
+    hash.writeString(this._outcome);
     hash.writeString(this._mode);
   }
 
   public toJSON(): Outcome.JSON<V> {
-    return { value: this._value, rule: this._rule.toJSON(), mode: this._mode };
+    return {
+      outcome: this._outcome,
+      rule: this._rule.toJSON(),
+      mode: this._mode,
+    };
   }
 
   public toEARL(): Outcome.EARL {
@@ -134,7 +155,7 @@ export namespace Outcome {
 
   export interface JSON<V extends Value = Value> {
     [key: string]: json.JSON;
-    value: V;
+    outcome: V;
     rule: Rule.JSON;
     mode: Mode;
   }


### PR DESCRIPTION
Revert a breaking change accidentally introduced in #1318 where the property (and JSON) accessor for `Outcome` was changed from `outcome` to `value`.

The internal enum type is still named `Outcome.Value`, and `Outcome#outcome` ranges over it, mimicking the vocabulary used in EARL.