### PR TITLE
Compute line-height from percentage of font-size of self instead of from parent

### DIFF
--- a/packages/alfa-style/src/property/line-height.ts
+++ b/packages/alfa-style/src/property/line-height.ts
@@ -59,7 +59,7 @@ export default Property.register(
     (value, style) =>
       value.map((height) => {
         const percentage = Resolver.percentage(
-          style.parent.computed("font-size").value
+          style.computed("font-size").value
         );
         const length = Resolver.length(style);
 

--- a/packages/alfa-style/test/property/line-height.spec.tsx
+++ b/packages/alfa-style/test/property/line-height.spec.tsx
@@ -36,7 +36,7 @@ test("#computed() resolves `line-height: calc(1 + 2)`", (t) => {
   });
 });
 
-test("#computed() does not resolve `line-height: 150%` from parent", (t) => {
+test("#computed() resolves percentages from the element's \`font-size\`", (t) => {
   const target = (
     <div style={{ lineHeight: "150%", fontSize: "10px" }}>Hello</div>
   );

--- a/packages/alfa-style/test/property/line-height.spec.tsx
+++ b/packages/alfa-style/test/property/line-height.spec.tsx
@@ -35,3 +35,22 @@ test("#computed() resolves `line-height: calc(1 + 2)`", (t) => {
     source: h.declaration("line-height", "calc(1 + 2)").toJSON(),
   });
 });
+
+test("#computed() does not resolve `line-height: 150%` from parent", (t) => {
+  const target = (
+    <div style={{ lineHeight: "150%", fontSize: "10px" }}>Hello</div>
+  );
+
+  <div style={{ fontSize: "20px" }}>{target}</div>;
+
+  const style = Style.from(target, device);
+
+  t.deepEqual(style.computed("line-height").toJSON(), {
+    value: {
+      type: "length",
+      unit: "px",
+      value: 15,
+    },
+    source: h.declaration("line-height", "150%").toJSON(),
+  });
+});


### PR DESCRIPTION
Resolves #1323

When `line-height` is specified as a percentage, it's computed based on the elements `font-size` rather than that of its parent.
