### PR TITLE
Use layout to improve handling of interposed elements

### DIFF
--- a/.changeset/calm-camels-sell.md
+++ b/.changeset/calm-camels-sell.md
@@ -1,0 +1,7 @@
+---
+"@siteimprove/alfa-rules": minor
+---
+
+**Changed:** Color contrast rules, currently SIA-R66 and SIA-R69, can now tell which interposed elements can be ignored if layout is available.
+
+If layout is not available the rules keep the current behavior of asking a `ignored-interposed-elements` question.

--- a/.changeset/empty-ears-cheat.md
+++ b/.changeset/empty-ears-cheat.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-selector": minor
+---
+
+**Added:** A function `isEmpty` to `Context` class

--- a/.changeset/lovely-bees-type.md
+++ b/.changeset/lovely-bees-type.md
@@ -1,0 +1,7 @@
+---
+"@siteimprove/alfa-style": minor
+---
+
+Added: A function for getting the bounding box of an element given a device.
+
+This should be the only way of accessing an elements bounding box and prepares us for having device dependent boxes.

--- a/.changeset/lovely-bees-type.md
+++ b/.changeset/lovely-bees-type.md
@@ -2,6 +2,6 @@
 "@siteimprove/alfa-style": minor
 ---
 
-Added: A function for getting the bounding box of an element given a device.
+**Added:** A function for getting the bounding box of an element given a device.
 
 This should be the only way of accessing an elements bounding box and prepares us for having device dependent boxes.

