### PR TITLE
Do not clutter packages changelogs with deps version changes

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,8 +1,17 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
-  "changelog": ["@svitejs/changesets-changelog-github-compact", { "repo": "Siteimprove/alfa" }],
+  "changelog": [
+    "../scripts/src/changelog.js",
+    {
+      "repo": "Siteimprove/alfa"
+    }
+  ],
   "commit": false,
-  "fixed": [["@siteimprove/alfa-*"]],
+  "fixed": [
+    [
+      "@siteimprove/alfa-*"
+    ]
+  ],
   "linked": [],
   "access": "restricted",
   "baseBranch": "main",

--- a/.github/workflows/alfa-release.yml
+++ b/.github/workflows/alfa-release.yml
@@ -78,6 +78,8 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --immutable
+      - name: Build changelog script
+        run: yarn build scripts
 
       - name: Is current version unique?
         # Check that all packages are at the same version, if not, abort.

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ node_modules
 **/*.map
 
 !**/scripts/**/*.js
+scripts/src/changelog.js
 !**/types/**/*.d.ts

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   ],
   "devDependencies": {
     "@changesets/cli": "^2.26.1",
+    "@changesets/types": "^5.2.1",
     "@microsoft/api-documenter": "^7.19.9",
     "@microsoft/api-extractor": "^7.29.5",
-    "@svitejs/changesets-changelog-github-compact": "^1.1.0",
     "@types/async": "^3.2.5",
     "@types/jsonld": "^1.5.6",
     "@types/node": "^14.14.31",

--- a/scripts/src/changelog.ts
+++ b/scripts/src/changelog.ts
@@ -1,0 +1,110 @@
+/**
+ * Generate changelogs from the changesets.
+ * {@link https://github.com/changesets/changesets/blob/main/docs/modifying-changelog-format.md}
+ *
+ * @remarks
+ * This is copied from {@link https://github.com/svitejs/changesets-changelog-github-compact}
+ * but removing the list of dependencies updates that is cluttering the packages
+ * changelogs
+ */
+
+import type {
+  ChangelogFunctions,
+  NewChangesetWithCommit,
+  VersionType,
+} from "@changesets/types";
+import { getInfo, getInfoFromPullRequest } from "@changesets/get-github-info";
+
+function validate(options: Record<string, any> | null) {
+  if (!options || !options.repo) {
+    throw new Error(
+      'Please provide a repo to this changelog generator like this:\n"changelog": ["path/to/changelog.js", { "repo": "org/repo" }]'
+    );
+  }
+}
+
+async function getDependencyReleaseLine(): Promise<string> {
+  return "";
+}
+
+async function getReleaseLine(
+  changeset: NewChangesetWithCommit,
+  type: VersionType,
+  options: Record<string, any> | null
+): Promise<string> {
+  validate(options);
+  const repo = options!.repo;
+  let prFromSummary: number | undefined;
+  let commitFromSummary: string | undefined;
+
+  const replacedChangelog = changeset.summary
+    .replace(/^\s*(?:pr|pull|pull\s+request):\s*#?(\d+)/im, (_, pr) => {
+      const num = Number(pr);
+      if (!isNaN(num)) prFromSummary = num;
+      return "";
+    })
+    .replace(/^\s*commit:\s*([^\s]+)/im, (_, commit) => {
+      commitFromSummary = commit;
+      return "";
+    })
+    .replace(/^\s*(?:author|user):\s*@?([^\s]+)/gim, "")
+    .trim();
+
+  // add links to issue hints (fix #123) => (fix [#123](https://....))
+  const linkifyIssueHints = (line: string) =>
+    line.replace(/(?<=\( ?(?:fix|fixes|see) )(#\d+)(?= ?\))/g, (issueHash) => {
+      return `[${issueHash}](https://github.com/${repo}/issues/${issueHash.substring(
+        1
+      )})`;
+    });
+  const [firstLine, ...futureLines] = replacedChangelog
+    .split("\n")
+    .map((l) => linkifyIssueHints(l.trimRight()));
+
+  const links = await (async () => {
+    if (prFromSummary !== undefined) {
+      let { links } = await getInfoFromPullRequest({
+        repo,
+        pull: prFromSummary,
+      });
+      if (commitFromSummary) {
+        links = {
+          ...links,
+          commit: `[\`${commitFromSummary}\`](https://github.com/${repo}/commit/${commitFromSummary})`,
+        };
+      }
+      return links;
+    }
+    const commitToFetchFrom = commitFromSummary || changeset.commit;
+    if (commitToFetchFrom) {
+      const { links } = await getInfo({
+        repo,
+        commit: commitToFetchFrom,
+      });
+      return links;
+    }
+    return {
+      commit: null,
+      pull: null,
+      user: null,
+    };
+  })();
+
+  // only link PR or merge commit not both
+  const suffix = links.pull
+    ? ` (${links.pull})`
+    : links.commit
+    ? ` (${links.commit})`
+    : "";
+
+  return `\n- ${firstLine}${suffix}\n${futureLines
+    .map((l) => `  ${l}`)
+    .join("\n")}`;
+}
+
+const changelogFunctions: ChangelogFunctions = {
+  getDependencyReleaseLine,
+  getReleaseLine,
+};
+
+export default changelogFunctions;

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["es2018", "dom"],
+    "types": ["node"],
+  },
+  "files": ["src/changelog.ts"],
+  "references": [
+    {
+      "path": "../packages"
+    }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,11 +14,8 @@
   },
   "files": [],
   "references": [
-    {
-      "path": "packages"
-    },
-    {
-      "path": "scratches"
-    }
+    { "path": "packages" },
+    { "path": "scratches" },
+    { "path": "scripts" }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -172,16 +172,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/get-github-info@npm:^0.5.2":
-  version: 0.5.2
-  resolution: "@changesets/get-github-info@npm:0.5.2"
-  dependencies:
-    dataloader: ^1.4.0
-    node-fetch: ^2.5.0
-  checksum: 067e07eeaecdbedbd1c715513c4aa6206a941bd1d3af292d067792808c6fa6644caad2b35fba614a44892559c031c234df8028f8d2abd4cb2682d48080ef5df3
-  languageName: node
-  linkType: hard
-
 "@changesets/get-release-plan@npm:^3.0.16":
   version: 3.0.16
   resolution: "@changesets/get-release-plan@npm:3.0.16"
@@ -1680,9 +1670,9 @@ __metadata:
   resolution: "@siteimprove/alfa@workspace:."
   dependencies:
     "@changesets/cli": ^2.26.1
+    "@changesets/types": ^5.2.1
     "@microsoft/api-documenter": ^7.19.9
     "@microsoft/api-extractor": ^7.29.5
-    "@svitejs/changesets-changelog-github-compact": ^1.1.0
     "@types/async": ^3.2.5
     "@types/jsonld": ^1.5.6
     "@types/node": ^14.14.31
@@ -1695,16 +1685,6 @@ __metadata:
     typescript: ^5.0.4
   languageName: unknown
   linkType: soft
-
-"@svitejs/changesets-changelog-github-compact@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@svitejs/changesets-changelog-github-compact@npm:1.1.0"
-  dependencies:
-    "@changesets/get-github-info": ^0.5.2
-    dotenv: ^16.0.3
-  checksum: 51a8727f6ee5d0eddc48c24ef1b809d714d1d1b04cbb4bbb33f39e3096708e7f5957274a2fcaa8eeb273a16295f0f612ca4d7e5e672dfce558e1f3d7faeb1815
-  languageName: node
-  linkType: hard
 
 "@tootallnate/once@npm:1":
   version: 1.1.2
@@ -2563,13 +2543,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dataloader@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "dataloader@npm:1.4.0"
-  checksum: e2c93d43afde68980efc0cd9ff48e9851116e27a9687f863e02b56d46f7e7868cc762cd6dcbaf4197e1ca850a03651510c165c2ae24b8e9843fd894002ad0e20
-  languageName: node
-  linkType: hard
-
 "debug@npm:4, debug@npm:4.3.4, debug@npm:^4.1.0, debug@npm:^4.1.1":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
@@ -2684,13 +2657,6 @@ __metadata:
   dependencies:
     path-type: ^4.0.0
   checksum: fa05e18324510d7283f55862f3161c6759a3f2f8dbce491a2fc14c8324c498286c54282c1f0e933cb930da8419b30679389499b919122952a4f8592362ef4615
-  languageName: node
-  linkType: hard
-
-"dotenv@npm:^16.0.3":
-  version: 16.0.3
-  resolution: "dotenv@npm:16.0.3"
-  checksum: afcf03f373d7a6d62c7e9afea6328e62851d627a4e73f2e12d0a8deae1cd375892004f3021883f8aec85932cd2834b091f568ced92b4774625b321db83b827f8
   languageName: node
   linkType: hard
 
@@ -4236,7 +4202,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.5.0, node-fetch@npm:^2.6.5":
+"node-fetch@npm:^2.6.5":
   version: 2.6.9
   resolution: "node-fetch@npm:2.6.9"
   dependencies:


### PR DESCRIPTION
Make our own changelog generating functions to not include the "updated dependencies" bit, this was cluttering the changelogs beyond readability.
