### PR TITLE
alfa-dom: Use exports map

### DIFF
--- a/packages/alfa-dom/package.json
+++ b/packages/alfa-dom/package.json
@@ -12,6 +12,17 @@
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./h": "./h.js",
+    "./h.js": "./h.js",
+    "./jsx": "./jsx.js",
+    "./jsx.js": "./jsx.js",
+    "./jsx-runtime": "./jsx-runtime.js",
+    "./jsx-runtime.js": "./jsx-runtime.js",
+    "./native": "./native.js",
+    "./native.js": "./native.js"
+  },
   "types": "src/index.d.ts",
   "files": [
     "h.js",


### PR DESCRIPTION
Use an export map for the [package entry point](https://nodejs.org/api/packages.html#package-entry-points) of `alfa-dom`.
This is especially needed for `jsx-runtime` due to the way that `jsxImportSource` option works in `tsconfig.json`: https://github.com/microsoft/TypeScript/issues/41623#issuecomment-734050495

This is a breaking change since it reduce the exported API. Some import path to internal files won't work anymore (which is actually a good thing to reduce footprint and enforce better modularity and separation of concerns).
