### PR TITLE
Show tested file during `yarn test`

### DIFF
--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -15,10 +15,24 @@ if (status !== 0) {
 test(flags.project);
 
 function test(root = "packages") {
+  let first = true;
+  let frameIndex = 0;
+  const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
   async.eachLimit(
     system.readDirectory(root, [".spec.ts", ".spec.tsx"], ["node_modules"]),
     os.cpus().length,
     (fileName, done) => {
+      if (!first) {
+        // Move cursor up one line and 13 to the left and erase
+        system.write("\x1B[1A\x1B[13D\x1B[K");
+      }
+      const frame = frames[frameIndex % frames.length];
+      system.write(frame + ` testing ${fileName}`);
+      system.write(system.newLine);
+      frameIndex++;
+      first = false;
+
       execaNode(fileName.replace(/\.tsx?$/, ".js"), [], {
         nodeOptions: [...process.execArgv, "--enable-source-maps"],
         stdio: "inherit",


### PR DESCRIPTION
Similarly to what we do for build, showing the tested file.
This is less perfect due to parallelism in tests, but at least shows it is not stuck 😄 
