### PR TITLE
Update whitespace parser to parse one or more

### DIFF
--- a/docs/review/api/alfa-parser.api.md
+++ b/docs/review/api/alfa-parser.api.md
@@ -42,7 +42,7 @@ export namespace Parser {
     // (undocumented)
     export function mapResult<I, T, U, E, A extends Array_2<unknown> = []>(parser: Parser<I, T, E, A>, mapper: Mapper<T, Result<U, E>>): Parser<I, U, E, A>;
     // (undocumented)
-    export function oneOrMore<I, T, E, A extends Array_2<unknown> = []>(parser: Parser<I, T, E, A>): Parser<I, Array_2<T>, E, A>;
+    export function oneOrMore<I, T, E, A extends Array_2<unknown> = []>(parser: Parser<I, T, E, A>): Parser<I, [T, ...Array_2<T>], E, A>;
     // (undocumented)
     export function option<I, T, E, A extends Array_2<unknown> = []>(parser: Parser<I, T, E, A>): Parser<I, Option<T>, E, A>;
     // (undocumented)

--- a/packages/alfa-css/src/syntax/token.ts
+++ b/packages/alfa-css/src/syntax/token.ts
@@ -8,6 +8,7 @@ import { Slice } from "@siteimprove/alfa-slice";
 
 import * as json from "@siteimprove/alfa-json";
 
+const { oneOrMore } = Parser;
 const { fromCharCode } = String;
 const { and } = Refinement;
 
@@ -811,7 +812,7 @@ export namespace Token {
 
   export const { of: whitespace, isWhitespace } = Whitespace;
 
-  export const parseWhitespace = parseToken(isWhitespace);
+  export const parseWhitespace = oneOrMore(parseToken(isWhitespace));
 
   export class Colon implements Equatable, Serializable<Colon.JSON> {
     private static _instance = new Colon();

--- a/packages/alfa-css/src/syntax/token.ts
+++ b/packages/alfa-css/src/syntax/token.ts
@@ -812,11 +812,9 @@ export namespace Token {
 
   export const { of: whitespace, isWhitespace } = Whitespace;
 
-  // If more than one whitespace is parsed, we only want one in the result.
-  // Calling `oneOrMore` ensures at least one, so indexing should be safe.
   export const parseWhitespace = map(
     oneOrMore(parseToken(isWhitespace)),
-    (whitespaces) => whitespaces[0]
+    ([first,]) => first
   );
 
   export class Colon implements Equatable, Serializable<Colon.JSON> {

--- a/packages/alfa-css/src/syntax/token.ts
+++ b/packages/alfa-css/src/syntax/token.ts
@@ -814,7 +814,7 @@ export namespace Token {
 
   export const parseWhitespace = map(
     oneOrMore(parseToken(isWhitespace)),
-    ([first,]) => first
+    ([first]) => first
   );
 
   export class Colon implements Equatable, Serializable<Colon.JSON> {

--- a/packages/alfa-css/src/syntax/token.ts
+++ b/packages/alfa-css/src/syntax/token.ts
@@ -8,7 +8,7 @@ import { Slice } from "@siteimprove/alfa-slice";
 
 import * as json from "@siteimprove/alfa-json";
 
-const { oneOrMore } = Parser;
+const { map, oneOrMore } = Parser;
 const { fromCharCode } = String;
 const { and } = Refinement;
 
@@ -812,7 +812,12 @@ export namespace Token {
 
   export const { of: whitespace, isWhitespace } = Whitespace;
 
-  export const parseWhitespace = oneOrMore(parseToken(isWhitespace));
+  // If more than one whitespace is parsed, we only want one in the result.
+  // Calling `oneOrMore` ensures at least one, so indexing should be safe.
+  export const parseWhitespace = map(
+    oneOrMore(parseToken(isWhitespace)),
+    (whitespaces) => whitespaces[0]
+  );
 
   export class Colon implements Equatable, Serializable<Colon.JSON> {
     private static _instance = new Colon();

--- a/packages/alfa-css/test/value/color/rgb.spec.ts
+++ b/packages/alfa-css/test/value/color/rgb.spec.ts
@@ -1,0 +1,48 @@
+import { Slice } from "@siteimprove/alfa-slice";
+import { test } from "@siteimprove/alfa-test";
+
+import { RGB, Token } from "../../../src";
+
+const { parse } = RGB;
+const { func, number, comma, whitespace, closeParenthesis } = Token;
+
+test("parse() parses consecutive whitespace", (t) => {
+  const tokens = Slice.of([
+    func("rgba"),
+    number(255, true, false),
+    comma(),
+    whitespace(),
+    number(255, true, false),
+    comma(),
+    whitespace(),
+    number(255, true, false),
+    comma(),
+    whitespace(),
+    whitespace(),
+    number(1, true, false),
+    closeParenthesis(),
+  ]);
+    
+  const result = parse(tokens).map(([_, color]) => color.toJSON());
+
+  t.deepEqual(result.get(), {
+    type: "color",
+    format: "rgb",
+    red: {
+      value: 255,
+      type: "number",
+    },
+    green: {
+      value: 255,
+      type: "number",
+    },
+    blue: {
+      value: 255,
+      type: "number",
+    },
+    alpha: {
+      value: 1,
+      type: "number",
+    },
+  });
+});

--- a/packages/alfa-css/tsconfig.json
+++ b/packages/alfa-css/tsconfig.json
@@ -73,7 +73,8 @@
     "test/value/shape/ellipse.spec.ts",
     "test/value/shape/inset.spec.ts",
     "test/value/shape/polygon.spec.ts",
-    "test/value/shape/rectangle.spec.ts"
+    "test/value/shape/rectangle.spec.ts",
+    "test/value/color/rgb.spec.ts"
   ],
   "references": [
     { "path": "../alfa-array" },

--- a/packages/alfa-parser/src/parser.ts
+++ b/packages/alfa-parser/src/parser.ts
@@ -106,8 +106,9 @@ export namespace Parser {
 
   export function oneOrMore<I, T, E, A extends Array<unknown> = []>(
     parser: Parser<I, T, E, A>
-  ): Parser<I, Array<T>, E, A> {
-    return takeAtLeast(parser, 1);
+  ): Parser<I, [T, ...Array<T>], E, A> {
+    // The result contains at least one token, so this cast is safe
+    return map(takeAtLeast(parser, 1), (result) => result as [T, ...Array<T>]);
   }
 
   export function take<I, T, E, A extends Array<unknown> = []>(

--- a/packages/alfa-parser/src/parser.ts
+++ b/packages/alfa-parser/src/parser.ts
@@ -108,7 +108,7 @@ export namespace Parser {
     parser: Parser<I, T, E, A>
   ): Parser<I, [T, ...Array<T>], E, A> {
     // The result contains at least one token, so this cast is safe
-    return map(takeAtLeast(parser, 1), (result) => result as [T, ...Array<T>]);
+    return takeAtLeast(parser, 1) as Parser<I, [T, ...Array<T>], E, A>;
   }
 
   export function take<I, T, E, A extends Array<unknown> = []>(


### PR DESCRIPTION
Resolves #1291 

Update `parseWhitespace` so that it accepts one or more whitespace tokens to allow for the possibility that the lexer didn't manage to collapse all whitespace prior to the parsing. This might affect performance due to the extra check for more whitespaces and since this affects all users of the parser. If the performance hit is deemed unacceptable, we will explore other solutions.
