### PR TITLE
Remove `transcript-perceivable` question

### DIFF
--- a/packages/alfa-rules/src/common/act/question.ts
+++ b/packages/alfa-rules/src/common/act/question.ts
@@ -122,7 +122,7 @@ export namespace Question {
     },
     "has-captions": {
       type: "boolean",
-      message: `Does the \`<video>\` element have captions?`,
+      message: `Does the \`<video>\` element have captions that describe the content of the video?`,
     },
     "has-description": {
       type: "boolean",
@@ -158,16 +158,11 @@ export namespace Question {
     },
     transcript: {
       type: "node",
-      message: `Where is the transcript of the [audio/video] element?`,
+      message: `Where is the transcript that describes the content of the [audio/video] element?`,
     },
     "transcript-link": {
       type: "node",
-      message: `Where is the link pointing to the transcript of the [audio/video]
-                  element?`,
-    },
-    "transcript-perceivable": {
-      type: "boolean",
-      message: `Is the transcript of the [audio/video] element perceivable?`,
+      message: `Where is the link pointing to the transcript that describes the content of the [audio/video] element?`,
     },
     // R39
     "name-describes-purpose": {

--- a/packages/alfa-rules/src/common/expectation/media-transcript.ts
+++ b/packages/alfa-rules/src/common/expectation/media-transcript.ts
@@ -68,13 +68,13 @@ export function audioTranscript(target: Element, device: Device) {
   const alt = Question.of(
     "transcript",
     target,
-    `Where is the transcript of the \`<audio>\` element?`
+    `Where is the transcript that describes the content of the \`<audio>\` element?`
   );
 
   const label = Question.of(
     "transcript-link",
     target,
-    `Where is the link pointing to a perceivable transcript of the \`<audio>\` element?`
+    `Where is the link pointing to a perceivable transcript that describes the content of the \`<audio>\` element?`
   );
 
   return mediaTranscript(alt, label, device, "<audio>");
@@ -84,13 +84,13 @@ export function videoTranscript(target: Element, device: Device) {
   const alt = Question.of(
     "transcript",
     target,
-    `Where is the transcript of the \`<video>\` element?`
+    `Where is the transcript that describes the content of the \`<video>\` element?`
   );
 
   const label = Question.of(
     "transcript-link",
     target,
-    `Where is the link pointing to a perceivable transcript of the \`<video>\` element?`
+    `Where is the link pointing to a perceivable transcript that describes the content of the \`<video>\` element?`
   );
 
   return mediaTranscript(alt, label, device, "<video>");

--- a/packages/alfa-rules/test/sia-r23/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r23/rule.spec.tsx
@@ -52,7 +52,6 @@ test(`evaluate() passes an audio with a link to a transcript`, async (t) => {
         "is-playing": true,
         transcript: None,
         "transcript-link": Option.of(transcript),
-        "transcript-perceivable": true,
       })
     ),
     [


### PR DESCRIPTION
Resolves #1329 

The `transcript-perceivable` question has been removed and `has-captions`, `transcript` and `transcript-link` has been rephrased to make it clear that they are asking about captions/transcripts that describe the content of the video/audio.
