### PR TITLE
SIA-R13: make inapplicable to `<iframe>` that are marked as decorative.

### DIFF
--- a/.changeset/orange-cameras-ring.md
+++ b/.changeset/orange-cameras-ring.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-rules": patch
+---
+
+**Changed:** SIA-R13 is now inapplicable to `<iframe>` elements that are marked as decorative, following latest ACT rules changes.

--- a/packages/alfa-rules/src/sia-r13/rule.ts
+++ b/packages/alfa-rules/src/sia-r13/rule.ts
@@ -10,7 +10,11 @@ import { expectation } from "../common/act/expectation";
 
 import { Scope } from "../tags";
 
-const { hasNonEmptyAccessibleName, isIncludedInTheAccessibilityTree } = DOM;
+const {
+  hasNonEmptyAccessibleName,
+  isIncludedInTheAccessibilityTree,
+  isMarkedDecorative,
+} = DOM;
 const { hasName, hasNamespace, hasTabIndex } = Element;
 const { and, not } = Predicate;
 const { getElementDescendants } = Query;
@@ -27,7 +31,8 @@ export default Rule.Atomic.of<Page, Element>({
             hasNamespace(Namespace.HTML),
             hasName("iframe"),
             isIncludedInTheAccessibilityTree(device),
-            not(hasTabIndex((n) => n < 0))
+            not(hasTabIndex((n) => n < 0)),
+            not(isMarkedDecorative)
           )
         );
       },

--- a/packages/alfa-rules/test/sia-r13/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r13/rule.spec.tsx
@@ -70,3 +70,11 @@ test(`evaluates() is inapplicable to an <iframe> with negative tabindex`, async 
 
   t.deepEqual(await evaluate(R13, { document }), [inapplicable(R13)]);
 });
+
+test("evaluates() is inapplicable to an <iframe> that is marked as decorative", async (t) => {
+  const target = <iframe title="iframe" srcdoc="Hello World!" role="none" />;
+
+  const document = h.document([target]);
+
+  t.deepEqual(await evaluate(R13, { document }), [inapplicable(R13)]);
+});


### PR DESCRIPTION
Following https://github.com/act-rules/act-rules.github.io/pull/2034 and https://github.com/Siteimprove/sanshikan/pull/292
