### PR TITLE
SIA-R13: ignore `<iframe>` with negative `tabindex`

### DIFF
--- a/packages/alfa-rules/src/sia-r13/rule.ts
+++ b/packages/alfa-rules/src/sia-r13/rule.ts
@@ -11,8 +11,8 @@ import { expectation } from "../common/act/expectation";
 import { Scope } from "../tags";
 
 const { hasNonEmptyAccessibleName, isIncludedInTheAccessibilityTree } = DOM;
-const { hasName, hasNamespace } = Element;
-const { and } = Predicate;
+const { hasName, hasNamespace, hasTabIndex } = Element;
+const { and, not } = Predicate;
 
 export default Rule.Atomic.of<Page, Element>({
   uri: "https://alfa.siteimprove.com/rules/sia-r13",
@@ -27,7 +27,8 @@ export default Rule.Atomic.of<Page, Element>({
             and(
               hasNamespace(Namespace.HTML),
               hasName("iframe"),
-              isIncludedInTheAccessibilityTree(device)
+              isIncludedInTheAccessibilityTree(device),
+              not(hasTabIndex((n) => n < 0))
             )
           );
       },

--- a/packages/alfa-rules/test/sia-r13/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r13/rule.spec.tsx
@@ -62,3 +62,11 @@ test("evaluate() is inapplicable to a document without <iframe> elements", async
 
   t.deepEqual(await evaluate(R13, { document }), [inapplicable(R13)]);
 });
+
+test(`evaluates() is inapplicable to an <iframe> with negative tabindex`, async (t) => {
+  const target = <iframe title="iframe" srcdoc="Hello World!" tabindex="-1" />;
+
+  const document = h.document([target]);
+
+  t.deepEqual(await evaluate(R13, { document }), [inapplicable(R13)]);
+});


### PR DESCRIPTION
Resolves #1380 
