### PR TITLE
SIA-R19: fix regression

### DIFF
--- a/.changeset/rotten-socks-approve.md
+++ b/.changeset/rotten-socks-approve.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-rules": patch
+---
+
+**Fixed:** SIA-R19 correctly searches for `id` in the full DOM tree again (instead of the subtree of the element).

--- a/docs/review/api/alfa-dom.api.md
+++ b/docs/review/api/alfa-dom.api.md
@@ -409,7 +409,7 @@ export namespace Fragment {
 // @public (undocumented)
 function getElementDescendants(node: Node, options?: Node.Traversal): Sequence<Element>;
 
-// @public (undocumented)
+// @public
 function getElementIdMap(node: Node): Map_2<string, Element>;
 
 // Warning: (ae-forgotten-export) The symbol "Options" needs to be exported by the entry point index.d.ts

--- a/packages/alfa-dom/src/node/query/element-id-map.ts
+++ b/packages/alfa-dom/src/node/query/element-id-map.ts
@@ -10,10 +10,13 @@ import { getElementDescendants } from "./element-descendants";
 const elementMapCache = Cache.empty<Document, Map<string, Element>>();
 
 /**
- * @public
+ * Returns a map from id to elements, in the subtree rooted at a given node.
  *
- * @remarks Since `id` are scoped to trees, and do not cross shadow or content boundaries,
+ * @privateRemarks
+ * Since `id` are scoped to trees, and do not cross shadow or content boundaries,
  * we never need traversal options.
+ *
+ * @public
  */
 export function getElementIdMap(node: Node): Map<string, Element> {
   if (Document.isDocument(node)) {

--- a/packages/alfa-rules/src/sia-r19/rule.ts
+++ b/packages/alfa-rules/src/sia-r19/rule.ts
@@ -115,7 +115,8 @@ function isValid(attribute: aria.Attribute): boolean {
 }
 
 function treeHasId(id: string, node: Node): boolean {
-  return Query.getElementIdMap(node).has(id);
+  // Since ID are scoped to tree, we need no traversal option to find the root.
+  return Query.getElementIdMap(node.root()).has(id);
 }
 
 /**

--- a/packages/alfa-rules/test/sia-r19/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r19/rule.spec.tsx
@@ -291,6 +291,19 @@ test("evaluate() fails a required aria-controls property pointing to a non-exist
   ]);
 });
 
+test("evaluate() passes a required aria-controls property pointing to an existent ID", async (t) => {
+  const target = <div role="scrollbar" aria-controls="content"></div>;
+  const controlled = <div id="content"></div>;
+
+  const document = h.document([target, controlled]);
+
+  t.deepEqual(await evaluate(R19, { document }), [
+    passed(R19, target.attribute("aria-controls").getUnsafe(), {
+      1: Outcomes.HasValidValue,
+    }),
+  ]);
+});
+
 test("evaluate() is inapplicable when an element does not have any ARIA attribute", async (t) => {
   const document = h.document([<div>Some Content</div>]);
 


### PR DESCRIPTION
Back in [#1413](https://github.com/Siteimprove/alfa/pull/1413/files#diff-264574bd61bf30e83177f4f8f2af2e52fb9308fc56bfe55c7ab97e8fd3de115cL119-L131) we accidentally started searching for IDs in the subtree of the element, rather than its full tree (going to the root).
Fixing it.
