### PR TITLE
SIA-R66, R69: Only report interposed elements until another problem is encountered

### DIFF
--- a/packages/alfa-rules/src/common/expectation/contrast.ts
+++ b/packages/alfa-rules/src/common/expectation/contrast.ts
@@ -14,7 +14,7 @@ import { Contrast as Outcomes } from "../outcome/contrast";
 import { isLargeText } from "../predicate";
 
 const { isElement } = Element;
-const { flatMap, map } = Iterable;
+const { flatMap, map, takeWhile } = Iterable;
 const { min, max, round } = Math;
 
 /**
@@ -85,9 +85,11 @@ export function hasSufficientContrastExperimental(
     .err()
     .map((errors) =>
       flatMap(
-        errors.errors
-          // gather all interposed-descendant errors
-          .filter(ColorError.isInterposedDescendants),
+        // We only keep the initial "interposed-descendants" problems. As soon as we
+        // encounter some other problem, the "ignored-interposed-elements" question
+        // won't solve it, and we'll ask for colors anyway. So there is no need to ask
+        // "ignored-interposed-elements" for them.
+        takeWhile(errors.errors, ColorError.isInterposedDescendants),
         // and keep the interposed elements.
         (error) => error.positionedDescendants
       )
@@ -97,7 +99,7 @@ export function hasSufficientContrastExperimental(
     .err()
     .map((errors) =>
       flatMap(
-        errors.errors.filter(ColorError.isInterposedDescendants),
+        takeWhile(errors.errors, ColorError.isInterposedDescendants),
         (error) => error.positionedDescendants
       )
     )

--- a/packages/alfa-rules/test/sia-er69/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-er69/rule.spec.tsx
@@ -1,8 +1,7 @@
-/// <reference lib="dom" />
 import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { Future } from "@siteimprove/alfa-future";
-import { None, Option } from "@siteimprove/alfa-option";
+import { None } from "@siteimprove/alfa-option";
 import { test } from "@siteimprove/alfa-test";
 
 import { RGB, Percentage, Keyword } from "@siteimprove/alfa-css";

--- a/packages/alfa-rules/test/sia-er69/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-er69/rule.spec.tsx
@@ -1,5 +1,8 @@
+/// <reference lib="dom" />
 import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
+import { Future } from "@siteimprove/alfa-future";
+import { None, Option } from "@siteimprove/alfa-option";
 import { test } from "@siteimprove/alfa-test";
 
 import { RGB, Percentage, Keyword } from "@siteimprove/alfa-css";
@@ -725,8 +728,8 @@ test(`evaluate() does not consider ancestors as interposed elements`, async (t) 
   const interposed = (
     <div
       style={{
+        background: "url('foo.jpg')",
         position: "absolute",
-        backgroundColor: "red",
         width: "100%",
         height: "100%",
       }}
@@ -735,6 +738,7 @@ test(`evaluate() does not consider ancestors as interposed elements`, async (t) 
     </div>
   );
 
+  // interposed is interposed inside the <body>.
   // target1 is inside interposed, therefore it does not consider it as an
   // "interposed element", but as an absolutely positioned ancestor.
   // target2 is outside interposed and considers it as an "interposed element",
@@ -748,18 +752,19 @@ test(`evaluate() does not consider ancestors as interposed elements`, async (t) 
 
   const document = h.document([body]);
 
-  t.deepEqual(await evaluate(R69, { document }), [
-    passed(R69, target1, {
-      1: Outcomes.HasSufficientContrast(5.25, 4.5, [
-        Diagnostic.Pairing.of(
-          ["foreground", rgb(0, 0, 0)],
-          ["background", rgb(1, 0, 0)],
-          5.25
-        ),
-      ]),
-    }),
-    cantTell(R69, target2),
-  ]);
+  await evaluate(R69, { document }, (_, question) => {
+    let expected = "Unexpected question";
+    if (question.context === target1) {
+      expected = "background-colors";
+    }
+
+    if (question.context === target2) {
+      expected = "ignored-interposed-elements";
+    }
+
+    t.deepEqual(question.uri, expected);
+    return Future.now(None);
+  });
 });
 
 test(`evaluate() ignore interposed descendants if it can resolve colors


### PR DESCRIPTION
When asking about `ignored-interposed-elements`, only ask about the ones encountered until the first different problem (image, non-static ancestor, …)

The reasoning is that whatever the answer is for further interposed elements, Alfa will still need to ask because of the other problem. Since we do not handle other `getColors` separately, this result in a `background-colors` question which is final, u.e. we never look at the other interposed elements and asking about them brings no value.
