### PR TITLE
Fix bug in whitespace parser due to incorrect use of `Slice` type

### DIFF
--- a/packages/alfa-css/src/syntax/token.ts
+++ b/packages/alfa-css/src/syntax/token.ts
@@ -1350,15 +1350,13 @@ export namespace Token {
 function parseToken<T extends Token>(
   refinement: Refinement<Token, T>
 ): Parser<Slice<Token>, T, string> {
-  return (input) => {
-    const result = input
+  return (input) =>
+    input
       .first()
-      .andThen((token) =>
+      .map((token) =>
         refinement(token)
-          ? Option.of(Ok.of<[Slice<Token>, T]>([input.rest(), token]))
-          : None
-      );
-
-    return result.isSome() ? result.get() : Err.of("Expected token");
-  };
+          ? Ok.of<[Slice<Token>, T]>([input.rest(), token])
+          : Err.of("Mismatching token")
+      )
+      .getOr(Err.of("No token left"));
 }

--- a/packages/alfa-css/src/syntax/token.ts
+++ b/packages/alfa-css/src/syntax/token.ts
@@ -2,11 +2,12 @@ import { Equatable } from "@siteimprove/alfa-equatable";
 import { Serializable } from "@siteimprove/alfa-json";
 import { Parser } from "@siteimprove/alfa-parser";
 import { Predicate } from "@siteimprove/alfa-predicate";
-import { Result, Err } from "@siteimprove/alfa-result";
+import { Result, Err, Ok } from "@siteimprove/alfa-result";
 import { Refinement } from "@siteimprove/alfa-refinement";
 import { Slice } from "@siteimprove/alfa-slice";
 
 import * as json from "@siteimprove/alfa-json";
+import { None, Option } from "@siteimprove/alfa-option";
 
 const { map, oneOrMore } = Parser;
 const { fromCharCode } = String;
@@ -947,7 +948,8 @@ export namespace Token {
   export const parseComma = parseToken(isComma);
 
   export class OpenParenthesis
-    implements Equatable, Serializable<OpenParenthesis.JSON> {
+    implements Equatable, Serializable<OpenParenthesis.JSON>
+  {
     private static _instance = new OpenParenthesis();
 
     public static of(): OpenParenthesis {
@@ -997,7 +999,8 @@ export namespace Token {
   export const parseOpenParenthesis = parseToken(isOpenParenthesis);
 
   export class CloseParenthesis
-    implements Equatable, Serializable<CloseParenthesis.JSON> {
+    implements Equatable, Serializable<CloseParenthesis.JSON>
+  {
     private static _instance = new CloseParenthesis();
 
     public static of(): CloseParenthesis {
@@ -1047,7 +1050,8 @@ export namespace Token {
   export const parseCloseParenthesis = parseToken(isCloseParenthesis);
 
   export class OpenSquareBracket
-    implements Equatable, Serializable<OpenSquareBracket.JSON> {
+    implements Equatable, Serializable<OpenSquareBracket.JSON>
+  {
     private static _instance = new OpenSquareBracket();
 
     public static of(): OpenSquareBracket {
@@ -1092,15 +1096,14 @@ export namespace Token {
     }
   }
 
-  export const {
-    of: openSquareBracket,
-    isOpenSquareBracket,
-  } = OpenSquareBracket;
+  export const { of: openSquareBracket, isOpenSquareBracket } =
+    OpenSquareBracket;
 
   export const parseOpenSquareBracket = parseToken(isOpenSquareBracket);
 
   export class CloseSquareBracket
-    implements Equatable, Serializable<CloseSquareBracket.JSON> {
+    implements Equatable, Serializable<CloseSquareBracket.JSON>
+  {
     private static _instance = new CloseSquareBracket();
 
     public static of(): CloseSquareBracket {
@@ -1145,15 +1148,14 @@ export namespace Token {
     }
   }
 
-  export const {
-    of: closeSquareBracket,
-    isCloseSquareBracket,
-  } = CloseSquareBracket;
+  export const { of: closeSquareBracket, isCloseSquareBracket } =
+    CloseSquareBracket;
 
   export const parseCloseSquareBracket = parseToken(isCloseSquareBracket);
 
   export class OpenCurlyBracket
-    implements Equatable, Serializable<OpenCurlyBracket.JSON> {
+    implements Equatable, Serializable<OpenCurlyBracket.JSON>
+  {
     private static _instance = new OpenCurlyBracket();
 
     public static of(): OpenCurlyBracket {
@@ -1203,7 +1205,8 @@ export namespace Token {
   export const parseOpenCurlyBracket = parseToken(isOpenCurlyBracket);
 
   export class CloseCurlyBracket
-    implements Equatable, Serializable<CloseCurlyBracket.JSON> {
+    implements Equatable, Serializable<CloseCurlyBracket.JSON>
+  {
     private static _instance = new CloseCurlyBracket();
 
     public static of(): CloseCurlyBracket {
@@ -1248,15 +1251,14 @@ export namespace Token {
     }
   }
 
-  export const {
-    of: closeCurlyBracket,
-    isCloseCurlyBracket,
-  } = CloseCurlyBracket;
+  export const { of: closeCurlyBracket, isCloseCurlyBracket } =
+    CloseCurlyBracket;
 
   export const parseCloseCurlyBracket = parseToken(isCloseCurlyBracket);
 
   export class OpenComment
-    implements Equatable, Serializable<OpenComment.JSON> {
+    implements Equatable, Serializable<OpenComment.JSON>
+  {
     private static _instance = new OpenComment();
 
     public static of(): OpenComment {
@@ -1300,7 +1302,8 @@ export namespace Token {
   export const parseOpenComment = parseToken(isOpenComment);
 
   export class CloseComment
-    implements Equatable, Serializable<CloseComment.JSON> {
+    implements Equatable, Serializable<CloseComment.JSON>
+  {
     private static _instance = new CloseComment();
 
     public static of(): CloseComment {
@@ -1348,12 +1351,14 @@ function parseToken<T extends Token>(
   refinement: Refinement<Token, T>
 ): Parser<Slice<Token>, T, string> {
   return (input) => {
-    const token = input.array[input.offset];
+    const result = input
+      .first()
+      .andThen((token) =>
+        refinement(token)
+          ? Option.of(Ok.of<[Slice<Token>, T]>([input.rest(), token]))
+          : None
+      );
 
-    if (token !== undefined && refinement(token)) {
-      return Result.of([input.slice(1), token]);
-    }
-
-    return Err.of("Expected token");
+    return result.isSome() ? result.get() : Err.of("Expected token");
   };
 }

--- a/packages/alfa-css/src/syntax/token.ts
+++ b/packages/alfa-css/src/syntax/token.ts
@@ -2,12 +2,11 @@ import { Equatable } from "@siteimprove/alfa-equatable";
 import { Serializable } from "@siteimprove/alfa-json";
 import { Parser } from "@siteimprove/alfa-parser";
 import { Predicate } from "@siteimprove/alfa-predicate";
-import { Err, Ok } from "@siteimprove/alfa-result";
 import { Refinement } from "@siteimprove/alfa-refinement";
+import { Err, Ok } from "@siteimprove/alfa-result";
 import { Slice } from "@siteimprove/alfa-slice";
 
 import * as json from "@siteimprove/alfa-json";
-import { None, Option } from "@siteimprove/alfa-option";
 
 const { map, oneOrMore } = Parser;
 const { fromCharCode } = String;

--- a/packages/alfa-css/src/syntax/token.ts
+++ b/packages/alfa-css/src/syntax/token.ts
@@ -2,7 +2,7 @@ import { Equatable } from "@siteimprove/alfa-equatable";
 import { Serializable } from "@siteimprove/alfa-json";
 import { Parser } from "@siteimprove/alfa-parser";
 import { Predicate } from "@siteimprove/alfa-predicate";
-import { Result, Err, Ok } from "@siteimprove/alfa-result";
+import { Err, Ok } from "@siteimprove/alfa-result";
 import { Refinement } from "@siteimprove/alfa-refinement";
 import { Slice } from "@siteimprove/alfa-slice";
 

--- a/packages/alfa-css/test/syntax/token.spec.ts
+++ b/packages/alfa-css/test/syntax/token.spec.ts
@@ -11,5 +11,5 @@ test("`parseWhiteSpace` handles empty slice of array with more whitespace after 
   // It should not parse the whitespace after the slice (and go into an infinite loop),
   // but instead return an instance of `Err`.
   const slice = Slice.of([ident("foo"), whitespace()], 1, 1);
-  t.equal(parseWhitespace(slice).getErr(), "Expected token");
+  t.equal(parseWhitespace(slice).getErr(), "No token left");
 });

--- a/packages/alfa-css/test/syntax/token.spec.ts
+++ b/packages/alfa-css/test/syntax/token.spec.ts
@@ -1,0 +1,15 @@
+import { Slice } from "@siteimprove/alfa-slice";
+import { test } from "@siteimprove/alfa-test";
+
+import { Token } from "../../src/syntax/token";
+
+const { ident, whitespace, parseWhitespace } = Token;
+
+test("`parseWhiteSpace` handles empty slice of array with more whitespace after in underlying array", (t) => {
+  // Slice is empty since start = end = 1,
+  // but there is still a whitespace after the slice in the underlying array.
+  // It should not parse the whitespace after the slice (and go into an infinite loop),
+  // but instead return an instance of `Err`.
+  const slice = Slice.of([ident("foo"), whitespace()], 1, 1);
+  t.equal(parseWhitespace(slice).getErr(), "Expected token");
+});

--- a/packages/alfa-css/tsconfig.json
+++ b/packages/alfa-css/tsconfig.json
@@ -64,6 +64,7 @@
     "test/syntax/declaration.spec.ts",
     "test/syntax/lexer.spec.ts",
     "test/syntax/nth.spec.ts",
+    "test/syntax/token.spec.ts",
     "test/value/calculation.spec.ts",
     "test/value/gradient/radial.spec.ts",
     "test/value/math-functions.spec.ts",


### PR DESCRIPTION
Fix to a bug uncovered after the release of [v0.60.0](https://github.com/Siteimprove/alfa/releases/tag/v0.60.0) where parsing whitespace could sometimes go into an infinite loop because of incorrect use of the `Slice` type. More specifically, when parsing an empty slice of an array, with more whitespace tokens in the array after the end of the slice, the parser would try to parse the whitespace after the slice and return the same empty array to be parsed again. This caused the bug because we now parse an unlimited number of whitespaces, instead of just one.