### PR TITLE
Parse `:host` pseudo-class selector

### DIFF
--- a/docs/review/api/alfa-selector.api.md
+++ b/docs/review/api/alfa-selector.api.md
@@ -399,6 +399,13 @@ export namespace Selector {
         }
     }
     // (undocumented)
+    export class Host extends Pseudo.Class<"host"> {
+        // (undocumented)
+        matches(_element: Element): boolean;
+        // (undocumented)
+        static of(): Host;
+    }
+    // (undocumented)
     export class Hover extends Pseudo.Class<"hover"> {
         // (undocumented)
         matches(element: Element, context?: Context): boolean;

--- a/docs/review/api/alfa-selector.api.md
+++ b/docs/review/api/alfa-selector.api.md
@@ -401,8 +401,6 @@ export namespace Selector {
     // (undocumented)
     export class Host extends Pseudo.Class<"host"> {
         // (undocumented)
-        matches(_element: Element): boolean;
-        // (undocumented)
         static of(): Host;
     }
     // (undocumented)

--- a/packages/alfa-selector/src/selector.ts
+++ b/packages/alfa-selector/src/selector.ts
@@ -1503,11 +1503,6 @@ export namespace Selector {
       super("host");
     }
 
-    public matches(_element: Element): boolean {
-      // The shadow DOM is currently not supported so there should not be any matches.
-      // If support for the shadow DOM is added, then this should be implemented.
-      return false;
-    }
   }
 
   /**

--- a/packages/alfa-selector/src/selector.ts
+++ b/packages/alfa-selector/src/selector.ts
@@ -884,6 +884,8 @@ export namespace Selector {
             return Result.of(Enabled.of());
           case "root":
             return Result.of(Root.of());
+          case "host":
+            return Result.of(Host.of());
           case "empty":
             return Result.of(Empty.of());
           case "first-child":
@@ -1486,6 +1488,25 @@ export namespace Selector {
     public matches(element: Element): boolean {
       // The root element is the element whose parent is NOT itself an element.
       return element.parent().every(not(isElement));
+    }
+  }
+
+  /**
+   * {@link https://drafts.csswg.org/css-scoping-1/#selectordef-host}
+   */
+  export class Host extends Pseudo.Class<"host"> {
+    public static of(): Host {
+      return new Host();
+    }
+
+    private constructor() {
+      super("host");
+    }
+
+    public matches(_element: Element): boolean {
+      // The shadow DOM is currently not supported so there should not be any matches.
+      // If support for the shadow DOM is added, then this should be implemented.
+      return false;
     }
   }
 

--- a/packages/alfa-selector/src/selector.ts
+++ b/packages/alfa-selector/src/selector.ts
@@ -1502,7 +1502,6 @@ export namespace Selector {
     private constructor() {
       super("host");
     }
-
   }
 
   /**

--- a/packages/alfa-selector/test/selector.spec.tsx
+++ b/packages/alfa-selector/test/selector.spec.tsx
@@ -693,14 +693,7 @@ test(".parse() parses a named pseudo-class selector", (t) => {
 });
 
 test(".parse() parses :host pseudo-class selector", (t) => {
-  const parseResult = parse(":host");
-
-  if (parseResult.isErr()) {
-    t.fail(parseResult.getErr());
-    return;
-  }
-
-  t.deepEqual(parseResult.get().toJSON(), {
+  t.deepEqual(parse(":host").get().toJSON(), {
     type: "pseudo-class",
     name: "host",
   });

--- a/packages/alfa-selector/test/selector.spec.tsx
+++ b/packages/alfa-selector/test/selector.spec.tsx
@@ -692,6 +692,20 @@ test(".parse() parses a named pseudo-class selector", (t) => {
   });
 });
 
+test(".parse() parses :host pseudo-class selector", (t) => {
+  const parseResult = parse(":host");
+
+  if (parseResult.isErr()) {
+    t.fail(parseResult.getErr());
+    return;
+  }
+
+  t.deepEqual(parseResult.get().toJSON(), {
+    type: "pseudo-class",
+    name: "host",
+  });
+});
+
 test(".parse() parses a functional pseudo-class selector", (t) => {
   t.deepEqual(parse(":not(.foo)").get().toJSON(), {
     type: "pseudo-class",


### PR DESCRIPTION
Resolves #1347

Updated the pseudo class parser to parse the `:host` selector.
