### PR TITLE
Abstract Math calculation in style properties

### DIFF
--- a/.changeset/gold-pens-shave.md
+++ b/.changeset/gold-pens-shave.md
@@ -1,0 +1,8 @@
+---
+"@siteimprove/alfa-css": minor
+---
+
+**Breaking:** `Math.resolve` now returns a `Result<Numeric, string>` instead of an `Option`.
+Invalid experssions return an error message.
+
+**Breaking:** No resolver is needed `Math.resolve` on `Number` expressions.

--- a/.changeset/short-feet-drive.md
+++ b/.changeset/short-feet-drive.md
@@ -1,0 +1,7 @@
+---
+"@siteimprove/alfa-css": minor
+---
+
+**Removed:** `Math.parseLengthNumberPercentage` is no longer available.
+
+Instead, a combination of `parseLengthPercentage` and `parseNumber` should be used.

--- a/.changeset/short-rings-drop.md
+++ b/.changeset/short-rings-drop.md
@@ -1,0 +1,7 @@
+---
+"@siteimprove/alfa-style": minor
+---
+
+**Added:** New abstraction for math expressions
+
+Addedd an abstraction for length, length-percentage and number that handle the possible math expressions in these value.

--- a/docs/review/api/alfa-css.api.md
+++ b/docs/review/api/alfa-css.api.md
@@ -921,11 +921,11 @@ class Math_2<out D extends Math_2.Dimension = Math_2.Dimension> extends Value<"m
     static of(expression: Expression): Math_2;
     // (undocumented)
     reduce(resolver: Expression.Resolver): Math_2;
-    resolve(this: Math_2<"length">, resolver: Expression.LengthResolver): Option<Length<"px">>;
+    resolve(this: Math_2<"length">, resolver: Expression.LengthResolver): Result<Length<"px">, string>;
     // (undocumented)
-    resolve(this: Math_2<"length-percentage">, resolver: Expression.Resolver<"px", Length<"px">>): Option<Length<"px">>;
+    resolve(this: Math_2<"length-percentage">, resolver: Expression.Resolver<"px", Length<"px">>): Result<Length<"px">, string>;
     // (undocumented)
-    resolve(this: Math_2<"number">, resolver: Expression.PercentageResolver): Option<Number_2>;
+    resolve(this: Math_2<"number">): Result<Number_2, string>;
     // (undocumented)
     toJSON(): Math_2.JSON;
     // (undocumented)
@@ -961,6 +961,8 @@ namespace Math_2 {
     parseLengthPercentage: Parser<Slice<Token>, Math_2<"length-percentage">, string, []>;
     const // (undocumented)
     parseLengthNumberPercentage: Parser<Slice<Token>, Math_2<"number"> | Math_2<"length-percentage">, string, []>;
+    const // (undocumented)
+    parseNumber: Parser<Slice<Token>, Math_2<"number">, string, []>;
 }
 export { Math_2 as Math }
 

--- a/docs/review/api/alfa-css.api.md
+++ b/docs/review/api/alfa-css.api.md
@@ -960,8 +960,6 @@ namespace Math_2 {
     const // (undocumented)
     parseLengthPercentage: Parser<Slice<Token>, Math_2<"length-percentage">, string, []>;
     const // (undocumented)
-    parseLengthNumberPercentage: Parser<Slice<Token>, Math_2<"number"> | Math_2<"length-percentage">, string, []>;
-    const // (undocumented)
     parseNumber: Parser<Slice<Token>, Math_2<"number">, string, []>;
 }
 export { Math_2 as Math }

--- a/docs/review/api/alfa-style.api.md
+++ b/docs/review/api/alfa-style.api.md
@@ -33,6 +33,7 @@ import { Node } from '@siteimprove/alfa-dom';
 import { Number as Number_2 } from '@siteimprove/alfa-css';
 import { Numeric } from '@siteimprove/alfa-css';
 import { Option } from '@siteimprove/alfa-option';
+import { Parser } from '@siteimprove/alfa-parser';
 import * as parser from '@siteimprove/alfa-parser';
 import { Percentage } from '@siteimprove/alfa-css';
 import { Perspective } from '@siteimprove/alfa-css';
@@ -53,6 +54,7 @@ import { System } from '@siteimprove/alfa-css';
 import { Text } from '@siteimprove/alfa-dom';
 import { Token } from '@siteimprove/alfa-css';
 import { Translate } from '@siteimprove/alfa-css';
+import { Unit } from '@siteimprove/alfa-css';
 import { URL } from '@siteimprove/alfa-css';
 import { Value as Value_2 } from '@siteimprove/alfa-css';
 
