### PR TITLE
Fix false positive bug in R75

### DIFF
--- a/.changeset/silver-lions-smoke.md
+++ b/.changeset/silver-lions-smoke.md
@@ -1,0 +1,8 @@
+---
+"@siteimprove/alfa-rules": patch
+---
+
+**Fixed:** Issue where R75 would incorrectly flag some elements with invisible text
+
+This was due to a change in the applicability of the rule which exposed some elements to being misidentified as having insufficient font size, even though they in fact had invisible text.
+Other elements are in some cases also now passing where they would previously not be flagged by the rule, but this is not considered a bug.

--- a/packages/alfa-rules/src/sia-r75/rule.ts
+++ b/packages/alfa-rules/src/sia-r75/rule.ts
@@ -40,14 +40,15 @@ export default Rule.Atomic.of<Page, Element>({
           and(
             hasNamespace(Namespace.HTML),
             not(hasName("sup", "sub")),
-            (node) =>
+            not((node) =>
               visibleTextCache
                 .get(node, () =>
                   node
                     .descendants(Node.fullTree)
                     .filter(and(isText, isVisible(device)))
                 )
-                .some(() => true),
+                .isEmpty()
+            ),
             hasCascadedStyle(`font-size`, () => true, device)
           )
         );

--- a/packages/alfa-rules/test/sia-r75/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r75/rule.spec.tsx
@@ -5,7 +5,7 @@ import { test } from "@siteimprove/alfa-test";
 import R75, { Outcomes } from "../../src/sia-r75/rule";
 
 import { evaluate } from "../common/evaluate";
-import { passed, failed, inapplicable } from "../common/outcome";
+import { failed, inapplicable, passed } from "../common/outcome";
 
 const fontSize = (value: string) => Declaration.of("font-size", value);
 const makeTarget = (
@@ -148,4 +148,47 @@ test("evaluate() is inapplicable to a <sup> element", async (t) => {
   const document = h.document([target]);
 
   t.deepEqual(await evaluate(R75, { document }), [inapplicable(R75)]);
+});
+
+test("evaluate() passes visible element with font-size: 0px and non-whitespace text", async (t) => {
+  const div = <div style={{ fontSize: "14px" }}>world</div>;
+  const target = (
+    <div style={{ background: "#eee", fontSize: "0px" }}>
+      hello
+      {div}!
+    </div>
+  );
+
+  const document = h.document([target]);
+
+  t.deepEqual(await evaluate(R75, { document }), [
+    passed(R75, target, {
+      1: Outcomes.IsSufficient(Option.of(fontSize("0px"))),
+    }),
+    passed(R75, div, {
+      1: Outcomes.IsSufficient(Option.of(fontSize("14px"))),
+    }),
+  ]);
+});
+
+test("evaluate() passes visible element with font-size: 0px and whitespace text", async (t) => {
+  const div = <div style={{ fontSize: "14px" }}>world</div>;
+  const target = (
+    <div style={{ background: "#eee", fontSize: "0px" }}>
+      {h.text("\n")}
+      {div}
+      {h.text("\n")}
+    </div>
+  );
+
+  const document = h.document([target]);
+
+  t.deepEqual(await evaluate(R75, { document }), [
+    passed(R75, target, {
+      1: Outcomes.IsSufficient(Option.of(fontSize("0px"))),
+    }),
+    passed(R75, div, {
+      1: Outcomes.IsSufficient(Option.of(fontSize("14px"))),
+    }),
+  ]);
 });


### PR DESCRIPTION
In v0.65.0, there were two changes in behavior in R75.
In
```html
<div style="background: #eee; font-size: 0px">
    <div style="font-size: 14px">world</div>
</div>
```
R75 was previously not applicable to the first `div` because the applicability explicitly checked for `font-size: 0px`. In v0.65.0 that check was removed and we instead expected `isVisible` to filter out elements with `font-size: 0px`. It doesn't however because the element is still be visible so the rule now applies to more elements than before. We decided that was acceptable in this case because the rules passes this element since the non-whitespace text content is large enough. We still rewrote the applicability so that it checks for "elements with visible text" in stead of "visible elements with text" as that is closer to the intended applicability as stated on https://alfa.siteimprove.com/rules/sia-r75.

On the other hand, in
```html
<div style="background: #eee; font-size: 0px">
    hello
    <div style="font-size: 14px">world</div>
</div>
```
the first `div` would incorrectly be flagged as an error due to the fact that it now passed the applicability test and contained non-whitespace text `hello`. So the "real" bug, which was just uncovered by the change to the applicability, was actually in `.expectations()` since that didn't filter out the invisible `hello` when checking for font-size >= 9px.