### PR TITLE
SIA-R16: Make `aria-controls` optional for role `combobox`

### DIFF
--- a/packages/alfa-rules/src/sia-r16/rule.ts
+++ b/packages/alfa-rules/src/sia-r16/rule.ts
@@ -274,12 +274,8 @@ function isAttributeOptional(
   role: aria.Role.Name,
   attribute: aria.Attribute.Name
 ) {
-  if (role === "combobox" && attribute === "aria-controls") {
-    // combobox only requires aria-controls when opened, which we can't detect
-    // same as for sia-r19, @see https://github.com/Siteimprove/alfa/pull/1313
-    // should be refined to look at `aria-expanded` at some point
-    return true;
-  }
-
-  return false;
+  // combobox only requires aria-controls when opened, which we can't detect
+  // same as for sia-r19, @see https://github.com/Siteimprove/alfa/pull/1313
+  // should be refined to look at `aria-expanded` at some point
+  return role === "combobox" && attribute === "aria-controls";
 }

--- a/packages/alfa-rules/src/sia-r16/rule.ts
+++ b/packages/alfa-rules/src/sia-r16/rule.ts
@@ -73,7 +73,8 @@ function hasRequiredValues(
       // ones
       if (
         node.attribute(attribute).every(property("value", isEmpty)) &&
-        !isManagedAttribute(element, role.name, attribute)
+        !isManagedAttribute(element, role.name, attribute) &&
+        !isAttributeOptional(role.name, attribute)
       ) {
         missing.push(attribute);
         result = false;
@@ -263,6 +264,20 @@ function isManagedAttribute(
       element
     )
   ) {
+    return true;
+  }
+
+  return false;
+}
+
+function isAttributeOptional(
+  role: aria.Role.Name,
+  attribute: aria.Attribute.Name
+) {
+  if (role === "combobox" && attribute === "aria-controls") {
+    // combobox only requires aria-controls when opened, which we can't detect
+    // same as for sia-r19, @see https://github.com/Siteimprove/alfa/pull/1313
+    // should be refined to look at `aria-expanded` at some point
     return true;
   }
 

--- a/packages/alfa-rules/test/sia-r16/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r16/rule.spec.tsx
@@ -1,10 +1,7 @@
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
-import R16, {
-  Outcomes,
-  RoleAndRequiredAttributes,
-} from "../../src/sia-r16/rule";
+import R16, { Outcomes } from "../../src/sia-r16/rule";
 
 import { evaluate } from "../common/evaluate";
 import { passed, failed, inapplicable } from "../common/outcome";
@@ -43,6 +40,40 @@ test(`evaluate() passes a focusable <div> element with a role of separator and
   t.deepEqual(await evaluate(R16, { document }), [
     passed(R16, target, {
       1: Outcomes.HasAllStates("separator", ["aria-valuenow"], []),
+    }),
+  ]);
+});
+
+test(`evaluate() passes a <div> element with a role of combobox,
+      aria-expanded value of false and missing aria-controls attribute`, async (t) => {
+  const target = <div role="combobox" aria-expanded="false"></div>;
+
+  const document = h.document([target]);
+
+  t.deepEqual(await evaluate(R16, { document }), [
+    passed(R16, target, {
+      1: Outcomes.HasAllStates(
+        "combobox",
+        ["aria-controls", "aria-expanded"],
+        []
+      ),
+    }),
+  ]);
+});
+
+test(`evaluate() passes a <div> element with a role of combobox,
+aria-expanded value of false and missing aria-controls attribute`, async (t) => {
+  const target = <div role="combobox" aria-expanded="true"></div>;
+
+  const document = h.document([target]);
+
+  t.deepEqual(await evaluate(R16, { document }), [
+    passed(R16, target, {
+      1: Outcomes.HasAllStates(
+        "combobox",
+        ["aria-controls", "aria-expanded"],
+        []
+      ),
     }),
   ]);
 });

--- a/packages/alfa-rules/test/sia-r16/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r16/rule.spec.tsx
@@ -62,7 +62,7 @@ test(`evaluate() passes a <div> element with a role of combobox,
 });
 
 test(`evaluate() passes a <div> element with a role of combobox,
-aria-expanded value of false and missing aria-controls attribute`, async (t) => {
+      aria-expanded value of true and missing aria-controls attribute`, async (t) => {
   const target = <div role="combobox" aria-expanded="true"></div>;
 
   const document = h.document([target]);


### PR DESCRIPTION
Resolves #1340 

Element with role `combobox` and missing `aria-controls` now passes SIA-R16 regardless of the state of `aria-expanded`. In the future we might refine this so that it won't pass when the combobox is open.
