### PR TITLE
Fix `this` binding issue in alfa-performance

### DIFF
--- a/.changeset/metal-points-build.md
+++ b/.changeset/metal-points-build.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-performance": patch
+---
+
+**Fixed:** A bug caused runtime exceptions when calling `Performance.of()` in nrode v 19.0.0 and above has been fixed.

--- a/.changeset/metal-points-build.md
+++ b/.changeset/metal-points-build.md
@@ -2,4 +2,4 @@
 "@siteimprove/alfa-performance": patch
 ---
 
-**Fixed:** A bug caused runtime exceptions when calling `Performance.of()` in nrode v 19.0.0 and above has been fixed.
+**Fixed:** A bug caused runtime exceptions when calling `Performance.of()` in node v 19.0.0 and above has been fixed.

--- a/packages/alfa-performance/src/now.ts
+++ b/packages/alfa-performance/src/now.ts
@@ -3,15 +3,23 @@
 import { Thunk } from "@siteimprove/alfa-thunk";
 
 declare const require: (module: string) => any;
+const perfHooks = require("perf_hooks");
 
 export let now: Thunk<number>;
 
+/**
+ * The continuations are needed to correctly handle the "this" bindings.
+ * Eta-contracting breaks in node 19.0.0 and above. This may be linked to the
+ * upgrade to V8 10.7.
+ *
+ * Date.now actually works without the eta-expansion, keeping it for consistency.
+ */
 if (typeof performance !== "undefined") {
-  now = performance.now;
+  now = () => performance.now();
 } else {
   try {
-    now = require("perf_hooks").performance.now;
+    now = () => perfHooks.performance.now();
   } catch {
-    now = Date.now;
+    now = () => Date.now();
   }
 }


### PR DESCRIPTION
With Node 19.0.0 and above, `Performance.of()` throws at run time, with a `this` binding error message. This is likely due to a change how `performance` is implemented there 🤔, maybe related to the update to V8 10.7.

Anyway, this boiled down to the way `now` was defined. Eta-expanding the calls let the correct `this` bindings happen and stuff works again.