### PR TITLE
SIA-R70: Accept `<hgroup>`

### DIFF
--- a/.changeset/old-badgers-drive.md
+++ b/.changeset/old-badgers-drive.md
@@ -1,0 +1,7 @@
+---
+"@siteimprove/alfa-rules": patch
+---
+
+**Fixed:** SIA-R70 ow accepts `<hgroup>`.
+
+The element has been re-introduced in the HTML standard, with improved content model.

--- a/.changeset/purple-lemons-buy.md
+++ b/.changeset/purple-lemons-buy.md
@@ -1,0 +1,7 @@
+---
+"@siteimprove/alfa-aria": patch
+---
+
+**Fixed:** The `<hgroup>` element now has an implicit role of `group`.
+
+Following the re-introduction of `<hgroup>`, and subsequent changes to the HTML AAM.

--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -354,6 +354,8 @@ const Features: Features = {
       ),
     ),
 
+    hgroup: html("group"),
+
     hr: html("separator"),
 
     img: html(
@@ -799,7 +801,6 @@ const Features: Features = {
     body: Feature.generic,
     data: Feature.generic,
     div: Feature.generic,
-    hgroup: Feature.generic,
     i: Feature.generic,
     pre: Feature.generic,
     q: Feature.generic,

--- a/packages/alfa-rules/src/sia-r70/rule.ts
+++ b/packages/alfa-rules/src/sia-r70/rule.ts
@@ -36,7 +36,6 @@ const isDeprecated = hasName(
   "font",
   "frame",
   "frameset",
-  "hgroup",
   "image",
   "keygen",
   "marquee",


### PR DESCRIPTION
`<hgroup>` was de-deprecated some times ago, and is present again in the standard, with new content model:
https://html.spec.whatwg.org/multipage/sections.html#the-hgroup-element
