### PR TITLE
Rename `isAriaControlsRequired` -> `isAriaControlsOpitonal`

### DIFF
--- a/.changeset/purple-cats-applaud.md
+++ b/.changeset/purple-cats-applaud.md
@@ -1,0 +1,7 @@
+---
+"@siteimprove/alfa-rules": patch
+---
+
+Rename isAriaControlsRequired to isAriaControlsOptional
+
+This matches the actual behavior of the function.

--- a/packages/alfa-rules/src/common/predicate/is-aria-controls-optional.ts
+++ b/packages/alfa-rules/src/common/predicate/is-aria-controls-optional.ts
@@ -14,7 +14,7 @@ const { and } = Predicate;
  *
  * @internal
  */
-export const isAriaControlsRequired = and(
+export const isAriaControlsOptional = and(
   hasRole("combobox"),
   hasAttribute("aria-expanded", (expanded) => expanded !== "true")
 );

--- a/packages/alfa-rules/src/sia-r16/rule.ts
+++ b/packages/alfa-rules/src/sia-r16/rule.ts
@@ -12,7 +12,7 @@ import { Criterion, Technique } from "@siteimprove/alfa-wcag";
 import { Page } from "@siteimprove/alfa-web";
 
 import * as aria from "@siteimprove/alfa-aria";
-import { isAriaControlsRequired } from "../common/predicate/is-aria-controls-required";
+import { isAriaControlsOptional } from "../common/predicate/is-aria-controls-optional";
 
 import { Scope } from "../tags";
 
@@ -72,7 +72,7 @@ function hasRequiredValues(
       // ones
       if (
         node.attribute(attribute).every(property("value", isEmpty)) &&
-        !(isAriaControlsRequired(node) && attribute === "aria-controls")
+        !(isAriaControlsOptional(node) && attribute === "aria-controls")
       ) {
         missing.push(attribute);
         result = false;

--- a/packages/alfa-rules/src/sia-r19/rule.ts
+++ b/packages/alfa-rules/src/sia-r19/rule.ts
@@ -12,7 +12,7 @@ import { Page } from "@siteimprove/alfa-web";
 import * as aria from "@siteimprove/alfa-aria";
 
 import { expectation } from "../common/act/expectation";
-import { isAriaControlsRequired } from "../common/predicate/is-aria-controls-required";
+import { isAriaControlsOptional } from "../common/predicate/is-aria-controls-optional";
 
 import { Scope } from "../tags";
 
@@ -144,7 +144,7 @@ function isAttributeOptionalOrValid(
   for (const role of node.role) {
     const { name, type, value } = attribute;
 
-    if (isAriaControlsRequired(node) && name === "aria-controls") {
+    if (isAriaControlsOptional(node) && name === "aria-controls") {
       return true;
     }
 

--- a/packages/alfa-rules/tsconfig.json
+++ b/packages/alfa-rules/tsconfig.json
@@ -39,7 +39,7 @@
     "src/common/outcome/refresh-delay.ts",
     "src/common/predicate.ts",
     "src/common/predicate/has-interposed-descendant.ts",
-    "src/common/predicate/is-aria-controls-required.ts",
+    "src/common/predicate/is-aria-controls-optional.ts",
     "src/common/predicate/is-at-the-start.ts",
     "src/common/predicate/is-large-text.ts",
     "src/common/predicate/is-whitespace.ts",


### PR DESCRIPTION
Thus matching the actual behavior.