--- a/docs/review/api/alfa-selector.api.md
+++ b/docs/review/api/alfa-selector.api.md
@@ -42,6 +42,8 @@ export class Context {
     // (undocumented)
     isActive(element: Element): boolean;
     // (undocumented)
+    isEmpty(): boolean;
+    // (undocumented)
     isFocused(element: Element): boolean;
     // (undocumented)
     isHovered(element: Element): boolean;

--- a/docs/review/api/alfa-style.api.md
+++ b/docs/review/api/alfa-style.api.md
@@ -50,7 +50,7 @@ import { Unit } from '@siteimprove/alfa-css';
 import { URL } from '@siteimprove/alfa-css';
 
 // @public
-function getBoundingBox(element: Element, device: Device): Option<Rectangle_2>;
+function getBoundingBox(element: Element, device: Device, context?: Context): Option<Rectangle_2>;
 
 // @public (undocumented)
 function getOffsetParent(element: Element, device: Device): Option<Element>;
@@ -444,6 +444,7 @@ export namespace Style {
     const // Warning: (ae-forgotten-export) The symbol "element" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
+    getBoundingBox: typeof element.getBoundingBox, // (undocumented)
     getOffsetParent: typeof element.getOffsetParent, // (undocumented)
     getPositioningParent: typeof element.getPositioningParent, // (undocumented)
     hasBorder: typeof element.hasBorder, // (undocumented)

--- a/docs/review/api/alfa-style.api.md
+++ b/docs/review/api/alfa-style.api.md
@@ -35,6 +35,7 @@ import { Percentage } from '@siteimprove/alfa-css';
 import { Position } from '@siteimprove/alfa-css';
 import { Predicate } from '@siteimprove/alfa-predicate';
 import { Rectangle } from '@siteimprove/alfa-css';
+import { Rectangle as Rectangle_2 } from '@siteimprove/alfa-rectangle';
 import { Rotate } from '@siteimprove/alfa-css';
 import { Serializable } from '@siteimprove/alfa-json';
 import { Shadow } from '@siteimprove/alfa-css';
@@ -47,6 +48,9 @@ import { Transform } from '@siteimprove/alfa-css';
 import { Tuple } from '@siteimprove/alfa-css';
 import { Unit } from '@siteimprove/alfa-css';
 import { URL } from '@siteimprove/alfa-css';
+
+// @public
+function getBoundingBox(element: Element, device: Device): Option<Rectangle_2>;
 
 // @public (undocumented)
 function getOffsetParent(element: Element, device: Device): Option<Element>;

--- a/packages/alfa-rules/src/common/expectation/contrast.ts
+++ b/packages/alfa-rules/src/common/expectation/contrast.ts
@@ -249,7 +249,6 @@ function getIntersectors(
 
   const elementBox = getBoundingBox(element, device);
 
-  // If just one of the elements involved doesn't have a bounding box, we regard that as an invalid state for deciding intersectors and return `None`
   if (
     !elementBox.isSome() ||
     Iterable.some(candidates, (candidate) =>

--- a/packages/alfa-rules/src/common/expectation/contrast.ts
+++ b/packages/alfa-rules/src/common/expectation/contrast.ts
@@ -235,7 +235,7 @@ export function contrast(foreground: RGB, background: RGB): number {
  * Finds elements from a collection of candidate that intersect with a given element
  *
  * @remarks
- * If `candidates` is non-empty and just one element doesn't have layout `None` is returned
+ * If either the element or one of the `candidates` doesn't have layout, we can't fully decide intersection and return `None`.
  */
 function getIntersectors(
   element: Element<string>,

--- a/packages/alfa-rules/src/common/expectation/contrast.ts
+++ b/packages/alfa-rules/src/common/expectation/contrast.ts
@@ -265,7 +265,7 @@ function getIntersectors(
       (canditate) =>
         elementBox
           .get()
-          .intersects(getBoundingBox(canditate, device).getUnsafe()) // Precense of the box is guaranteed by the above check
+          .intersects(getBoundingBox(canditate, device).getUnsafe()) // Presence of the box is guaranteed by the above check
     )
   );
 }

--- a/packages/alfa-rules/src/common/expectation/contrast.ts
+++ b/packages/alfa-rules/src/common/expectation/contrast.ts
@@ -3,10 +3,10 @@ import { RGB } from "@siteimprove/alfa-css";
 import { Device } from "@siteimprove/alfa-device";
 import { Element, Node, Text } from "@siteimprove/alfa-dom";
 import { Iterable } from "@siteimprove/alfa-iterable";
-import { Set } from "@siteimprove/alfa-set";
-
 import { None, Option } from "@siteimprove/alfa-option";
-import { getBoundingBox } from "@siteimprove/alfa-style/src/element/element";
+import { Set } from "@siteimprove/alfa-set";
+import { Style } from "@siteimprove/alfa-style";
+
 import { expectation } from "../act/expectation";
 import { Group } from "../act/group";
 import { Question } from "../act/question";
@@ -18,6 +18,7 @@ import { isLargeText } from "../predicate";
 const { isElement } = Element;
 const { flatMap, map, takeWhile } = Iterable;
 const { min, max, round } = Math;
+const { getBoundingBox } = Style;
 
 /**
  * @deprecated This is only used in the deprecated R66v1 and R69v1.

--- a/packages/alfa-rules/src/common/expectation/contrast.ts
+++ b/packages/alfa-rules/src/common/expectation/contrast.ts
@@ -110,14 +110,6 @@ export function hasSufficientContrast(
   // for foreground and background.
   const interposedDescendants = Set.from(foreground).concat(background);
 
-  // If we have layout we should be able to answer the ignored-interposed-elements question
-
-  // 1. Check if (parent element of) target has layout, if not we cannot answer the question
-  // 2. If there is just one interposed element without layout we cannot answer the question, this corresponds to the status quo
-  // 3. If all interposed elements have layout, we can answer the question, the answer will be a list of all the interposed elements not overlapping the (parent element of the) target.
-  //    Note to self: The fact that we answered the question means it won't be asked to the consumer
-  //
-
   let ignoredInterposedElements = Question.of(
     "ignored-interposed-elements",
     Group.of(interposedDescendants),

--- a/packages/alfa-rules/test/sia-r69/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r69/rule.spec.tsx
@@ -4,19 +4,19 @@ import { Future } from "@siteimprove/alfa-future";
 import { None } from "@siteimprove/alfa-option";
 import { test } from "@siteimprove/alfa-test";
 
-import { RGB, Percentage, Keyword } from "@siteimprove/alfa-css";
+import { Keyword, Percentage, RGB } from "@siteimprove/alfa-css";
 import { Device } from "@siteimprove/alfa-device";
 import { Style } from "@siteimprove/alfa-style";
 
-import R69 from "../../src/sia-r69/rule";
 import { Contrast as Diagnostic } from "../../src/common/diagnostic/contrast";
 import { Contrast as Outcomes } from "../../src/common/outcome/contrast";
+import R69 from "../../src/sia-r69/rule";
 
 import { evaluate } from "../common/evaluate";
-import { passed, failed, cantTell, inapplicable } from "../common/outcome";
+import { cantTell, failed, inapplicable, passed } from "../common/outcome";
 
-import { oracle } from "../common/oracle";
 import { ColorError, ColorErrors } from "../../src/common/dom/get-colors";
+import { oracle } from "../common/oracle";
 
 const rgb = (r: number, g: number, b: number, a: number = 1) =>
   RGB.of(
@@ -842,6 +842,46 @@ test("evaluate() can tell when encountering an opaque background before an absol
     >
       {target}
     </div>,
+  ]);
+
+  t.deepEqual(await evaluate(R69, { document }), [
+    passed(R69, target, {
+      1: Outcomes.HasSufficientContrast(21, 4.5, [
+        Diagnostic.Pairing.of(
+          ["foreground", rgb(0, 0, 0)],
+          ["background", rgb(1, 1, 1)],
+          21
+        ),
+      ]),
+    }),
+  ]);
+});
+
+test("evaluate() can tell when interposed descendant overlaps offset parent, but does not overlap target", async (t) => {
+  const target = h.text("Hello World");
+
+  const document = h.document([
+    <body box={{ x: 8, y: 8, width: 1070, height: 126 }}>
+      <div
+        style={{
+          position: "absolute",
+          backgroundColor: "green",
+          opacity: "50%",
+          top: "100px",
+          left: "100px",
+          width: "100px",
+          height: "100px",
+        }}
+        box={{ x: 100, y: 100, width: 100, height: 100 }}
+      ></div>
+      <div box={{ x: 8, y: 8, width: 1070, height: 18 }}>{target}</div>
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+    </body>,
   ]);
 
   t.deepEqual(await evaluate(R69, { document }), [

--- a/packages/alfa-rules/test/sia-r69/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r69/rule.spec.tsx
@@ -896,30 +896,3 @@ test("evaluate() can tell when interposed descendant overlaps offset parent, but
     }),
   ]);
 });
-
-test("evaluate() does not ask about ignored interposed descendants when layout is available", async (t) => {
-  const target = h.text("Hello World");
-
-  const document = h.document([
-    <body box={{ x: 8, y: 8, width: 1070, height: 18 }}>
-      <div
-        style={{
-          position: "absolute",
-          backgroundColor: "green",
-          opacity: "50%",
-          width: "100px",
-          height: "100px",
-        }}
-        box={{ x: 8, y: 8, width: 100, height: 100 }}
-      ></div>
-      <div box={{ x: 8, y: 8, width: 1070, height: 18 }}>{target}</div>
-    </body>,
-  ]);
-
-  await evaluate(R69, { document }, (_, question) => {
-    if (question.uri === "ignored-interposed-elements") {
-      t.fail("An ignored-interposed-elements question was unexpectedly asked");
-    }
-    return Future.now(None);
-  });
-});

--- a/packages/alfa-rules/test/sia-r69/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r69/rule.spec.tsx
@@ -896,3 +896,30 @@ test("evaluate() can tell when interposed descendant overlaps offset parent, but
     }),
   ]);
 });
+
+test("evaluate() does not ask about ignored interposed descendants when layout is available", async (t) => {
+  const target = h.text("Hello World");
+
+  const document = h.document([
+    <body box={{ x: 8, y: 8, width: 1070, height: 18 }}>
+      <div
+        style={{
+          position: "absolute",
+          backgroundColor: "green",
+          opacity: "50%",
+          width: "100px",
+          height: "100px",
+        }}
+        box={{ x: 8, y: 8, width: 100, height: 100 }}
+      ></div>
+      <div box={{ x: 8, y: 8, width: 1070, height: 18 }}>{target}</div>
+    </body>,
+  ]);
+
+  await evaluate(R69, { document }, (_, question) => {
+    if (question.uri === "ignored-interposed-elements") {
+      t.fail("An ignored-interposed-elements question was unexpectedly asked");
+    }
+    return Future.now(None);
+  });
+});

--- a/packages/alfa-selector/src/context.ts
+++ b/packages/alfa-selector/src/context.ts
@@ -21,6 +21,10 @@ export class Context {
     this._state = state;
   }
 
+  public isEmpty(): boolean {
+    return this._state.isEmpty();
+  }
+
   public hasState(element: Element, state: Context.State): boolean {
     return this._state.get(element).some((found) => (found & state) !== 0);
   }

--- a/packages/alfa-style/src/element/element.ts
+++ b/packages/alfa-style/src/element/element.ts
@@ -1,3 +1,4 @@
+export * from "./helpers/get-bounding-box";
 export * from "./helpers/get-offset-parent";
 export * from "./helpers/get-positioning-parent";
 export * from "./predicate/has-border";

--- a/packages/alfa-style/src/element/helpers/get-bounding-box.ts
+++ b/packages/alfa-style/src/element/helpers/get-bounding-box.ts
@@ -1,0 +1,18 @@
+import { Device } from "@siteimprove/alfa-device";
+import { Element } from "@siteimprove/alfa-dom";
+import { Option } from "@siteimprove/alfa-option";
+import { Rectangle } from "@siteimprove/alfa-rectangle";
+
+/**
+ * @public
+ * Gets the bounding box, corresponding to a specific device, of an element
+ *
+ * @privateRemarks
+ * We don't use the passed in device yet, but later we should use it to ensure the device used to collect the bounding box corresponds to the current device
+ */
+export function getBoundingBox(
+  element: Element,
+  device: Device
+): Option<Rectangle> {
+  return element.box;
+}

--- a/packages/alfa-style/src/element/helpers/get-bounding-box.ts
+++ b/packages/alfa-style/src/element/helpers/get-bounding-box.ts
@@ -1,7 +1,8 @@
 import { Device } from "@siteimprove/alfa-device";
 import { Element } from "@siteimprove/alfa-dom";
-import { Option } from "@siteimprove/alfa-option";
+import { None, Option } from "@siteimprove/alfa-option";
 import { Rectangle } from "@siteimprove/alfa-rectangle";
+import { Context } from "@siteimprove/alfa-selector";
 
 /**
  * @public
@@ -12,7 +13,13 @@ import { Rectangle } from "@siteimprove/alfa-rectangle";
  */
 export function getBoundingBox(
   element: Element,
-  device: Device
+  device: Device,
+  context: Context = Context.empty()
 ): Option<Rectangle> {
+  // We assume layout is only grabbed on empty contexts, so if the context is non-empty we don't have layout
+  if (!context.isEmpty()) {
+    return None;
+  }
+
   return element.box;
 }

--- a/packages/alfa-style/src/style.ts
+++ b/packages/alfa-style/src/style.ts
@@ -336,6 +336,7 @@ export namespace Style {
   export type Inherited<N extends Name> = Longhands.Inherited<N>;
 
   export const {
+    getBoundingBox,
     getOffsetParent,
     getPositioningParent,
     hasBorder,

--- a/packages/alfa-style/tsconfig.json
+++ b/packages/alfa-style/tsconfig.json
@@ -7,6 +7,7 @@
   },
   "files": [
     "src/element/element.ts",
+    "src/element/helpers/get-bounding-box.ts",
     "src/element/helpers/get-offset-parent.ts",
     "src/element/helpers/get-positioning-parent.ts",
     "src/element/predicate/has-border.ts",


### PR DESCRIPTION
With this PR we now try to automatically answer the question of which interposed elements can be ignored using layout.

This will affect SIA-R66 and SIA-R69 so that they won't need to ask about ignored interposed descendants if layout is available.

In addition we prepare for getting device dependent boxes by adding a helper function `getBoundingBox(Element, Device)` to `alfa-style` even though we do not yet store information about which device was used to collect the boxes.