### PR TITLE
Add `Maybe#toOption` and move out of `Option` namespace

### DIFF
--- a/.changeset/dry-apples-think.md
+++ b/.changeset/dry-apples-think.md
@@ -1,0 +1,7 @@
+---
+"@siteimprove/alfa-option": minor
+---
+
+**Breaking:** Moved `Maybe` type out of `Option` namespace
+
+The type was moved while adding the function `Maybe.toOption`. The type is an internal convenience type that is only used when it's not possible or practical to use `Option`. To migrate, import `Maybe` from the `alfa-option` package and replace `Option.Maybe` with `Maybe`.

--- a/docs/review/api/alfa-act.api.md
+++ b/docs/review/api/alfa-act.api.md
@@ -16,6 +16,7 @@ import { Hashable } from '@siteimprove/alfa-hash';
 import { Iterable as Iterable_2 } from '@siteimprove/alfa-iterable';
 import * as json from '@siteimprove/alfa-json';
 import { Mapper } from '@siteimprove/alfa-mapper';
+import { Maybe } from '@siteimprove/alfa-option';
 import { Monad } from '@siteimprove/alfa-monad';
 import { Option } from '@siteimprove/alfa-option';
 import { Performance } from '@siteimprove/alfa-performance';
@@ -612,9 +613,9 @@ export namespace Rule {
                 mark: (name: string) => Performance.Mark<Event<I, T, Q, S>>;
                 measure: (name: string, start?: number) => Performance.Measure<Event<I, T, Q, S>>;
             }): {
-                applicability(): Iterable_2<Interview<Q, S, T, Option.Maybe<T>>>;
+                applicability(): Iterable_2<Interview<Q, S, T, Maybe<T>>>;
                 expectations(target: T): {
-                    [key: string]: Interview<Q, S, T, Option.Maybe<Result<Diagnostic>>>;
+                    [key: string]: Interview<Q, S, T, Maybe<Result<Diagnostic>>>;
                 };
             };
         }
@@ -653,7 +654,7 @@ export namespace Rule {
                 measure: (name: string, start?: number) => Performance.Measure<Event<I, T, Q, S>>;
             }): {
                 expectations(outcomes: Sequence<Outcome.Applicable<I, T, Q, S>>): {
-                    [key: string]: Interview<Q, S, T, Option.Maybe<Result<Diagnostic>>>;
+                    [key: string]: Interview<Q, S, T, Maybe<Result<Diagnostic>>>;
                 };
             };
         }

--- a/docs/review/api/alfa-option.api.md
+++ b/docs/review/api/alfa-option.api.md
@@ -25,7 +25,7 @@ import { Thunk } from '@siteimprove/alfa-thunk';
 
 // Warning: (ae-internal-missing-underscore) The name "Maybe" should be prefixed with an underscore because the declaration is marked as @internal
 //
-// @internal
+// @internal (undocumented)
 export type Maybe<T> = T | Option<T>;
 
 // @internal (undocumented)

--- a/docs/review/api/alfa-option.api.md
+++ b/docs/review/api/alfa-option.api.md
@@ -23,6 +23,17 @@ import { Refinement } from '@siteimprove/alfa-refinement';
 import { Serializable } from '@siteimprove/alfa-json';
 import { Thunk } from '@siteimprove/alfa-thunk';
 
+// Warning: (ae-internal-missing-underscore) The name "Maybe" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export type Maybe<T> = T | Option<T>;
+
+// @internal (undocumented)
+export namespace Maybe {
+    // (undocumented)
+    export function toOption<T>(maybe: Maybe<T>): Option<T>;
+}
+
 // @public (undocumented)
 export interface None extends Option<never> {
 }
@@ -127,8 +138,6 @@ export namespace Option {
     export function isSome<T>(value: unknown): value is Some<T>;
     // (undocumented)
     export type JSON<T> = Some.JSON<T> | None.JSON;
-    // (undocumented)
-    export type Maybe<T> = T | Option<T>;
     // (undocumented)
     export function of<T>(value: T): Some<T>;
 }

--- a/packages/alfa-option/src/index.ts
+++ b/packages/alfa-option/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./maybe";
 export * from "./none";
 export * from "./option";
 export * from "./some";

