### PR TITLE
Typescript 5

### DIFF
--- a/docs/review/api/alfa-aria.api.md
+++ b/docs/review/api/alfa-aria.api.md
@@ -118,10 +118,10 @@ export namespace DOM {
     hasRole: typeof dom.hasRole, // (undocumented)
     isIgnored: typeof dom.isIgnored, // (undocumented)
     isIncludedInTheAccessibilityTree: typeof dom.isIncludedInTheAccessibilityTree, // (undocumented)
-    isMarkedDecorative: Predicate<Element_2<string>, []>, // (undocumented)
+    isMarkedDecorative: Predicate<Element_2<string>>, // (undocumented)
     isPerceivableForAll: typeof dom.isPerceivableForAll, // (undocumented)
     isProgrammaticallyHidden: typeof dom.isProgrammaticallyHidden, // (undocumented)
-    isSemanticallyDisabled: Predicate<Element_2<string>, []>;
+    isSemanticallyDisabled: Predicate<Element_2<string>>;
 }
 
 // @public (undocumented)

--- a/docs/review/api/alfa-css.api.md
+++ b/docs/review/api/alfa-css.api.md
@@ -389,7 +389,7 @@ namespace Function_2 {
     const // (undocumented)
     consume: Parser<Slice<Token>, Function_2, string>;
     const // (undocumented)
-    parse: <T>(name?: string, body?: Parser<Slice<Token>, T, string, []> | undefined) => Parser<Slice<Token>, readonly [Function_2, T], string, []>;
+    parse: <T>(name?: string, body?: Parser<Slice<Token>, T, string> | undefined) => Parser<Slice<Token>, readonly [Function_2, T], string, []>;
 }
 export { Function_2 as Function }
 
@@ -1314,7 +1314,7 @@ export namespace Position {
     // (undocumented)
     export type Component<S extends Horizontal | Vertical = Horizontal | Vertical, U extends Unit.Length = Unit.Length> = Center | Offset<U> | Side<S, Offset<U>>;
     const // (undocumented)
-    parseCenter: Parser<Slice<Token>, Keyword<"center">, string, []>;
+    parseCenter: Parser<Slice<Token>, Keyword<"center">, string>;
     // (undocumented)
     export namespace Component {
         // (undocumented)

--- a/docs/review/api/alfa-selector.api.md
+++ b/docs/review/api/alfa-selector.api.md
@@ -948,7 +948,7 @@ export namespace Selector {
         static of(): Visited;
     }
     const // (undocumented)
-    parse: Parser<Slice<Token>, Simple | Compound | Complex | List<Simple | Compound | Complex>, string, []>;
+    parse: Parser<Slice<Token>, Simple | Compound | Complex | List<Simple | Compound | Complex>, string>;
         {};
 }
 

--- a/docs/review/api/alfa-style.api.md
+++ b/docs/review/api/alfa-style.api.md
@@ -153,7 +153,7 @@ export namespace Longhand {
     // (undocumented)
     export type Parser<SPECIFIED> = parser.Parser<Slice<Token>, Default | SPECIFIED, string>;
     const // (undocumented)
-    parseDefaults: parser.Parser<Slice<Token>, Keyword<"initial"> | Keyword<"inherit"> | Keyword<"unset">, string, []>;
+    parseDefaults: parser.Parser<Slice<Token>, Keyword<"initial"> | Keyword<"inherit"> | Keyword<"unset">, string>;
 }
 
 // @public (undocumented)

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "minimist": "^1.2.6",
     "package-dependency-graph": "^1.14.3",
     "prettier": "^2.7.1",
-    "typescript": "=4.8.4"
+    "typescript": "^5.0.4"
   },
   "packageManager": "yarn@3.5.0"
 }

