### PR TITLE
Update package-dependency-graph and node

### DIFF
--- a/.github/workflows/alfa-release.yml
+++ b/.github/workflows/alfa-release.yml
@@ -66,7 +66,7 @@ jobs:
           token: ${{ secrets.token }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
           registry-url: 'https://npm.pkg.github.com'
           scope: '@siteimprove'

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-2019]
-        node: [14, 16]
+        node: [18, 20]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
       - run: yarn install --immutable
       - run: yarn build --quiet

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "axios": "^0.27.2",
     "execa": "^5.1.1",
     "minimist": "^1.2.6",
-    "package-dependency-graph": "^1.14.3",
+    "package-dependency-graph": "^1.14.4",
     "prettier": "^2.7.1",
     "typescript": "^5.0.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1676,7 +1676,7 @@ __metadata:
     axios: ^0.27.2
     execa: ^5.1.1
     minimist: ^1.2.6
-    package-dependency-graph: ^1.14.3
+    package-dependency-graph: ^1.14.4
     prettier: ^2.7.1
     typescript: ^5.0.4
   languageName: unknown
@@ -2101,6 +2101,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"brace-expansion@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "brace-expansion@npm:2.0.1"
+  dependencies:
+    balanced-match: ^1.0.0
+  checksum: a61e7cd2e8a8505e9f0036b3b6108ba5e926b4b55089eeb5550cd04a471fe216c96d4fe7e4c7f995c728c554ae20ddfc4244cad10aef255e72b62930afd233d1
+  languageName: node
+  linkType: hard
+
 "braces@npm:^3.0.2":
   version: 3.0.2
   resolution: "braces@npm:3.0.2"
@@ -2218,14 +2227,14 @@ __metadata:
   linkType: hard
 
 "canvas@npm:2":
-  version: 2.9.0
-  resolution: "canvas@npm:2.9.0"
+  version: 2.11.2
+  resolution: "canvas@npm:2.11.2"
   dependencies:
     "@mapbox/node-pre-gyp": ^1.0.0
-    nan: ^2.15.0
+    nan: ^2.17.0
     node-gyp: latest
     simple-get: ^3.0.3
-  checksum: 376ccd47340a46c04d5cabafd6feb1b7ae82c92dc3ae6db68c9cbac17ec1c43d2bf6aab60019690e9d49bf40b41bee3e4e0a8901f39b53e993789698e77e2699
+  checksum: 61e554aef80022841dc836964534082ec21435928498032562089dfb7736215f039c7d99ee546b0cf10780232d9bf310950f8b4d489dc394e0fb6f6adfc97994
   languageName: node
   linkType: hard
 
@@ -3162,7 +3171,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:7, glob@npm:^7.1.3, glob@npm:^7.1.4":
+"glob@npm:7 || 8":
+  version: 8.1.0
+  resolution: "glob@npm:8.1.0"
+  dependencies:
+    fs.realpath: ^1.0.0
+    inflight: ^1.0.4
+    inherits: 2
+    minimatch: ^5.0.1
+    once: ^1.3.0
+  checksum: 92fbea3221a7d12075f26f0227abac435de868dd0736a17170663783296d0dd8d3d532a5672b4488a439bf5d7fb85cdd07c11185d6cd39184f0385cbdfb86a47
+  languageName: node
+  linkType: hard
+
+"glob@npm:^7.1.3, glob@npm:^7.1.4":
   version: 7.2.0
   resolution: "glob@npm:7.2.0"
   dependencies:
@@ -4036,6 +4058,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^5.0.1":
+  version: 5.1.6
+  resolution: "minimatch@npm:5.1.6"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: 7564208ef81d7065a370f788d337cd80a689e981042cb9a1d0e6580b6c6a8c9279eba80010516e258835a988363f99f54a6f711a315089b8b42694f5da9d0d77
+  languageName: node
+  linkType: hard
+
 "minimist-options@npm:^4.0.2":
   version: 4.1.0
   resolution: "minimist-options@npm:4.1.0"
