### PR TITLE
Cache descendants of trees

### DIFF
--- a/docs/review/api/alfa-dom.api.md
+++ b/docs/review/api/alfa-dom.api.md
@@ -15,6 +15,7 @@ import { Predicate } from '@siteimprove/alfa-predicate';
 import { Refinement } from '@siteimprove/alfa-refinement';
 import * as sarif from '@siteimprove/alfa-sarif';
 import { Sequence } from '@siteimprove/alfa-sequence';
+import { Sequence as Sequence_2 } from '@siteimprove/alfa-sequence/src/sequence';
 import { Serializable } from '@siteimprove/alfa-json';
 import { Trampoline } from '@siteimprove/alfa-trampoline';
 import * as tree from '@siteimprove/alfa-tree';
@@ -211,6 +212,8 @@ export class Document extends Node<"document"> {
     _attachFrame(frame: Element): boolean;
     // @internal (undocumented)
     _attachParent(): boolean;
+    // (undocumented)
+    elementDescendants(options?: Node.Traversal): Sequence_2<Element>;
     // (undocumented)
     static empty(): Document;
     // (undocumented)
@@ -779,6 +782,8 @@ export namespace NamespaceRule {
 // @public (undocumented)
 export abstract class Node<T extends string = string> extends tree.Node<Node.Traversal.Flag, T> implements earl.Serializable<Node.EARL>, json.Serializable<tree.Node.JSON<T>>, sarif.Serializable<sarif.Location> {
     protected constructor(children: Array<Node>, type: T);
+    // (undocumented)
+    elementDescendants(options?: Node.Traversal): Sequence<Element>;
     // (undocumented)
     equals(value: Node): boolean;
     // (undocumented)

--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -160,7 +160,7 @@ const labels = Cache.empty<Node, Sequence<Element>>();
 const nameFromLabel = (element: Element, device: Device, state: Name.State) => {
   const root = element.root();
 
-  const elements = root.inclusiveDescendants().filter(isElement);
+  const elements = root.elementDescendants();
 
   const isFirstReference = element.id.some((id) =>
     ids

--- a/packages/alfa-aria/src/name.ts
+++ b/packages/alfa-aria/src/name.ts
@@ -2,13 +2,7 @@ import { Array } from "@siteimprove/alfa-array";
 import { Cache } from "@siteimprove/alfa-cache";
 import { Comparable } from "@siteimprove/alfa-comparable";
 import { Device } from "@siteimprove/alfa-device";
-import {
-  Attribute,
-  Document,
-  Element,
-  Node,
-  Text,
-} from "@siteimprove/alfa-dom";
+import { Attribute, Element, Node, Text } from "@siteimprove/alfa-dom";
 import { Equatable } from "@siteimprove/alfa-equatable";
 import { Iterable } from "@siteimprove/alfa-iterable";
 import { Serializable } from "@siteimprove/alfa-json";

--- a/packages/alfa-aria/src/name.ts
+++ b/packages/alfa-aria/src/name.ts
@@ -2,7 +2,13 @@ import { Array } from "@siteimprove/alfa-array";
 import { Cache } from "@siteimprove/alfa-cache";
 import { Comparable } from "@siteimprove/alfa-comparable";
 import { Device } from "@siteimprove/alfa-device";
-import { Attribute, Element, Node, Text } from "@siteimprove/alfa-dom";
+import {
+  Attribute,
+  Document,
+  Element,
+  Node,
+  Text,
+} from "@siteimprove/alfa-dom";
 import { Equatable } from "@siteimprove/alfa-equatable";
 import { Iterable } from "@siteimprove/alfa-iterable";
 import { Serializable } from "@siteimprove/alfa-json";
@@ -892,8 +898,7 @@ export namespace Name {
     // single traversal) and then sort by tokens order rather than grab the ids
     // one by one in the correct order.
     const references = root
-      .descendants()
-      .filter(isElement)
+      .elementDescendants()
       .filter(hasId(equals(...ids)))
       .sortWith((a, b) =>
         Comparable.compareNumber(

--- a/packages/alfa-dom/src/node.ts
+++ b/packages/alfa-dom/src/node.ts
@@ -165,6 +165,14 @@ export abstract class Node<T extends string = string>
     }
   }
 
+  // This does almost nothing but can be overwritten by inherited classes for
+  // specific optimisations.
+  public elementDescendants(
+    options: Node.Traversal = Node.Traversal.empty
+  ): Sequence<Element> {
+    return this.descendants(options).filter(Element.isElement);
+  }
+
   public equals(value: Node): boolean;
 
   public equals(value: unknown): value is this;

--- a/packages/alfa-dom/src/node/document.ts
+++ b/packages/alfa-dom/src/node/document.ts
@@ -1,4 +1,5 @@
 import { None, Option } from "@siteimprove/alfa-option";
+import { Sequence } from "@siteimprove/alfa-sequence/src/sequence";
 import { Trampoline } from "@siteimprove/alfa-trampoline";
 
 import { Node } from "../node";
@@ -35,6 +36,24 @@ export class Document extends Node<"document"> {
 
   public get frame(): Option<Element> {
     return this._frame;
+  }
+
+  private _elementDescendants: Array<Sequence<Element>> = [];
+  /**
+   * {@link https://dom.spec.whatwg.org/#concept-tree-descendant}
+   */
+  // We very often need all elements in a document, typically at the start of
+  // a rule Applicability. Caching the filtering saves a lot of time.
+  public elementDescendants(
+    options: Node.Traversal = Node.Traversal.empty
+  ): Sequence<Element> {
+    if (this._elementDescendants[options.value] === undefined) {
+      this._elementDescendants[options.value] = this.descendants(
+        options
+      ).filter(Element.isElement);
+    }
+
+    return this._elementDescendants[options.value];
   }
 
   public parent(options: Node.Traversal = Node.Traversal.empty): Option<Node> {

--- a/packages/alfa-rules/src/common/applicability/audio.ts
+++ b/packages/alfa-rules/src/common/applicability/audio.ts
@@ -19,8 +19,7 @@ export function audio(
   options: audio.Options = {}
 ): Iterable<Interview<Question.Metadata, Element, Element, Option<Element>>> {
   return document
-    .descendants(Node.fullTree)
-    .filter(isElement)
+    .elementDescendants(Node.fullTree)
     .filter(
       // Non-rendered <audio> are not playing
       and(hasNamespace(Namespace.HTML), hasName("audio"), isRendered(device))

--- a/packages/alfa-rules/src/common/applicability/video.ts
+++ b/packages/alfa-rules/src/common/applicability/video.ts
@@ -19,8 +19,7 @@ export function video(
   const { audio, track } = options;
 
   return document
-    .descendants(Node.fullTree)
-    .filter(isElement)
+    .elementDescendants(Node.fullTree)
     .filter(
       and(
         hasNamespace(Namespace.HTML),

--- a/packages/alfa-rules/src/sia-er18/rule.ts
+++ b/packages/alfa-rules/src/sia-er18/rule.ts
@@ -28,8 +28,7 @@ export default Rule.Atomic.of<Page, Attribute>({
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(isIncludedInTheAccessibilityTree(device))
           .flatMap((element) =>
             Sequence.from(element.attributes).filter(

--- a/packages/alfa-rules/src/sia-er87/rule.ts
+++ b/packages/alfa-rules/src/sia-er87/rule.ts
@@ -107,8 +107,7 @@ export default Rule.Atomic.of<Page, Document, Question.Metadata, Element>({
             url.fragment.flatMap((fragment) =>
               element
                 .root()
-                .inclusiveDescendants()
-                .filter(isElement)
+                .elementDescendants()
                 .find((element) => element.id.includes(fragment))
             )
           );

--- a/packages/alfa-rules/src/sia-r1/rule.ts
+++ b/packages/alfa-rules/src/sia-r1/rule.ts
@@ -34,8 +34,7 @@ export default Rule.Atomic.of<Page, Document>({
 
       expectations(target) {
         const title = target
-          .descendants()
-          .filter(isElement)
+          .elementDescendants()
           .find(and(hasNamespace(Namespace.HTML), hasName("title")));
 
         return {

--- a/packages/alfa-rules/src/sia-r10/rule.ts
+++ b/packages/alfa-rules/src/sia-r10/rule.ts
@@ -33,8 +33,7 @@ export default Rule.Atomic.of<Page, Attribute>({
       applicability() {
         return (
           document
-            .descendants(dom.Node.fullTree)
-            .filter(isElement)
+            .elementDescendants(dom.Node.fullTree)
             .filter(
               and(
                 hasNamespace(Namespace.HTML),

--- a/packages/alfa-rules/src/sia-r11/rule.ts
+++ b/packages/alfa-rules/src/sia-r11/rule.ts
@@ -27,16 +27,13 @@ export default Rule.Atomic.of<Page, Element>({
   evaluate({ device, document }) {
     return {
       applicability() {
-        return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
-          .filter(
-            and(
-              hasNamespace(Namespace.HTML),
-              hasRole(device, (role) => role.is("link")),
-              isIncludedInTheAccessibilityTree(device)
-            )
-          );
+        return document.elementDescendants(Node.fullTree).filter(
+          and(
+            hasNamespace(Namespace.HTML),
+            hasRole(device, (role) => role.is("link")),
+            isIncludedInTheAccessibilityTree(device)
+          )
+        );
       },
 
       expectations(target) {

--- a/packages/alfa-rules/src/sia-r110/rule.ts
+++ b/packages/alfa-rules/src/sia-r110/rule.ts
@@ -27,8 +27,7 @@ export default Rule.Atomic.of<Page, Attribute>({
       applicability() {
         return (
           document
-            .descendants(Node.fullTree)
-            .filter(isElement)
+            .elementDescendants(Node.fullTree)
             .filter(
               and(
                 hasNamespace(Namespace.HTML, Namespace.SVG),

--- a/packages/alfa-rules/src/sia-r12/rule.ts
+++ b/packages/alfa-rules/src/sia-r12/rule.ts
@@ -23,8 +23,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(
             and(
               not(hasInputType("image")),

--- a/packages/alfa-rules/src/sia-r13/rule.ts
+++ b/packages/alfa-rules/src/sia-r13/rule.ts
@@ -22,8 +22,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(
             and(
               hasNamespace(Namespace.HTML),

--- a/packages/alfa-rules/src/sia-r14/rule.ts
+++ b/packages/alfa-rules/src/sia-r14/rule.ts
@@ -29,28 +29,25 @@ export default Rule.Atomic.of<Page, Element>({
   evaluate({ device, document }) {
     return {
       applicability() {
-        return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
-          .filter(
-            and(
-              hasNamespace(Namespace.HTML, Namespace.SVG),
-              hasAttribute(
-                (attribute) =>
-                  attribute.name === "aria-label" ||
-                  attribute.name === "aria-labelledby"
-              ),
-              isFocusable(device),
-              hasRole(
-                device,
-                (role) => role.isWidget() && role.isNamedBy("contents")
-              ),
-              hasDescendant(
-                and(Text.isText, isPerceivableForAll(device)),
-                Node.flatTree
-              )
+        return document.elementDescendants(Node.fullTree).filter(
+          and(
+            hasNamespace(Namespace.HTML, Namespace.SVG),
+            hasAttribute(
+              (attribute) =>
+                attribute.name === "aria-label" ||
+                attribute.name === "aria-labelledby"
+            ),
+            isFocusable(device),
+            hasRole(
+              device,
+              (role) => role.isWidget() && role.isNamedBy("contents")
+            ),
+            hasDescendant(
+              and(Text.isText, isPerceivableForAll(device)),
+              Node.flatTree
             )
-          );
+          )
+        );
       },
 
       expectations(target) {

--- a/packages/alfa-rules/src/sia-r15/rule.ts
+++ b/packages/alfa-rules/src/sia-r15/rule.ts
@@ -29,8 +29,7 @@ export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
     return {
       applicability() {
         return document
-          .descendants(dom.Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(dom.Node.fullTree)
           .filter(
             and(
               hasName("iframe"),

--- a/packages/alfa-rules/src/sia-r16/rule.ts
+++ b/packages/alfa-rules/src/sia-r16/rule.ts
@@ -34,8 +34,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(Node.composedNested)
-          .filter(isElement)
+          .elementDescendants(Node.composedNested)
           .filter(
             and(hasNamespace(Namespace.HTML, Namespace.SVG), hasNonDefaultRole)
           )

--- a/packages/alfa-rules/src/sia-r17/rule.ts
+++ b/packages/alfa-rules/src/sia-r17/rule.ts
@@ -25,8 +25,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(hasAttribute("aria-hidden", equals("true")));
       },
 

--- a/packages/alfa-rules/src/sia-r18/rule.ts
+++ b/packages/alfa-rules/src/sia-r18/rule.ts
@@ -28,8 +28,7 @@ export default Rule.Atomic.of<Page, Attribute>({
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(isIncludedInTheAccessibilityTree(device))
           .flatMap((element) =>
             Sequence.from(element.attributes).filter(

--- a/packages/alfa-rules/src/sia-r19/rule.ts
+++ b/packages/alfa-rules/src/sia-r19/rule.ts
@@ -26,8 +26,7 @@ export default Rule.Atomic.of<Page, Attribute>({
     return {
       applicability() {
         return document
-          .descendants(Node.composedNested)
-          .filter(isElement)
+          .elementDescendants(Node.composedNested)
           .filter(hasNamespace(Namespace.HTML, Namespace.SVG))
           .flatMap((element) =>
             Sequence.from(element.attributes).filter(
@@ -121,8 +120,7 @@ function treeHasId(id: string, node: Node): boolean {
       Set.from(
         node
           .root()
-          .descendants()
-          .filter(isElement)
+          .elementDescendants()
           .collect((element) => element.id)
       )
     )

--- a/packages/alfa-rules/src/sia-r2/rule.ts
+++ b/packages/alfa-rules/src/sia-r2/rule.ts
@@ -27,8 +27,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(
             and(
               hasNamespace(Namespace.HTML),

--- a/packages/alfa-rules/src/sia-r20/rule.ts
+++ b/packages/alfa-rules/src/sia-r20/rule.ts
@@ -18,8 +18,7 @@ export default Rule.Atomic.of<Page, Attribute>({
     return {
       applicability() {
         return document
-          .descendants(Node.composedNested)
-          .filter(isElement)
+          .elementDescendants(Node.composedNested)
           .flatMap((element) =>
             Sequence.from(element.attributes).filter((attribute) =>
               attribute.name.startsWith("aria-")

--- a/packages/alfa-rules/src/sia-r21/rule.ts
+++ b/packages/alfa-rules/src/sia-r21/rule.ts
@@ -23,8 +23,7 @@ export default Rule.Atomic.of<Page, Attribute>({
       applicability() {
         return (
           document
-            .descendants(Node.fullTree)
-            .filter(isElement)
+            .elementDescendants(Node.fullTree)
             .filter(
               and(
                 hasNamespace(Namespace.HTML, Namespace.SVG),

--- a/packages/alfa-rules/src/sia-r28/rule.ts
+++ b/packages/alfa-rules/src/sia-r28/rule.ts
@@ -27,8 +27,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(
             and(
               hasNamespace(Namespace.HTML),

--- a/packages/alfa-rules/src/sia-r3/rule.ts
+++ b/packages/alfa-rules/src/sia-r3/rule.ts
@@ -22,8 +22,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(Node.composedNested)
-          .filter(isElement)
+          .elementDescendants(Node.composedNested)
           .filter(hasId(not(isEmpty)));
       },
 

--- a/packages/alfa-rules/src/sia-r39/rule.ts
+++ b/packages/alfa-rules/src/sia-r39/rule.ts
@@ -26,30 +26,27 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
   evaluate({ device, document }) {
     return {
       applicability() {
-        return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
-          .filter(
-            and(
-              hasNamespace(Namespace.HTML),
-              or(hasName("img"), and(hasName("input"), hasInputType("image"))),
-              isIncludedInTheAccessibilityTree(device),
-              (element) =>
-                test(
-                  hasAccessibleName(device, (accessibleName) =>
-                    element
-                      .attribute("src")
-                      .map((attr) => getFilename(attr.value))
-                      .some(
-                        (filename) =>
-                          filename.toLowerCase() ===
-                          accessibleName.value.toLowerCase().trim()
-                      )
-                  ),
+        return document.elementDescendants(Node.fullTree).filter(
+          and(
+            hasNamespace(Namespace.HTML),
+            or(hasName("img"), and(hasName("input"), hasInputType("image"))),
+            isIncludedInTheAccessibilityTree(device),
+            (element) =>
+              test(
+                hasAccessibleName(device, (accessibleName) =>
                   element
-                )
-            )
-          );
+                    .attribute("src")
+                    .map((attr) => getFilename(attr.value))
+                    .some(
+                      (filename) =>
+                        filename.toLowerCase() ===
+                        accessibleName.value.toLowerCase().trim()
+                    )
+                ),
+                element
+              )
+          )
+        );
       },
 
       expectations(target) {

--- a/packages/alfa-rules/src/sia-r40/rule.ts
+++ b/packages/alfa-rules/src/sia-r40/rule.ts
@@ -26,8 +26,7 @@ export default Rule.Atomic.of<Page, Element>({
       applicability() {
         return (
           document
-            .descendants(Node.fullTree)
-            .filter(isElement)
+            .elementDescendants(Node.fullTree)
             .filter(
               and(
                 hasRole(device, (role) => role.is("region")),

--- a/packages/alfa-rules/src/sia-r41/rule.ts
+++ b/packages/alfa-rules/src/sia-r41/rule.ts
@@ -31,8 +31,7 @@ export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
     return {
       applicability() {
         return document
-          .descendants(dom.Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(dom.Node.fullTree)
           .filter(
             and(
               hasNamespace(Namespace.HTML, Namespace.SVG),

--- a/packages/alfa-rules/src/sia-r42/rule.ts
+++ b/packages/alfa-rules/src/sia-r42/rule.ts
@@ -25,16 +25,13 @@ export default Rule.Atomic.of<Page, Element>({
   evaluate({ device, document }) {
     return {
       applicability() {
-        return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
-          .filter(
-            and(
-              hasNamespace(Namespace.HTML, Namespace.SVG),
-              isIncludedInTheAccessibilityTree(device),
-              hasRole(device, (role) => role.hasRequiredParent())
-            )
-          );
+        return document.elementDescendants(Node.fullTree).filter(
+          and(
+            hasNamespace(Namespace.HTML, Namespace.SVG),
+            isIncludedInTheAccessibilityTree(device),
+            hasRole(device, (role) => role.hasRequiredParent())
+          )
+        );
       },
 
       expectations(target) {

--- a/packages/alfa-rules/src/sia-r43/rule.ts
+++ b/packages/alfa-rules/src/sia-r43/rule.ts
@@ -26,8 +26,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(
             and(
               hasNamespace(Namespace.SVG),

--- a/packages/alfa-rules/src/sia-r44/rule.ts
+++ b/packages/alfa-rules/src/sia-r44/rule.ts
@@ -58,8 +58,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(isVisible(device))
           .filter(
             or(

--- a/packages/alfa-rules/src/sia-r46/rule.ts
+++ b/packages/alfa-rules/src/sia-r46/rule.ts
@@ -26,8 +26,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       *applicability() {
         const tables = document
-          .descendants()
-          .filter(isElement)
+          .elementDescendants()
           .filter(
             and(
               hasNamespace(Namespace.HTML),
@@ -40,8 +39,7 @@ export default Rule.Atomic.of<Page, Element>({
           const model = Table.from(table);
 
           const headers = table
-            .descendants()
-            .filter(isElement)
+            .elementDescendants()
             .filter(
               and(
                 hasNamespace(Namespace.HTML),

--- a/packages/alfa-rules/src/sia-r47/rule.ts
+++ b/packages/alfa-rules/src/sia-r47/rule.ts
@@ -35,8 +35,7 @@ export default Rule.Atomic.of<Page, Element>({
       applicability() {
         return (
           document
-            .descendants()
-            .filter(isElement)
+            .elementDescendants()
             .filter(
               and(
                 hasNamespace(Namespace.HTML),

--- a/packages/alfa-rules/src/sia-r48/rule.ts
+++ b/packages/alfa-rules/src/sia-r48/rule.ts
@@ -24,8 +24,7 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
     return {
       applicability() {
         return document
-          .descendants(Node.composedNested)
-          .filter(isElement)
+          .elementDescendants(Node.composedNested)
           .filter(
             and(
               hasNamespace(Namespace.HTML),

--- a/packages/alfa-rules/src/sia-r49/rule.ts
+++ b/packages/alfa-rules/src/sia-r49/rule.ts
@@ -26,8 +26,7 @@ export default Rule.Atomic.of<Page, Element, Question.Metadata>({
     return {
       applicability() {
         return document
-          .descendants(Node.composedNested)
-          .filter(isElement)
+          .elementDescendants(Node.composedNested)
           .filter(
             and(
               hasNamespace(Namespace.HTML),

--- a/packages/alfa-rules/src/sia-r53/rule.ts
+++ b/packages/alfa-rules/src/sia-r53/rule.ts
@@ -19,8 +19,7 @@ export default Rule.Atomic.of<Page, Element>({
   tags: [Scope.Component],
   evaluate({ device, document }) {
     const headings = document
-      .descendants(Node.flatTree)
-      .filter(isElement)
+      .elementDescendants(Node.flatTree)
       .filter(
         and(
           hasRole(device, "heading"),

--- a/packages/alfa-rules/src/sia-r54/rule.ts
+++ b/packages/alfa-rules/src/sia-r54/rule.ts
@@ -20,16 +20,13 @@ export default Rule.Atomic.of<Page, Element>({
   evaluate({ device, document }) {
     return {
       applicability() {
-        return document
-          .descendants(dom.Node.fullTree)
-          .filter(isElement)
-          .filter(
-            and(isIncludedInTheAccessibilityTree(device), (element) =>
-              Node.from(element, device)
-                .attribute("aria-live")
-                .some((attribute) => attribute.value === "assertive")
-            )
-          );
+        return document.elementDescendants(dom.Node.fullTree).filter(
+          and(isIncludedInTheAccessibilityTree(device), (element) =>
+            Node.from(element, device)
+              .attribute("aria-live")
+              .some((attribute) => attribute.value === "assertive")
+          )
+        );
       },
 
       expectations(target) {

--- a/packages/alfa-rules/src/sia-r55/rule.ts
+++ b/packages/alfa-rules/src/sia-r55/rule.ts
@@ -33,8 +33,7 @@ export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
       applicability() {
         return (
           document
-            .descendants(dom.Node.fullTree)
-            .filter(isElement)
+            .elementDescendants(dom.Node.fullTree)
             .filter(
               and(
                 hasNamespace(equals(Namespace.HTML)),

--- a/packages/alfa-rules/src/sia-r56/rule.ts
+++ b/packages/alfa-rules/src/sia-r56/rule.ts
@@ -34,8 +34,7 @@ export default Rule.Atomic.of<Page, Group<Element>>({
       applicability() {
         return (
           document
-            .descendants(dom.Node.fullTree)
-            .filter(isElement)
+            .elementDescendants(dom.Node.fullTree)
             .filter(
               and(
                 hasNamespace(equals(Namespace.HTML)),

--- a/packages/alfa-rules/src/sia-r57/rule.ts
+++ b/packages/alfa-rules/src/sia-r57/rule.ts
@@ -38,10 +38,8 @@ export default Rule.Atomic.of<Page, Text>({
 
     return {
       *applicability() {
-        const descendants = document.descendants(dom.Node.fullTree);
-
         if (
-          descendants.filter(isElement).some(
+          document.elementDescendants(dom.Node.fullTree).some(
             and(
               hasRole(device, (role) => role.isLandmark()),
               // Circumventing https://github.com/Siteimprove/alfa/issues/298
@@ -49,7 +47,8 @@ export default Rule.Atomic.of<Page, Text>({
             )
           )
         ) {
-          yield* descendants
+          yield* document
+            .descendants(dom.Node.fullTree)
             .filter(isText)
             .filter(
               and(

--- a/packages/alfa-rules/src/sia-r59/rule.ts
+++ b/packages/alfa-rules/src/sia-r59/rule.ts
@@ -26,8 +26,7 @@ export default Rule.Atomic.of<Page, Document>({
 
       expectations(target) {
         const hasHeadings = target
-          .descendants(Node.flatTree)
-          .filter(isElement)
+          .elementDescendants(Node.flatTree)
           .some(and(hasNamespace(Namespace.HTML), hasRole(device, "heading")));
 
         return {

--- a/packages/alfa-rules/src/sia-r63/rule.ts
+++ b/packages/alfa-rules/src/sia-r63/rule.ts
@@ -22,8 +22,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(
             and(
               hasNamespace(Namespace.HTML),

--- a/packages/alfa-rules/src/sia-r64/rule.ts
+++ b/packages/alfa-rules/src/sia-r64/rule.ts
@@ -23,8 +23,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(
             and(
               hasNamespace(Namespace.HTML),

--- a/packages/alfa-rules/src/sia-r67/rule.ts
+++ b/packages/alfa-rules/src/sia-r67/rule.ts
@@ -23,8 +23,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(dom.Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(dom.Node.fullTree)
           .filter(
             and(
               or(

--- a/packages/alfa-rules/src/sia-r7/rule.ts
+++ b/packages/alfa-rules/src/sia-r7/rule.ts
@@ -73,8 +73,7 @@ export default Rule.Atomic.of<Page, Attribute>({
         }
 
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(and(hasNamespace(Namespace.HTML), hasName("body")))
           .flatMap((element) => Sequence.from(visit(element, None)))
           .distinct();

--- a/packages/alfa-rules/src/sia-r70/rule.ts
+++ b/packages/alfa-rules/src/sia-r70/rule.ts
@@ -59,8 +59,7 @@ export default Rule.Atomic.of<Page, Document>({
 
       expectations(target) {
         const deprecatedElements = target
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(
             and(hasNamespace(Namespace.HTML), isDeprecated, isRendered(device))
           );

--- a/packages/alfa-rules/src/sia-r71/rule.ts
+++ b/packages/alfa-rules/src/sia-r71/rule.ts
@@ -24,8 +24,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(and(hasRole(device, "paragraph"), isVisible(device)));
       },
 

--- a/packages/alfa-rules/src/sia-r72/rule.ts
+++ b/packages/alfa-rules/src/sia-r72/rule.ts
@@ -22,8 +22,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(and(hasRole(device, "paragraph"), isVisible(device)));
       },
 

--- a/packages/alfa-rules/src/sia-r73/rule.ts
+++ b/packages/alfa-rules/src/sia-r73/rule.ts
@@ -23,8 +23,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(and(hasRole(device, "paragraph"), isVisible(device)));
       },
 

--- a/packages/alfa-rules/src/sia-r74/rule.ts
+++ b/packages/alfa-rules/src/sia-r74/rule.ts
@@ -24,29 +24,26 @@ export default Rule.Atomic.of<Page, Element>({
   evaluate({ device, document }) {
     return {
       applicability() {
-        return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
-          .filter(
-            and(
-              hasRole(device, "paragraph"),
-              (element) =>
-                Style.from(element, device)
-                  .cascaded("font-size")
-                  .some(({ value: fontSize }) => {
-                    switch (fontSize.type) {
-                      case "length":
-                      case "percentage":
-                        return fontSize.value > 0;
+        return document.elementDescendants(Node.fullTree).filter(
+          and(
+            hasRole(device, "paragraph"),
+            (element) =>
+              Style.from(element, device)
+                .cascaded("font-size")
+                .some(({ value: fontSize }) => {
+                  switch (fontSize.type) {
+                    case "length":
+                    case "percentage":
+                      return fontSize.value > 0;
 
-                      default:
-                        return true;
-                    }
-                  }),
-              Node.hasTextContent(),
-              isVisible(device)
-            )
-          );
+                    default:
+                      return true;
+                  }
+                }),
+            Node.hasTextContent(),
+            isVisible(device)
+          )
+        );
       },
 
       expectations(target) {

--- a/packages/alfa-rules/src/sia-r75/rule.ts
+++ b/packages/alfa-rules/src/sia-r75/rule.ts
@@ -28,31 +28,28 @@ export default Rule.Atomic.of<Page, Element>({
   evaluate({ device, document }) {
     return {
       applicability() {
-        return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
-          .filter(
-            and(
-              hasNamespace(Namespace.HTML),
-              not(hasName("sup", "sub")),
-              Node.hasTextContent(),
-              isVisible(device),
-              hasCascadedStyle(
-                `font-size`,
-                (fontSize) => {
-                  switch (fontSize.type) {
-                    case "length":
-                    case "percentage":
-                      return fontSize.value > 0;
+        return document.elementDescendants(Node.fullTree).filter(
+          and(
+            hasNamespace(Namespace.HTML),
+            not(hasName("sup", "sub")),
+            Node.hasTextContent(),
+            isVisible(device),
+            hasCascadedStyle(
+              `font-size`,
+              (fontSize) => {
+                switch (fontSize.type) {
+                  case "length":
+                  case "percentage":
+                    return fontSize.value > 0;
 
-                    default:
-                      return true;
-                  }
-                },
-                device
-              )
+                  default:
+                    return true;
+                }
+              },
+              device
             )
-          );
+          )
+        );
       },
 
       expectations(target) {

--- a/packages/alfa-rules/src/sia-r77/rule.ts
+++ b/packages/alfa-rules/src/sia-r77/rule.ts
@@ -26,8 +26,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       *applicability() {
         const tables = document
-          .descendants()
-          .filter(isElement)
+          .elementDescendants()
           .filter(
             and(
               hasNamespace(Namespace.HTML),
@@ -44,8 +43,7 @@ export default Rule.Atomic.of<Page, Element>({
           }
 
           const dataCells = table
-            .descendants()
-            .filter(isElement)
+            .elementDescendants()
             .filter(
               and(
                 hasNamespace(Namespace.HTML),

--- a/packages/alfa-rules/src/sia-r79/rule.ts
+++ b/packages/alfa-rules/src/sia-r79/rule.ts
@@ -23,9 +23,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(and(hasName("pre"), isRendered(device)));
       },
 

--- a/packages/alfa-rules/src/sia-r8/rule.ts
+++ b/packages/alfa-rules/src/sia-r8/rule.ts
@@ -23,8 +23,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(
             and(
               hasNamespace(Namespace.HTML),

--- a/packages/alfa-rules/src/sia-r80/rule.ts
+++ b/packages/alfa-rules/src/sia-r80/rule.ts
@@ -25,8 +25,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(
             and(
               hasRole(device, "paragraph"),

--- a/packages/alfa-rules/src/sia-r81/rule.ts
+++ b/packages/alfa-rules/src/sia-r81/rule.ts
@@ -38,8 +38,7 @@ export default Rule.Atomic.of<Page, Group<Element>, Question.Metadata>({
         // This creates two separate targets and we must take care of not
         // colliding them.
         const map = document
-          .descendants(dom.Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(dom.Node.fullTree)
           .filter(
             and(
               hasNamespace(Namespace.HTML, Namespace.SVG),
@@ -143,8 +142,7 @@ function linkContext(element: Element, device: Device): Set<dom.Node> {
   for (const describedby of element.attribute("aria-describedby")) {
     for (const reference of element
       .root()
-      .descendants()
-      .filter(isElement)
+      .elementDescendants()
       .filter(hasId(equals(...describedby.tokens())))) {
       context = context.add(reference);
     }

--- a/packages/alfa-rules/src/sia-r82/rule.ts
+++ b/packages/alfa-rules/src/sia-r82/rule.ts
@@ -38,8 +38,7 @@ export default Rule.Atomic.of<
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(
             and(
               hasNamespace(Namespace.HTML),

--- a/packages/alfa-rules/src/sia-r84/rule.ts
+++ b/packages/alfa-rules/src/sia-r84/rule.ts
@@ -29,8 +29,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(
             and(
               hasNamespace(Namespace.HTML),

--- a/packages/alfa-rules/src/sia-r85/rule.ts
+++ b/packages/alfa-rules/src/sia-r85/rule.ts
@@ -22,8 +22,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(and(hasRole(device, "paragraph"), isVisible(device)));
       },
 

--- a/packages/alfa-rules/src/sia-r86/rule.ts
+++ b/packages/alfa-rules/src/sia-r86/rule.ts
@@ -18,8 +18,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(isMarkedDecorative);
       },
 

--- a/packages/alfa-rules/src/sia-r87/rule.ts
+++ b/packages/alfa-rules/src/sia-r87/rule.ts
@@ -62,8 +62,7 @@ export default Rule.Atomic.of<Page, Document, Question.Metadata>({
             url.fragment.flatMap((fragment) =>
               element
                 .root()
-                .inclusiveDescendants()
-                .filter(isElement)
+                .elementDescendants()
                 .find((element) => element.id.includes(fragment))
             )
           );

--- a/packages/alfa-rules/src/sia-r9/rule.ts
+++ b/packages/alfa-rules/src/sia-r9/rule.ts
@@ -31,8 +31,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants()
-          .filter(isElement)
+          .elementDescendants()
           .find(
             and(
               hasNamespace(Namespace.HTML),

--- a/packages/alfa-rules/src/sia-r94/rule.ts
+++ b/packages/alfa-rules/src/sia-r94/rule.ts
@@ -23,8 +23,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(
             and(
               hasNamespace(Namespace.HTML),

--- a/packages/alfa-rules/src/sia-r95/rule.ts
+++ b/packages/alfa-rules/src/sia-r95/rule.ts
@@ -34,15 +34,13 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants(Node.fullTree)
-          .filter(isElement)
+          .elementDescendants(Node.fullTree)
           .filter(and(hasNamespace(Namespace.HTML), hasName("iframe")))
           .filter((iframe) =>
             iframe.content
               .map((contentDocument) =>
                 contentDocument
-                  .descendants(Node.flatTree)
-                  .filter(isElement)
+                  .elementDescendants(Node.flatTree)
                   .filter(and(isVisible(device), isTabbable(device)))
               )
               .some((sequence) => {

--- a/packages/alfa-rules/src/sia-r96/rule.ts
+++ b/packages/alfa-rules/src/sia-r96/rule.ts
@@ -29,8 +29,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         return document
-          .descendants()
-          .filter(isElement)
+          .elementDescendants()
           .find(
             and(
               hasNamespace(Namespace.HTML),

--- a/packages/alfa-tree/src/tree.ts
+++ b/packages/alfa-tree/src/tree.ts
@@ -104,13 +104,14 @@ export abstract class Node<
   // if necessary. Once the tree is fully frozen, this only cost an extra look
   // through this.parent which is not expensive.
   public root(options?: Flags<F>): Node<F> {
-    let lastKnownRoot = this._lastKnownRoot[options?.value ?? 0] ?? this;
+    const value = options?.value ?? 0;
+    let lastKnownRoot = this._lastKnownRoot[value] ?? this;
 
     for (const parent of lastKnownRoot.parent(options)) {
       lastKnownRoot = parent.root(options);
     }
 
-    this._lastKnownRoot[options?.value ?? 0] = lastKnownRoot;
+    this._lastKnownRoot[value] = lastKnownRoot;
     return lastKnownRoot;
   }
 
@@ -143,17 +144,17 @@ export abstract class Node<
   // walk through the tree and resolve all the continuations.
   // Caching it saves a lot of time by generating the sequence only once.
   public descendants(options?: Flags<F>): Sequence<Node<F>> {
-    if (this._descendants[options?.value ?? 0] === undefined) {
-      this._descendants[options?.value ?? 0] = this.children(options).flatMap(
-        (child) =>
-          Sequence.of(
-            child,
-            Lazy.of(() => child.descendants(options))
-          )
+    const value = options?.value ?? 0;
+    if (this._descendants[value] === undefined) {
+      this._descendants[value] = this.children(options).flatMap((child) =>
+        Sequence.of(
+          child,
+          Lazy.of(() => child.descendants(options))
+        )
       );
     }
 
-    return this._descendants[options?.value ?? 0];
+    return this._descendants[value];
   }
 
   /**
@@ -258,13 +259,14 @@ export abstract class Node<
   // Due to reversing, this is not lazy and is costly at build time.
   // This only looks in frozen parts of the tree.
   public preceding(options?: Flags<F>): Sequence<Node<F>> {
-    if (this._preceding[options?.value ?? 0] === undefined) {
-      this._preceding[options?.value ?? 0] = this.inclusiveSiblings(options)
+    const value = options?.value ?? 0;
+    if (this._preceding[value] === undefined) {
+      this._preceding[value] = this.inclusiveSiblings(options)
         .takeUntil(equals(this))
         .reverse();
     }
 
-    return this._preceding[options?.value ?? 0];
+    return this._preceding[value];
   }
 
   private _following: Array<Sequence<Node<F>>> = [];
@@ -275,13 +277,14 @@ export abstract class Node<
   // Due to skipUntil, this is not fully lazy and is costly at build time.
   // This only looks in frozen parts of the tree.
   public following(options?: Flags<F>): Sequence<Node<F>> {
-    if (this._following[options?.value ?? 0] === undefined) {
-      this._following[options?.value ?? 0] = this.inclusiveSiblings(options)
+    const value = options?.value ?? 0;
+    if (this._following[value] === undefined) {
+      this._following[value] = this.inclusiveSiblings(options)
         .skipUntil(equals(this))
         .rest();
     }
 
-    return this._following[options?.value ?? 0];
+    return this._following[value];
   }
 
   /**
@@ -300,11 +303,12 @@ export abstract class Node<
   // Due to last, this is not lazy and is costly at build time.
   // This only looks in frozen parts of the tree.
   public last(options?: Flags<F>): Option<Node<F>> {
-    if (this._last[options?.value ?? 0] === undefined) {
-      this._last[options?.value ?? 0] = this.children(options).last();
+    const value = options?.value ?? 0;
+    if (this._last[value] === undefined) {
+      this._last[value] = this.children(options).last();
     }
 
-    return this._last[options?.value ?? 0];
+    return this._last[value];
   }
 
   /**


### PR DESCRIPTION
* Cache `Node.descendants()` in `alfa-tree`. This is a common use case; even if the sequence is lazy, actually building it requires recursing through the full tree, which takes time.
* Cache (and create) `Document.elementDescendants`. Many rules, and some other piece of code, gather all elements of a DOM tree, this saves a lot of time.