--- a/packages/alfa-option/src/maybe.ts
+++ b/packages/alfa-option/src/maybe.ts
@@ -1,0 +1,18 @@
+import { Option } from "./option";
+
+/**
+ * @remarks
+ * Should only be used when it's not possible or practical to use `Option<T>`
+ *
+ * @internal
+ */
+export type Maybe<T> = T | Option<T>;
+
+/**
+ * @internal
+ */
+export namespace Maybe {
+  export function toOption<T>(maybe: Maybe<T>): Option<T> {
+    return Option.isOption(maybe) ? maybe : Option.of(maybe);
+  }
+}

--- a/packages/alfa-option/src/option.ts
+++ b/packages/alfa-option/src/option.ts
@@ -1,6 +1,6 @@
 import { Applicative } from "@siteimprove/alfa-applicative";
 import { Callback } from "@siteimprove/alfa-callback";
-import { Comparable, Comparison, Comparer } from "@siteimprove/alfa-comparable";
+import { Comparable, Comparer, Comparison } from "@siteimprove/alfa-comparable";
 import { Equatable } from "@siteimprove/alfa-equatable";
 import { Foldable } from "@siteimprove/alfa-foldable";
 import { Functor } from "@siteimprove/alfa-functor";
@@ -74,8 +74,6 @@ export interface Option<T>
  * @public
  */
 export namespace Option {
-  export type Maybe<T> = T | Option<T>;
-
   export type JSON<T> = Some.JSON<T> | None.JSON;
 
   export function isOption<T>(value: Iterable<T>): value is Option<T>;

--- a/packages/alfa-option/test/maybe.spec.ts
+++ b/packages/alfa-option/test/maybe.spec.ts
@@ -1,0 +1,20 @@
+import { test } from "@siteimprove/alfa-test";
+
+import { Maybe } from "../src/maybe";
+import { None } from "../src/none";
+import { Some } from "../src/some";
+
+test("#toOption() of `None` returns the same instance", (t) => {
+  const none = None;
+  t.equal(Maybe.toOption(none), none);
+});
+
+test("#toOption() of `Some` returns the same instance", (t) => {
+  const some = Some.of("foo");
+  t.equal(Maybe.toOption(some), some);
+});
+
+test("#toOption() of `T` returns `Some<T>`", (t) => {
+  const foo = "foo";
+  t.deepEqual(Maybe.toOption(foo), Some.of(foo));
+});

--- a/packages/alfa-option/tsconfig.json
+++ b/packages/alfa-option/tsconfig.json
@@ -3,10 +3,12 @@
   "extends": "../tsconfig.json",
   "files": [
     "src/index.ts",
+    "src/maybe.ts",
     "src/none.ts",
     "src/option.ts",
     "src/some.ts",
-    "test/option.spec.ts"
+    "test/option.spec.ts",
+    "test/maybe.spec.ts"
   ],
   "references": [
     { "path": "../alfa-applicative" },

--- a/packages/alfa-rules/src/common/act/expectation.ts
+++ b/packages/alfa-rules/src/common/act/expectation.ts
@@ -1,5 +1,5 @@
 import type { Diagnostic, Interview, Question } from "@siteimprove/alfa-act";
-import { None, Option } from "@siteimprove/alfa-option";
+import { Maybe, None } from "@siteimprove/alfa-option";
 import type { Result } from "@siteimprove/alfa-result";
 import { Thunk } from "@siteimprove/alfa-thunk";
 import type { Trilean } from "@siteimprove/alfa-trilean";
@@ -20,14 +20,14 @@ type Expectation<
   S,
   C,
   D extends number = Interview.MaxDepth
-> = Interview<Q, S, C, Option.Maybe<Result<Diagnostic>>, D>;
+> = Interview<Q, S, C, Maybe<Result<Diagnostic>>, D>;
 
 export function expectation(
   test: Trilean,
-  ifTrue: Thunk<Option.Maybe<Result<Diagnostic>>>,
-  ifFalse: Thunk<Option.Maybe<Result<Diagnostic>>>,
-  ifUnknown?: Thunk<Option.Maybe<Result<Diagnostic>>>
-): Option.Maybe<Result<Diagnostic>>;
+  ifTrue: Thunk<Maybe<Result<Diagnostic>>>,
+  ifFalse: Thunk<Maybe<Result<Diagnostic>>>,
+  ifUnknown?: Thunk<Maybe<Result<Diagnostic>>>
+): Maybe<Result<Diagnostic>>;
 
 export function expectation<
   Q extends Question.Metadata,


### PR DESCRIPTION
Resolves part of #1037 

Added `Maybe#toOption` and moved type out of `Option` namespace. This is a step in the direction of cleaning how we use the `Maybe` type in the rules.