@@ -232,7 +234,7 @@ export namespace Longhands {
         readonly display: Longhand<Specified_25, Specified_25>;
         readonly "flex-direction": Longhand<Specified_26, Specified_26>;
         readonly "flex-wrap": Longhand<Specified_27, Specified_27>;
-        readonly float: Longhand<Keyword<"left"> | Keyword<"right"> | Keyword<"none">, Keyword<"left"> | Keyword<"right"> | Keyword<"none">>;
+        readonly float: Longhand<Keyword<"none"> | Keyword<"left"> | Keyword<"right">, Keyword<"none"> | Keyword<"left"> | Keyword<"right">>;
         readonly "font-family": Longhand<Specified_28, Specified_28>;
         readonly "font-size": Longhand<Specified_29, Computed_15>;
         readonly "font-stretch": Longhand<Specified_30, Percentage>;
@@ -259,30 +261,30 @@ export namespace Longhands {
         readonly "min-width": Longhand<Specified_43, Computed_21>;
         readonly opacity: Longhand<Specified_44, Number_2>;
         readonly "outline-color": Longhand<Specified_45, Computed_22>;
-        readonly "outline-offset": Longhand<Specified_46, Computed_23>;
-        readonly "outline-style": Longhand<Specified_47, Specified_47>;
-        readonly "outline-width": Longhand<Specified_48, Computed_24>;
-        readonly "overflow-x": Longhand<Specified_49, Specified_49>;
-        readonly "overflow-y": Longhand<Specified_50, Specified_50>;
-        readonly position: Longhand<Specified_51, Specified_51>;
+        readonly "outline-offset": Longhand<import("./property/value/compound").Length.Length, Computed_23>;
+        readonly "outline-style": Longhand<Specified_46, Specified_46>;
+        readonly "outline-width": Longhand<Specified_47, Computed_24>;
+        readonly "overflow-x": Longhand<Specified_48, Specified_48>;
+        readonly "overflow-y": Longhand<Specified_49, Specified_49>;
+        readonly position: Longhand<Specified_50, Specified_50>;
         readonly right: Longhand<Specified_19, Computed_12>;
-        readonly rotate: Longhand<Specified_52, Computed_25>;
-        readonly "text-align": Longhand<Specified_53, Specified_53>;
+        readonly rotate: Longhand<Specified_51, Computed_25>;
+        readonly "text-align": Longhand<Specified_52, Specified_52>;
         readonly "text-decoration-color": Longhand<Color, Computed_26>;
-        readonly "text-decoration-line": Longhand<Specified_54, Specified_54>;
-        readonly "text-decoration-style": Longhand<Specified_55, Specified_55>;
-        readonly "text-decoration-thickness": Longhand<Specified_56, Computed_27>;
-        readonly "text-indent": Longhand<Specified_57, Computed_28>;
-        readonly "text-overflow": Longhand<Specified_58, Specified_58>;
-        readonly "text-shadow": Longhand<Specified_59, Computed_29>;
-        readonly "text-transform": Longhand<Specified_60, Specified_60>;
+        readonly "text-decoration-line": Longhand<Specified_53, Specified_53>;
+        readonly "text-decoration-style": Longhand<Specified_54, Specified_54>;
+        readonly "text-decoration-thickness": Longhand<Specified_55, Computed_27>;
+        readonly "text-indent": Longhand<Specified_56, Computed_28>;
+        readonly "text-overflow": Longhand<Specified_57, Specified_57>;
+        readonly "text-shadow": Longhand<Specified_58, Computed_29>;
+        readonly "text-transform": Longhand<Specified_59, Specified_59>;
         readonly top: Longhand<Specified_19, Computed_12>;
-        readonly transform: Longhand<Specified_61, Computed_30>;
-        readonly "vertical-align": Longhand<Specified_62, Computed_31>;
-        readonly visibility: Longhand<Specified_63, Specified_63>;
-        readonly "white-space": Longhand<Specified_64, Specified_64>;
-        readonly width: Longhand<Specified_65, Computed_32>;
-        readonly "word-spacing": Longhand<Specified_66, Computed_33>;
+        readonly transform: Longhand<Specified_60, Computed_30>;
+        readonly "vertical-align": Longhand<Specified_61, Computed_31>;
+        readonly visibility: Longhand<Specified_62, Specified_62>;
+        readonly "white-space": Longhand<Specified_63, Specified_63>;
+        readonly width: Longhand<Specified_64, Computed_32>;
+        readonly "word-spacing": Longhand<Specified_65, Computed_33>;
     };
     // (undocumented)
     export type Property = typeof longHands;
@@ -367,9 +369,9 @@ export namespace Shorthands {
         readonly "font-variant": Shorthand<"font-variant-caps" | "font-variant-east-asian" | "font-variant-ligatures" | "font-variant-numeric">;
         readonly "inset-block": Shorthand<"inset-block-end" | "inset-block-start">;
         readonly "inset-inline": Shorthand<"inset-inline-end" | "inset-inline-start">;
-        readonly inset: Shorthand<"top" | "bottom" | "left" | "right">;
+        readonly inset: Shorthand<"left" | "right" | "top" | "bottom">;
         readonly margin: Shorthand<"margin-bottom" | "margin-left" | "margin-right" | "margin-top">;
-        readonly outline: Shorthand<"outline-color" | "outline-style" | "outline-width">;
+        readonly outline: Shorthand<"outline-style" | "outline-color" | "outline-width">;
         readonly overflow: Shorthand<"overflow-x" | "overflow-y">;
         readonly "text-decoration": Shorthand<"text-decoration-color" | "text-decoration-line" | "text-decoration-style" | "text-decoration-thickness">;
     };
@@ -671,7 +673,7 @@ export namespace Value {
 // src/longhands.ts:278:7 - (ae-forgotten-export) The symbol "Specified" needs to be exported by the entry point index.d.ts
 // src/longhands.ts:278:7 - (ae-forgotten-export) The symbol "Computed" needs to be exported by the entry point index.d.ts
 // src/longhands.ts:278:7 - (ae-incompatible-release-tags) The symbol ""outline-color"" is marked as @public, but its signature references "Longhand" which is marked as @internal
-// src/longhands.ts:279:7 - (ae-forgotten-export) The symbol "Specified" needs to be exported by the entry point index.d.ts
+// src/longhands.ts:279:7 - (ae-forgotten-export) The symbol "Length" needs to be exported by the entry point index.d.ts
 // src/longhands.ts:279:7 - (ae-forgotten-export) The symbol "Computed" needs to be exported by the entry point index.d.ts
 // src/longhands.ts:279:7 - (ae-incompatible-release-tags) The symbol ""outline-offset"" is marked as @public, but its signature references "Longhand" which is marked as @internal
 // src/longhands.ts:280:7 - (ae-forgotten-export) The symbol "Specified" needs to be exported by the entry point index.d.ts

--- a/docs/review/api/alfa-style.api.md
+++ b/docs/review/api/alfa-style.api.md
@@ -371,7 +371,7 @@ export namespace Shorthands {
         readonly "inset-inline": Shorthand<"inset-inline-end" | "inset-inline-start">;
         readonly inset: Shorthand<"left" | "right" | "top" | "bottom">;
         readonly margin: Shorthand<"margin-bottom" | "margin-left" | "margin-right" | "margin-top">;
-        readonly outline: Shorthand<"outline-style" | "outline-color" | "outline-width">;
+        readonly outline: Shorthand<"outline-color" | "outline-style" | "outline-width">;
         readonly overflow: Shorthand<"overflow-x" | "overflow-y">;
         readonly "text-decoration": Shorthand<"text-decoration-color" | "text-decoration-line" | "text-decoration-style" | "text-decoration-thickness">;
     };

--- a/docs/review/api/alfa-style.api.md
+++ b/docs/review/api/alfa-style.api.md
@@ -234,7 +234,7 @@ export namespace Longhands {
         readonly display: Longhand<Specified_25, Specified_25>;
         readonly "flex-direction": Longhand<Specified_26, Specified_26>;
         readonly "flex-wrap": Longhand<Specified_27, Specified_27>;
-        readonly float: Longhand<Keyword<"none"> | Keyword<"left"> | Keyword<"right">, Keyword<"none"> | Keyword<"left"> | Keyword<"right">>;
+        readonly float: Longhand<Keyword<"left"> | Keyword<"right"> | Keyword<"none">, Keyword<"left"> | Keyword<"right"> | Keyword<"none">>;
         readonly "font-family": Longhand<Specified_28, Specified_28>;
         readonly "font-size": Longhand<Specified_29, Computed_15>;
         readonly "font-stretch": Longhand<Specified_30, Percentage>;
@@ -369,7 +369,7 @@ export namespace Shorthands {
         readonly "font-variant": Shorthand<"font-variant-caps" | "font-variant-east-asian" | "font-variant-ligatures" | "font-variant-numeric">;
         readonly "inset-block": Shorthand<"inset-block-end" | "inset-block-start">;
         readonly "inset-inline": Shorthand<"inset-inline-end" | "inset-inline-start">;
-        readonly inset: Shorthand<"left" | "right" | "top" | "bottom">;
+        readonly inset: Shorthand<"top" | "bottom" | "left" | "right">;
         readonly margin: Shorthand<"margin-bottom" | "margin-left" | "margin-right" | "margin-top">;
         readonly outline: Shorthand<"outline-color" | "outline-style" | "outline-width">;
         readonly overflow: Shorthand<"overflow-x" | "overflow-y">;

--- a/packages/alfa-css/src/value/math-expression/math.ts
+++ b/packages/alfa-css/src/value/math-expression/math.ts
@@ -1,5 +1,4 @@
 import { Hash } from "@siteimprove/alfa-hash";
-import { Option, None } from "@siteimprove/alfa-option";
 import { Parser } from "@siteimprove/alfa-parser";
 import { Slice } from "@siteimprove/alfa-slice";
 import { Err, Ok, Result } from "@siteimprove/alfa-result";

--- a/packages/alfa-css/src/value/math-expression/math.ts
+++ b/packages/alfa-css/src/value/math-expression/math.ts
@@ -328,13 +328,6 @@ export namespace Math {
     () => `calc() expression must be of type "length" or "percentage"`
   );
 
-  export const parseLengthNumberPercentage = filter(
-    parse,
-    (calculation): calculation is Math<"length-percentage"> | Math<"number"> =>
-      calculation.isDimensionPercentage("length") || calculation.isNumber(),
-    () => `calc() expression must be of type "length" or "percentage"`
-  );
-
   export const parseNumber = filter(
     parse,
     (calculation): calculation is Math<"number"> => calculation.isNumber(),

--- a/packages/alfa-style/package.json
+++ b/packages/alfa-style/package.json
@@ -39,6 +39,7 @@
     "@siteimprove/alfa-predicate": "workspace:^0.62.2",
     "@siteimprove/alfa-refinement": "workspace:^0.62.2",
     "@siteimprove/alfa-result": "workspace:^0.62.2",
+    "@siteimprove/alfa-selective": "workspace:^0.62.2",
     "@siteimprove/alfa-selector": "workspace:^0.62.2",
     "@siteimprove/alfa-set": "workspace:^0.62.2",
     "@siteimprove/alfa-slice": "workspace:^0.62.2"

--- a/packages/alfa-style/src/property/font-size.ts
+++ b/packages/alfa-style/src/property/font-size.ts
@@ -1,6 +1,6 @@
-import { Length, Keyword, Token } from "@siteimprove/alfa-css";
+import { Length, Keyword, type Token } from "@siteimprove/alfa-css";
 import { Parser } from "@siteimprove/alfa-parser";
-import { Slice } from "@siteimprove/alfa-slice";
+import type { Slice } from "@siteimprove/alfa-slice";
 
 import { LengthPercentage } from "./value/compound";
 import { Longhand } from "../longhand";
@@ -110,30 +110,25 @@ const property: Longhand<Specified, Computed> = Longhand.of<
         return LengthPercentage.resolve(fontSize, parent, style.parent);
       }
 
-      switch (fontSize.type) {
-        case "keyword": {
-          switch (fontSize.value) {
-            case "larger":
-              return parent.scale(1.2);
+      switch (fontSize.value) {
+        case "larger":
+          return parent.scale(1.2);
 
-            case "smaller":
-              return parent.scale(0.85);
+        case "smaller":
+          return parent.scale(0.85);
 
-            default: {
-              const factor = factors[fontSize.value];
+        default: {
+          const factor = factors[fontSize.value];
 
-              // We need the type assertion to help TS break a circular type reference:
-              // this -> style.computed -> Longhands.Name -> Longhands.longhands -> this.
-              const [family] = (
-                style.computed("font-family").value as FontFamily
-              ).values;
+          // We need the type assertion to help TS break a circular type reference:
+          // this -> style.computed -> Longhands.Name -> Longhands.longhands -> this.
+          const [family] = (style.computed("font-family").value as FontFamily)
+            .values;
 
-              const base =
-                family.type === "keyword" ? bases[family.value] : bases.serif;
+          const base =
+            family.type === "keyword" ? bases[family.value] : bases.serif;
 
-              return Length.of(factor * base, "px");
-            }
-          }
+          return Length.of(factor * base, "px");
         }
       }
     }),

--- a/packages/alfa-style/src/property/font-size.ts
+++ b/packages/alfa-style/src/property/font-size.ts
@@ -1,17 +1,9 @@
-import {
-  Length,
-  Keyword,
-  Math,
-  Percentage,
-  Token,
-} from "@siteimprove/alfa-css";
+import { Length, Keyword, Token } from "@siteimprove/alfa-css";
 import { Parser } from "@siteimprove/alfa-parser";
 import { Slice } from "@siteimprove/alfa-slice";
 
-import { Compound } from "./value/compound";
-import LengthPercentage = Compound.LengthPercentage;
+import { LengthPercentage } from "./value/compound";
 import { Longhand } from "../longhand";
-import { Resolver } from "../resolver";
 
 import type { Computed as FontFamily } from "./font-family";
 

--- a/packages/alfa-style/src/property/font-size.ts
+++ b/packages/alfa-style/src/property/font-size.ts
@@ -107,9 +107,10 @@ const property: Longhand<Specified, Computed> = Longhand.of<
       const parent = style.parent.computed("font-size").value as Computed;
 
       if (LengthPercentage.isLengthPercentage(fontSize)) {
-        return LengthPercentage.resolve(fontSize, parent, style.parent);
+        return LengthPercentage.resolve(parent, style.parent)(fontSize);
       }
 
+      // Must be a keyword
       switch (fontSize.value) {
         case "larger":
           return parent.scale(1.2);

--- a/packages/alfa-style/src/property/line-height.ts
+++ b/packages/alfa-style/src/property/line-height.ts
@@ -8,10 +8,10 @@ import { Parser } from "@siteimprove/alfa-parser";
 import type { Slice } from "@siteimprove/alfa-slice";
 
 import { Longhand } from "../longhand";
-import { Resolver } from "../resolver";
 import { LengthPercentage, Number } from "./value/compound";
 
 import type { Computed as FontSize } from "./font-size";
+import { Selective } from "@siteimprove/alfa-selective";
 
 const { either } = Parser;
 
@@ -50,15 +50,13 @@ export default Longhand.of<Specified, Computed>(
       // this -> style.computed -> Longhands.Name -> Longhands.longhands -> this.
       const fontSize = style.computed("font-size").value as FontSize;
 
-      if (LengthPercentage.isLengthPercentage(height)) {
-        return LengthPercentage.resolve(height, fontSize, style);
-      }
-
-      if (Number.isNumber(height)) {
-        return Number.resolve(height);
-      }
-
-      return height;
+      return Selective.of(height)
+        .if(
+          LengthPercentage.isLengthPercentage,
+          LengthPercentage.resolve(fontSize, style)
+        )
+        .if(Number.isNumber, Number.resolve)
+        .get();
     }),
   {
     inherits: true,

--- a/packages/alfa-style/src/property/line-height.ts
+++ b/packages/alfa-style/src/property/line-height.ts
@@ -56,6 +56,7 @@ export default Longhand.of<Specified, Computed>(
           LengthPercentage.resolve(fontSize, style)
         )
         .if(Number.isNumber, Number.resolve)
+        // Keywords are left untouched
         .get();
     }),
   {

--- a/packages/alfa-style/src/property/line-height.ts
+++ b/packages/alfa-style/src/property/line-height.ts
@@ -11,6 +11,7 @@ import { Slice } from "@siteimprove/alfa-slice";
 
 import { Longhand } from "../longhand";
 import { Resolver } from "../resolver";
+import {LengthPercentage} from "./value/compound";
 
 import type {Computed as FontSize} from "./font-size"
 
@@ -22,9 +23,7 @@ const { either } = Parser;
 export type Specified =
   | Keyword<"normal">
   | Number
-  | Length
-  | Percentage
-  | Math<"length-percentage">
+  | LengthPercentage.LengthPercentage
   | Math<"number">;
 
 /**
@@ -38,7 +37,7 @@ export type Computed = Keyword<"normal"> | Number | Length<"px">;
 export const parse = either<Slice<Token>, Specified, string>(
   Keyword.parse("normal"),
   Number.parse,
-  Length.parse,
+  LengthPercentage.parse,
   Percentage.parse,
   Math.parseLengthNumberPercentage
 );

--- a/packages/alfa-style/src/property/line-height.ts
+++ b/packages/alfa-style/src/property/line-height.ts
@@ -11,9 +11,9 @@ import { Slice } from "@siteimprove/alfa-slice";
 
 import { Longhand } from "../longhand";
 import { Resolver } from "../resolver";
-import {LengthPercentage} from "./value/compound";
+import { LengthPercentage } from "./value/compound";
 
-import type {Computed as FontSize} from "./font-size"
+import type { Computed as FontSize } from "./font-size";
 
 const { either } = Parser;
 
@@ -73,7 +73,7 @@ export default Longhand.of<Specified, Computed>(
           return (
             (
               height.isNumber()
-                ? height.resolve({ percentage })
+                ? height.resolve()
                 : height.resolve({ length, percentage })
             )
               // Since the calculation has been parsed and typed, there should

--- a/packages/alfa-style/src/property/outline-offset.ts
+++ b/packages/alfa-style/src/property/outline-offset.ts
@@ -1,47 +1,23 @@
-import { Length, Math } from "@siteimprove/alfa-css";
-import { Parser } from "@siteimprove/alfa-parser";
+import { Length as CSSLength } from "@siteimprove/alfa-css";
 
 import { Longhand } from "../longhand";
-import { Resolver } from "../resolver";
-
-const { either } = Parser;
+import { Length } from "./value/compound";
 
 /**
  * @internal
  */
-export type Specified = Length | Math<"length">;
+export type Specified = Length.Length;
 
 /**
  * @internal
  */
-export type Computed = Length<"px">;
-
-/**
- * @internal
- */
-export const parse = either(Length.parse, Math.parseLength);
+export type Computed = CSSLength<"px">;
 
 /**
  * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/outline-offset}
  */
 export default Longhand.of<Specified, Computed>(
-  Length.of(0, "px"),
-  parse,
-  (value, style) =>
-    value.map((offset) => {
-      const length = Resolver.length(style);
-
-      switch (offset.type) {
-        case "length":
-          return length(offset);
-        case "math expression":
-          return (
-            offset
-              .resolve({ length })
-              // Since the calculation has been parsed and typed, there should
-              // always be something to get.
-              .getUnsafe()
-          );
-      }
-    })
+  CSSLength.of(0, "px"),
+  Length.parse,
+  (value, style) => value.map((offset) => Length.resolve(offset, style))
 );

--- a/packages/alfa-style/src/property/outline-offset.ts
+++ b/packages/alfa-style/src/property/outline-offset.ts
@@ -19,5 +19,5 @@ export type Computed = CSSLength<"px">;
 export default Longhand.of<Specified, Computed>(
   CSSLength.of(0, "px"),
   Length.parse,
-  (value, style) => value.map((offset) => Length.resolve(offset, style))
+  (value, style) => value.map(Length.resolve(style))
 );

--- a/packages/alfa-style/src/property/outline-width.ts
+++ b/packages/alfa-style/src/property/outline-width.ts
@@ -48,7 +48,7 @@ export default Longhand.of<Specified, Computed>(
 
     return value.map((width) => {
       if (Length.isLength(width)) {
-        return Length.resolve(width, style);
+        return Length.resolve(style)(width);
       }
 
       switch (width.value) {

--- a/packages/alfa-style/src/property/outline-width.ts
+++ b/packages/alfa-style/src/property/outline-width.ts
@@ -51,6 +51,7 @@ export default Longhand.of<Specified, Computed>(
         return Length.resolve(style)(width);
       }
 
+      // Must be a Keyword
       switch (width.value) {
         case "thin":
           return CSSLength.of(1, "px");

--- a/packages/alfa-style/src/property/outline-width.ts
+++ b/packages/alfa-style/src/property/outline-width.ts
@@ -1,10 +1,14 @@
-import { Keyword, Length, Math, Token } from "@siteimprove/alfa-css";
+import {
+  Keyword,
+  Length as CSSLength,
+  type Token,
+} from "@siteimprove/alfa-css";
 import { Parser } from "@siteimprove/alfa-parser";
-import { Slice } from "@siteimprove/alfa-slice";
+import type { Slice } from "@siteimprove/alfa-slice";
 
 import { Longhand } from "../longhand";
-import { Resolver } from "../resolver";
 import { Value } from "../value";
+import { Length } from "./value/compound";
 
 const { either } = Parser;
 
@@ -12,8 +16,7 @@ const { either } = Parser;
  * @internal
  */
 export type Specified =
-  | Length
-  | Math<"length">
+  | Length.Length
   | Keyword<"thin">
   | Keyword<"medium">
   | Keyword<"thick">;
@@ -21,15 +24,14 @@ export type Specified =
 /**
  * @internal
  */
-export type Computed = Length<"px">;
+export type Computed = CSSLength<"px">;
 
 /**
  * @internal
  */
 export const parse = either<Slice<Token>, Specified, string>(
   Keyword.parse("thin", "medium", "thick"),
-  Length.parse,
-  Math.parseLength
+  Length.parse
 );
 
 /**
@@ -37,40 +39,27 @@ export const parse = either<Slice<Token>, Specified, string>(
  * @internal
  */
 export default Longhand.of<Specified, Computed>(
-  Length.of(3, "px"),
+  CSSLength.of(3, "px"),
   parse,
   (value, style) => {
     if (style.computed("outline-style").some(({ value }) => value === "none")) {
-      return Value.of(Length.of(0, "px"));
+      return Value.of(CSSLength.of(0, "px"));
     }
 
     return value.map((width) => {
-      const length = Resolver.length(style);
+      if (Length.isLength(width)) {
+        return Length.resolve(width, style);
+      }
 
-      switch (width.type) {
-        case "length":
-          return length(width);
+      switch (width.value) {
+        case "thin":
+          return CSSLength.of(1, "px");
 
-        case "math expression":
-          return (
-            width
-              .resolve({ length })
-              // Since the calculation has been parsed and typed, there should
-              // always be something to get.
-              .getUnsafe()
-          );
+        case "medium":
+          return CSSLength.of(3, "px");
 
-        case "keyword":
-          switch (width.value) {
-            case "thin":
-              return Length.of(1, "px");
-
-            case "medium":
-              return Length.of(3, "px");
-
-            case "thick":
-              return Length.of(5, "px");
-          }
+        case "thick":
+          return CSSLength.of(5, "px");
       }
     });
   }

--- a/packages/alfa-style/src/property/value/compound.ts
+++ b/packages/alfa-style/src/property/value/compound.ts
@@ -53,32 +53,32 @@ export namespace LengthPercentage {
   /**
    * Resolve a LengthPercentage into an absolute Length in pixels.
    *
-   * @param value the LengthPercentage to resolve
    * @param percentageBase the absolute Length to resolve percentages against
    * @param lengthBase the style whose font-size serves as base for resolving
    * relative lengths (usually the element's own style, or its parent's style).
    */
   export function resolve(
-    value: LengthPercentage,
     percentageBase: CSSLength<"px">,
     lengthBase: Style
-  ): CSSLength<"px"> {
-    const percentage = Resolver.percentage(percentageBase);
-    const length = Resolver.length(lengthBase);
+  ): (value: LengthPercentage) => CSSLength<"px"> {
+    return (value) => {
+      const percentage = Resolver.percentage(percentageBase);
+      const length = Resolver.length(lengthBase);
 
-    switch (value.type) {
-      case "math expression":
-        // Since the calculation has been parsed and typed, there should
-        // always be something to get.
-        return value.resolve({ length, percentage }).getUnsafe();
+      switch (value.type) {
+        case "math expression":
+          // Since the calculation has been parsed and typed, there should
+          // always be something to get.
+          return value.resolve({ length, percentage }).getUnsafe();
 
-      case "length":
-        return length(value);
+        case "length":
+          return length(value);
 
-      case "percentage": {
-        return percentage(value);
+        case "percentage": {
+          return percentage(value);
+        }
       }
-    }
+    };
   }
 }
 
@@ -103,22 +103,25 @@ export namespace Length {
   /**
    * Resolve a Length into an absolute Length in pixels.
    *
-   * @param value the LengthPercentage to resolve
    * @param lengthBase the style whose font-size serves as base for resolving
    * relative lengths (usually the element's own style, or its parent's style).
    */
-  export function resolve(value: Length, lengthBase: Style): CSSLength<"px"> {
-    const length = Resolver.length(lengthBase);
+  export function resolve(
+    lengthBase: Style
+  ): (value: Length) => CSSLength<"px"> {
+    return (value) => {
+      const length = Resolver.length(lengthBase);
 
-    switch (value.type) {
-      case "math expression":
-        // Since the calculation has been parsed and typed, there should
-        // always be something to get.
-        return value.resolve({ length }).getUnsafe();
+      switch (value.type) {
+        case "math expression":
+          // Since the calculation has been parsed and typed, there should
+          // always be something to get.
+          return value.resolve({ length }).getUnsafe();
 
-      case "length":
-        return length(value);
-    }
+        case "length":
+          return length(value);
+      }
+    };
   }
 }
 

--- a/packages/alfa-style/src/property/value/compound.ts
+++ b/packages/alfa-style/src/property/value/compound.ts
@@ -135,10 +135,7 @@ export namespace Number {
     );
   }
 
-  export const parse = either<Slice<Token>, Number, string>(
-    CSSNumber.parse,
-    Math.parseNumber
-  );
+  export const parse = either(CSSNumber.parse, Math.parseNumber);
 
   /**
    * Resolve a Number .
@@ -151,7 +148,7 @@ export namespace Number {
         // Since the calculation has been parsed and typed, there should
         // always be something to get.
         return value.resolve().getUnsafe();
-      default:
+      case "number":
         return value;
     }
   }

--- a/packages/alfa-style/src/property/value/compound.ts
+++ b/packages/alfa-style/src/property/value/compound.ts
@@ -1,0 +1,79 @@
+import { Length, Math, Percentage, type Token } from "@siteimprove/alfa-css";
+import { Parser } from "@siteimprove/alfa-parser";
+import type { Slice } from "@siteimprove/alfa-slice";
+import { Resolver } from "../../resolver";
+
+import type { Style } from "../../style";
+
+const { either } = Parser;
+
+/**
+ * Compound values are unions of CSS values together with convenient helpers
+ * (parser and resolver).
+ * They are mostly intended to wrap the Math expressions in an abstraction that
+ * can easily by used by the individual properties.
+ *
+ * @internal
+ */
+export namespace Compound {
+  export namespace LengthPercentage {
+    /**
+     * {@link https://drafts.csswg.org/css-values/#mixed-percentages}
+     */
+    export type LengthPercentage =
+      | Length
+      | Percentage
+      | Math<"length-percentage">;
+
+    export function isLengthPercentage(
+      value: unknown
+    ): value is LengthPercentage {
+      return (
+        Length.isLength(value) ||
+        Percentage.isPercentage(value) ||
+        (Math.isCalculation(value) && value.isDimensionPercentage("length"))
+      );
+    }
+
+    export const parse = either<Slice<Token>, LengthPercentage, string>(
+      Percentage.parse,
+      Length.parse,
+      Math.parseLengthPercentage
+    );
+
+    /**
+     * Resolve a LengthPercentage into an absolute Length in pixels.
+     *
+     * @param value the LengthPercentage to resolve
+     * @param percentageBase the absolute Length to resolve percentages against
+     * @param lengthBase the style whose font-size serves as base for resolving
+     * relative lengths (usually the element's own style, or its parent's style).
+     */
+    export function resolve(
+      value: LengthPercentage,
+      percentageBase: Length<"px">,
+      lengthBase: Style
+    ): Length<"px"> {
+      const percentage = Resolver.percentage(percentageBase);
+      const length = Resolver.length(lengthBase);
+
+      switch (value.type) {
+        case "math expression":
+          return (
+            value
+              .resolve({ length, percentage })
+              // Since the calculation has been parsed and typed, there should
+              // always be something to get.
+              .getUnsafe()
+          );
+
+        case "length":
+          return length(value);
+
+        case "percentage": {
+          return percentage(value);
+        }
+      }
+    }
+  }
+}

--- a/packages/alfa-style/src/property/value/compound.ts
+++ b/packages/alfa-style/src/property/value/compound.ts
@@ -10,6 +10,7 @@
 import {
   Length as CSSLength,
   Math,
+  Number as CSSNumber,
   Percentage,
   type Token,
 } from "@siteimprove/alfa-css";
@@ -67,13 +68,9 @@ export namespace LengthPercentage {
 
     switch (value.type) {
       case "math expression":
-        return (
-          value
-            .resolve({ length, percentage })
-            // Since the calculation has been parsed and typed, there should
-            // always be something to get.
-            .getUnsafe()
-        );
+        // Since the calculation has been parsed and typed, there should
+        // always be something to get.
+        return value.resolve({ length, percentage }).getUnsafe();
 
       case "length":
         return length(value);
@@ -115,16 +112,47 @@ export namespace Length {
 
     switch (value.type) {
       case "math expression":
-        return (
-          value
-            .resolve({ length })
-            // Since the calculation has been parsed and typed, there should
-            // always be something to get.
-            .getUnsafe()
-        );
+        // Since the calculation has been parsed and typed, there should
+        // always be something to get.
+        return value.resolve({ length }).getUnsafe();
 
       case "length":
         return length(value);
+    }
+  }
+}
+
+/**
+ * @internal
+ */
+export namespace Number {
+  export type Number = CSSNumber | Math<"number">;
+
+  export function isNumber(value: unknown): value is Number {
+    return (
+      CSSNumber.isNumber(value) ||
+      (Math.isCalculation(value) && value.isNumber())
+    );
+  }
+
+  export const parse = either<Slice<Token>, Number, string>(
+    CSSNumber.parse,
+    Math.parseNumber
+  );
+
+  /**
+   * Resolve a Number .
+   *
+   * @param value the Number to resolve
+   */
+  export function resolve(value: Number): CSSNumber {
+    switch (value.type) {
+      case "math expression":
+        // Since the calculation has been parsed and typed, there should
+        // always be something to get.
+        return value.resolve().getUnsafe();
+      default:
+        return value;
     }
   }
 }

--- a/packages/alfa-style/src/property/value/compound.ts
+++ b/packages/alfa-style/src/property/value/compound.ts
@@ -1,4 +1,18 @@
-import { Length, Math, Percentage, type Token } from "@siteimprove/alfa-css";
+/**
+ * Compound values are unions of CSS values together with convenient helpers
+ * (parser and resolver).
+ * They are mostly intended to wrap the Math expressions in an abstraction that
+ * can easily by used by the individual properties.
+ *
+ * @internal
+ */
+
+import {
+  Length as CSSLength,
+  Math,
+  Percentage,
+  type Token,
+} from "@siteimprove/alfa-css";
 import { Parser } from "@siteimprove/alfa-parser";
 import type { Slice } from "@siteimprove/alfa-slice";
 import { Resolver } from "../../resolver";
@@ -8,72 +22,109 @@ import type { Style } from "../../style";
 const { either } = Parser;
 
 /**
- * Compound values are unions of CSS values together with convenient helpers
- * (parser and resolver).
- * They are mostly intended to wrap the Math expressions in an abstraction that
- * can easily by used by the individual properties.
- *
  * @internal
  */
-export namespace Compound {
-  export namespace LengthPercentage {
-    /**
-     * {@link https://drafts.csswg.org/css-values/#mixed-percentages}
-     */
-    export type LengthPercentage =
-      | Length
-      | Percentage
-      | Math<"length-percentage">;
+export namespace LengthPercentage {
+  /**
+   * {@link https://drafts.csswg.org/css-values/#mixed-percentages}
+   */
+  export type LengthPercentage =
+    | CSSLength
+    | Percentage
+    | Math<"length-percentage">;
 
-    export function isLengthPercentage(
-      value: unknown
-    ): value is LengthPercentage {
-      return (
-        Length.isLength(value) ||
-        Percentage.isPercentage(value) ||
-        (Math.isCalculation(value) && value.isDimensionPercentage("length"))
-      );
-    }
-
-    export const parse = either<Slice<Token>, LengthPercentage, string>(
-      Percentage.parse,
-      Length.parse,
-      Math.parseLengthPercentage
+  export function isLengthPercentage(
+    value: unknown
+  ): value is LengthPercentage {
+    return (
+      CSSLength.isLength(value) ||
+      Percentage.isPercentage(value) ||
+      (Math.isCalculation(value) && value.isDimensionPercentage("length"))
     );
+  }
 
-    /**
-     * Resolve a LengthPercentage into an absolute Length in pixels.
-     *
-     * @param value the LengthPercentage to resolve
-     * @param percentageBase the absolute Length to resolve percentages against
-     * @param lengthBase the style whose font-size serves as base for resolving
-     * relative lengths (usually the element's own style, or its parent's style).
-     */
-    export function resolve(
-      value: LengthPercentage,
-      percentageBase: Length<"px">,
-      lengthBase: Style
-    ): Length<"px"> {
-      const percentage = Resolver.percentage(percentageBase);
-      const length = Resolver.length(lengthBase);
+  export const parse = either<Slice<Token>, LengthPercentage, string>(
+    Percentage.parse,
+    CSSLength.parse,
+    Math.parseLengthPercentage
+  );
 
-      switch (value.type) {
-        case "math expression":
-          return (
-            value
-              .resolve({ length, percentage })
-              // Since the calculation has been parsed and typed, there should
-              // always be something to get.
-              .getUnsafe()
-          );
+  /**
+   * Resolve a LengthPercentage into an absolute Length in pixels.
+   *
+   * @param value the LengthPercentage to resolve
+   * @param percentageBase the absolute Length to resolve percentages against
+   * @param lengthBase the style whose font-size serves as base for resolving
+   * relative lengths (usually the element's own style, or its parent's style).
+   */
+  export function resolve(
+    value: LengthPercentage,
+    percentageBase: CSSLength<"px">,
+    lengthBase: Style
+  ): CSSLength<"px"> {
+    const percentage = Resolver.percentage(percentageBase);
+    const length = Resolver.length(lengthBase);
 
-        case "length":
-          return length(value);
+    switch (value.type) {
+      case "math expression":
+        return (
+          value
+            .resolve({ length, percentage })
+            // Since the calculation has been parsed and typed, there should
+            // always be something to get.
+            .getUnsafe()
+        );
 
-        case "percentage": {
-          return percentage(value);
-        }
+      case "length":
+        return length(value);
+
+      case "percentage": {
+        return percentage(value);
       }
+    }
+  }
+}
+
+/**
+ * @internal
+ */
+export namespace Length {
+  /**
+   * {@link https://drafts.csswg.org/css-values/#lengths}
+   */
+  export type Length = CSSLength | Math<"length">;
+
+  export function isLength(value: unknown): value is Length {
+    return (
+      CSSLength.isLength(value) ||
+      (Math.isCalculation(value) && value.isDimension("length"))
+    );
+  }
+
+  export const parse = either(CSSLength.parse, Math.parseLength);
+
+  /**
+   * Resolve a Length into an absolute Length in pixels.
+   *
+   * @param value the LengthPercentage to resolve
+   * @param lengthBase the style whose font-size serves as base for resolving
+   * relative lengths (usually the element's own style, or its parent's style).
+   */
+  export function resolve(value: Length, lengthBase: Style): CSSLength<"px"> {
+    const length = Resolver.length(lengthBase);
+
+    switch (value.type) {
+      case "math expression":
+        return (
+          value
+            .resolve({ length })
+            // Since the calculation has been parsed and typed, there should
+            // always be something to get.
+            .getUnsafe()
+        );
+
+      case "length":
+        return length(value);
     }
   }
 }

--- a/packages/alfa-style/src/resolver.ts
+++ b/packages/alfa-style/src/resolver.ts
@@ -39,8 +39,19 @@ export namespace Resolver {
 
   /**
    * Resolve a length in an arbitrary unit to a length in pixels.
+   * Absolute lengths are left untouched, and normalised into "px".
+   * Relative lengths resolution depends on another length which is passed as
+   * part of a Style:
+   * * viewport dimensions are fetch from style.device;
+   * * root relative depend on style.root().computed("font-size");
+   * * other relative unit depend on style.conputed("font-size");
    *
-   * {@link https://drafts.csswg.org/css-values/#lengths}
+   * In nearly all cases, the style is the element's own style, except for
+   * resolving font-size itself, in which case the parent's style is used.
+   * Since the resolver doesn't know which property is resolved, the onus of
+   * providing the correct style is left on the caller.
+   *
+   * {@link https://drafts.csswg.org/css-values/#relative-lengths}
    */
   export function length(style: Style): Mapper<Length, Length<"px">>;
 

--- a/packages/alfa-style/tsconfig.json
+++ b/packages/alfa-style/tsconfig.json
@@ -174,6 +174,7 @@
     "src/property/text-shadow.ts",
     "src/property/top.ts",
     "src/property/transform.ts",
+    "src/property/value/compound.ts",
     "src/property/value/list.ts",
     "src/property/value/tuple.ts",
     "src/property/vertical-align.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1468,6 +1468,7 @@ __metadata:
     "@siteimprove/alfa-predicate": "workspace:^0.62.2"
     "@siteimprove/alfa-refinement": "workspace:^0.62.2"
     "@siteimprove/alfa-result": "workspace:^0.62.2"
+    "@siteimprove/alfa-selective": "workspace:^0.62.2"
     "@siteimprove/alfa-selector": "workspace:^0.62.2"
     "@siteimprove/alfa-set": "workspace:^0.62.2"
     "@siteimprove/alfa-slice": "workspace:^0.62.2"


### PR DESCRIPTION
Part of #1037 and #1202.

Create an abstraction for length, length-percentage, and number that can also be the result of calculations. The abstraction is easy to use in individual properties since it appears as a CSS value with a handy resolver to absolutize it.