@@ -4168,12 +4199,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nan@npm:^2.15.0":
-  version: 2.15.0
-  resolution: "nan@npm:2.15.0"
+"nan@npm:^2.17.0":
+  version: 2.17.0
+  resolution: "nan@npm:2.17.0"
   dependencies:
     node-gyp: latest
-  checksum: 33e1bb4dfca447fe37d4bb5889be55de154828632c8d38646db67293a21afd61ed9909cdf1b886214a64707d935926c4e60e2b09de9edfc2ad58de31d6ce8f39
+  checksum: ec609aeaf7e68b76592a3ba96b372aa7f5df5b056c1e37410b0f1deefbab5a57a922061e2c5b369bae9c7c6b5e6eecf4ad2dac8833a1a7d3a751e0a7c7f849ed
   languageName: node
   linkType: hard
 
@@ -4428,41 +4459,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"package-dependency-collect@npm:^1.14.2":
-  version: 1.14.2
-  resolution: "package-dependency-collect@npm:1.14.2"
+"package-dependency-collect@npm:^1.14.4":
+  version: 1.14.4
+  resolution: "package-dependency-collect@npm:1.14.4"
   dependencies:
-    glob: 7
+    glob: 7 || 8
     tslib: 1 || 2
-  checksum: 98e4902fada7b5cbf35b398c973f8ef118000945b768ad9f93aac8fbfbff2853209e066f2f095d683ac7af7e8a872e024410b446df15e2da22775b7acf660b14
+  checksum: 26392eb6dcebdb04b5ae14142ba0c2a1a35238eb522be019cf3cf94de78bb997b55fddbd815275fb8421f32f446419f3b369d5bf7d37d74b06568f351bdbd756
   languageName: node
   linkType: hard
 
-"package-dependency-graph-core@npm:^1.14.3":
-  version: 1.14.3
-  resolution: "package-dependency-graph-core@npm:1.14.3"
+"package-dependency-graph-core@npm:^1.14.4":
+  version: 1.14.4
+  resolution: "package-dependency-graph-core@npm:1.14.4"
   dependencies:
     dagre-cluster-fix: 0.9.3
-    package-dependency-collect: ^1.14.2
+    package-dependency-collect: ^1.14.4
     tslib: 1 || 2
-  checksum: f7951614164e6c50c707ee99f519d0df24c9789015686d3a3610137b18541b7373866ad3b14dae0815e2d080a92faabb14a6e5f00ede66f558eaeeeec7802f98
+  checksum: c6d17e43fed352a151d9370fe33e429bd7a699da86db6db487c5af91aeda20fc5bf98d05339fa5977b15d13eec08545d7c10c38708f17d584cf28720cce9c285
   languageName: node
   linkType: hard
 
-"package-dependency-graph@npm:^1.14.3":
-  version: 1.14.3
-  resolution: "package-dependency-graph@npm:1.14.3"
+"package-dependency-graph@npm:^1.14.4":
+  version: 1.14.4
+  resolution: "package-dependency-graph@npm:1.14.4"
   dependencies:
     canvas: 2
     dagre-canvas: ^1.14.1
     dagre-svg: ^1.14.1
     graphviz-cli: 1
     minimist: 1
-    package-dependency-graph-core: ^1.14.3
+    package-dependency-graph-core: ^1.14.4
     ts-node: "*"
   bin:
     package-dependency-graph: bin/package-dependency-graph
-  checksum: 80f0bba262b76ff5d336052e44915f44c0c8ec82e4bdd091070fe49aa8f358b5aae9b39dfa1b6f8b16a1225c1ad9637e6d3ca725fb02d0427f09177958aa8c3c
+  checksum: f904ab4361a5786532f55d1f8b7677b804684e560c8de7a0071481eced0cff3348baa9a63f525ef55fa09bad5a1affaa8da65ce393ddfe2ffba76e65027fbd13
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves #1356 

Update `package-dependency-graph`, and especially its `canvas` dependency to get a version with prebuilds for node 18 and 20.
Switch the Github actions matrices from node (14, 16) to (18, 20) as 14 is now in End of life, and 16 will be in September 2023.