--- a/packages/alfa-dom/src/h.ts
+++ b/packages/alfa-dom/src/h.ts
@@ -69,7 +69,7 @@ export namespace h {
 
     const block = h.block(style);
 
-    if (style.length > 0) {
+    if (block.size > 0) {
       attributes = [...attributes, h.attribute("style", block.toString())];
     }
 

--- a/packages/alfa-style/src/style.ts
+++ b/packages/alfa-style/src/style.ts
@@ -11,14 +11,13 @@ import {
   Shadow,
 } from "@siteimprove/alfa-dom";
 import { Iterable } from "@siteimprove/alfa-iterable";
+import * as json from "@siteimprove/alfa-json";
 import { Serializable } from "@siteimprove/alfa-json";
 import { Map } from "@siteimprove/alfa-map";
 import { None, Option } from "@siteimprove/alfa-option";
 import { Result } from "@siteimprove/alfa-result";
 import { Context } from "@siteimprove/alfa-selector";
 import { Slice } from "@siteimprove/alfa-slice";
-
-import * as json from "@siteimprove/alfa-json";
 
 import * as element from "./element/element";
 import * as node from "./node/node";
@@ -213,13 +212,28 @@ export class Style implements Serializable<Style.JSON> {
     }
 
     if (!this._computed.has(name)) {
-      this._computed = this._computed.set(
-        name,
-        Longhands.get(name).compute(
-          this.specified(name) as Value<Style.Specified<Name>>,
-          this
-        )
-      );
+      // Keeping semi-useless variables to reduce the any-pollution to a single call
+      const compute = Longhands.get(name).compute;
+      const specified = this.specified(name);
+      // Typescript is completely struggling on this one.
+      // Essentially, N has to be assumed as Name at this point. TS lost the fact
+      // that specified and compute refer to the same property, because we're
+      // not really creating that link.
+      // So, it has specified of type S1 | S2 | …, and compute of type
+      // S1 -> C1 | S2 -> C2 | …, but no link to the fact that the same should
+      // be used in both.
+      // The union of functions is exploded as (S1 & S2 & …) -> (C1 | C2 | …)
+      // due to contravariance. But the Si tend to be unions, and the
+      // intersection of union is expanded a bit too greedily by TS and reaches
+      // its union size limit of 100,000 term (!)
+      // So, we just skip type checking here…
+      //
+      // See https://github.com/microsoft/TypeScript/issues/53234#issuecomment-1497872142
+      const computed = compute(specified as any, this) as Value<
+        Style.Computed<N>
+      >;
+
+      this._computed = this._computed.set(name, computed);
     }
 
     return (

--- a/packages/alfa-style/src/style.ts
+++ b/packages/alfa-style/src/style.ts
@@ -217,8 +217,7 @@ export class Style implements Serializable<Style.JSON> {
       const specified = this.specified(name);
       // Typescript is completely struggling on this one.
       // Essentially, N has to be assumed as Name at this point. TS lost the fact
-      // that specified and compute refer to the same property, because we're
-      // not really creating that link.
+      // that specified and compute refer to the same property.
       // So, it has specified of type S1 | S2 | …, and compute of type
       // S1 -> C1 | S2 -> C2 | …, but no link to the fact that the same should
       // be used in both.
@@ -228,7 +227,7 @@ export class Style implements Serializable<Style.JSON> {
       // its union size limit of 100,000 term (!)
       // So, we just skip type checking here…
       //
-      // See https://github.com/microsoft/TypeScript/issues/53234#issuecomment-1497872142
+      // See https://github.com/microsoft/TypeScript/issues/53234
       const computed = compute(specified as any, this) as Value<
         Style.Computed<N>
       >;

--- a/packages/alfa-tuple/src/tuple.ts
+++ b/packages/alfa-tuple/src/tuple.ts
@@ -303,7 +303,7 @@ export namespace Tuple {
   export type Append<T extends Tuple, V> = [...T, V];
 
   export function append<T extends Tuple, V>(tuple: T, value: V): Append<T, V> {
-    return Array.append(copy(tuple), value) as Append<T, V>;
+    return Array.append(copy(tuple), value) as unknown as Append<T, V>;
   }
 
   export type Prepend<T extends Tuple, V> = [V, ...T];
@@ -312,7 +312,7 @@ export namespace Tuple {
     tuple: T,
     value: V
   ): Prepend<T, V> {
-    return Array.prepend(copy(tuple), value) as Prepend<T, V>;
+    return Array.prepend(copy(tuple), value) as unknown as Prepend<T, V>;
   }
 
   export type First<T extends Tuple> = T extends readonly [infer H, ...infer _]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1674,7 +1674,7 @@ __metadata:
     minimist: ^1.2.6
     package-dependency-graph: ^1.14.3
     prettier: ^2.7.1
-    typescript: =4.8.4
+    typescript: ^5.0.4
   languageName: unknown
   linkType: soft
 
@@ -5500,23 +5500,23 @@ resolve@~1.19.0:
   languageName: node
   linkType: hard
 
-typescript@=4.8.4:
-  version: 4.8.4
-  resolution: "typescript@npm:4.8.4"
+"typescript@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "typescript@npm:5.0.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 3e4f061658e0c8f36c820802fa809e0fd812b85687a9a2f5430bc3d0368e37d1c9605c3ce9b39df9a05af2ece67b1d844f9f6ea8ff42819f13bcb80f85629af0
+  checksum: 82b94da3f4604a8946da585f7d6c3025fff8410779e5bde2855ab130d05e4fd08938b9e593b6ebed165bda6ad9292b230984f10952cf82f0a0ca07bbeaa08172
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@=4.8.4#~builtin<compat/typescript>":
-  version: 4.8.4
-  resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=1a91c8"
+"typescript@patch:typescript@^5.0.4#~builtin<compat/typescript>":
+  version: 5.0.4
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: c981e82b77a5acdcc4e69af9c56cdecf5b934a87a08e7b52120596701e389a878b8e3f860e73ffb287bf649cc47a8c741262ce058148f71de4cdd88bb9c75153
+  checksum: bb309d320c59a26565fb3793dba550576ab861018ff3fd1b7fccabbe46ae4a35546bc45f342c0a0b6f265c801ccdf64ffd68f548f117ceb7f0eac4b805cd52a9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Part of #1037.

Update to TS 5. There is still a type that cannot really be handled. This is partly due to some design choices in TS. So we have to help it and assert the correct type.
