### PR TITLE
Fix links in Changelogs of v0.69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 
 ### Fixed
 
-- [@siteimprove/alfa-rules](packages/alfa-rules/CHANGELOG.md#0690): SIA-R70 ow accepts `<hgroup>`.
+- [@siteimprove/alfa-rules](packages/alfa-rules/CHANGELOG.md#0690): SIA-R70 now accepts `<hgroup>`.
 
 - [@siteimprove/alfa-aria](packages/alfa-aria/CHANGELOG.md#0690): The `<hgroup>` element now has an implicit role of `group`.
 

--- a/packages/alfa-aria/CHANGELOG.md
+++ b/packages/alfa-aria/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- **Fixed:** The `<hgroup>` element now has an implicit role of `group`. ([`e2fe7c6f2`](https://github.com/Siteimprove/alfa/commit/e2fe7c6f2262327ce60b4a29504a20069f69e76c))
+- **Fixed:** The `<hgroup>` element now has an implicit role of `group`. ([#1506](https://github.com/Siteimprove/alfa/pull/1506))
 
   Following the re-introduction of `<hgroup>`, and subsequent changes to the HTML AAM.
 

--- a/packages/alfa-css/CHANGELOG.md
+++ b/packages/alfa-css/CHANGELOG.md
@@ -4,27 +4,27 @@
 
 ### Minor Changes
 
-- **Added:** `Value` now expose a `partiallyResolve()` instance method. ([`e2fe7c6f2`](https://github.com/Siteimprove/alfa/commit/e2fe7c6f2262327ce60b4a29504a20069f69e76c))
+- **Added:** `Value` now expose a `partiallyResolve()` instance method. ([#1495](https://github.com/Siteimprove/alfa/pull/1495))
 
-- **Breaking:** Various `Value.partiallyResolve()` functions have been removed. ([`e2fe7c6f2`](https://github.com/Siteimprove/alfa/commit/e2fe7c6f2262327ce60b4a29504a20069f69e76c))
+- **Breaking:** Various `Value.partiallyResolve()` functions have been removed. ([#1495](https://github.com/Siteimprove/alfa/pull/1495))
 
   Instead, use the corresponding `Value#partiallyResolve()` instance method.
 
-- **Added:** `Percentage` can now be partially resolved into fixed `Percentage`. ([`e2fe7c6f2`](https://github.com/Siteimprove/alfa/commit/e2fe7c6f2262327ce60b4a29504a20069f69e76c))
+- **Added:** `Percentage` can now be partially resolved into fixed `Percentage`. ([#1493](https://github.com/Siteimprove/alfa/pull/1493))
 
-- **Breaking:** The various `Value.parseBase` functions are no more available. ([`e2fe7c6f2`](https://github.com/Siteimprove/alfa/commit/e2fe7c6f2262327ce60b4a29504a20069f69e76c))
+- **Breaking:** The various `Value.parseBase` functions are no more available. ([#1487](https://github.com/Siteimprove/alfa/pull/1487))
 
   These where temporary helpers during migration to calculated values.
 
   Use `filter(Value.parse, value => !value.hasCalculation(), () => "Calculation not allowed")` instead.
 
-- **Breaking:** `Angle#resolve()` does not require a resolver anymore, since 100% is always 1 full turn. ([`e2fe7c6f2`](https://github.com/Siteimprove/alfa/commit/e2fe7c6f2262327ce60b4a29504a20069f69e76c))
+- **Breaking:** `Angle#resolve()` does not require a resolver anymore, since 100% is always 1 full turn. ([#1495](https://github.com/Siteimprove/alfa/pull/1495))
 
-- **Added:** a `AnglePercentage.resolve()` helper is now available to handle `Percentage` shenanigans. ([`e2fe7c6f2`](https://github.com/Siteimprove/alfa/commit/e2fe7c6f2262327ce60b4a29504a20069f69e76c))
+- **Added:** a `AnglePercentage.resolve()` helper is now available to handle `Percentage` shenanigans. ([#1493](https://github.com/Siteimprove/alfa/pull/1493))
 
-- **Added:** `Percentage` builders now accept an optional type hint indicating into what the percentage resolves. ([`e2fe7c6f2`](https://github.com/Siteimprove/alfa/commit/e2fe7c6f2262327ce60b4a29504a20069f69e76c))
+- **Added:** `Percentage` builders now accept an optional type hint indicating into what the percentage resolves. ([#1493](https://github.com/Siteimprove/alfa/pull/1493))
 
-- **Breaking:** CSS `Value` types no longer accept a `CALC` parameter; it is automatically inferred ([`e2fe7c6f2`](https://github.com/Siteimprove/alfa/commit/e2fe7c6f2262327ce60b4a29504a20069f69e76c))
+- **Breaking:** CSS `Value` types no longer accept a `CALC` parameter; it is automatically inferred ([#1491](https://github.com/Siteimprove/alfa/pull/1491))
 
 ## 0.68.0
 

--- a/packages/alfa-dom/CHANGELOG.md
+++ b/packages/alfa-dom/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Minor Changes
 
-- **Added:** Tree `Node`, and DOM `Node` can now have an `externalId` (`string`) and some `extraData` (`any`). ([`e2fe7c6f2`](https://github.com/Siteimprove/alfa/commit/e2fe7c6f2262327ce60b4a29504a20069f69e76c))
+- **Added:** Tree `Node`, and DOM `Node` can now have an `externalId` (`string`) and some `extraData` (`any`). ([#1498](https://github.com/Siteimprove/alfa/pull/1498))
 
   These are intended for callers that need to record some extra data during audits and retrieve it afterward. Especially, the `externalId` is intended for callers who already have an identifier for nodes and do not want to lose it during audits, nor maintain a map between these identifiers and Alfa nodes.
 
   Alfa is guaranteed to never interact with the `extraData` in any way; except that it will be typed as `any`, so any type guard or assertions must be re-applied afterward.
 
-  Alfa may, in the future, decide that `Node` with the same `externalId` can be identified in some way, e.g., because they represent two version of the same object that were turned into two different Alfa object. This can for example happen when two copies of the same page in different states (e.g., different tab opened) are audited; this creates two Alfa `Document`, but the external caller may have the extra knowledge that some of the nodes should be identified.
+  Alfa may, in the future, decide that `Node` with the same `externalId` can be identified in some way, e.g., because they represent two versions of the same object that were turned into two different Alfa object. This can for example happen when two copies of the same page in different states (e.g., different tab opened) are audited; this creates two Alfa `Document`, but the external caller may have the extra knowledge that some of the nodes should be identified.
 
   It is up to the callers to ensure that the `externalId` are unique, since they are meant to carry knowledge that Alfa cannot infer.
 

--- a/packages/alfa-rules/CHANGELOG.md
+++ b/packages/alfa-rules/CHANGELOG.md
@@ -4,17 +4,17 @@
 
 ### Minor Changes
 
-- **Added:** Accessible name is now recorded in the diagnostics for R15, R39, R41 and R81 ([`e2fe7c6f2`](https://github.com/Siteimprove/alfa/commit/e2fe7c6f2262327ce60b4a29504a20069f69e76c))
+- **Added:** Accessible name is now recorded in the diagnostics for R15, R39, R41 and R81 ([#1502](https://github.com/Siteimprove/alfa/pull/1502))
 
-- **Added:** Role is now recorded in the diagnostic for R8 ([`e2fe7c6f2`](https://github.com/Siteimprove/alfa/commit/e2fe7c6f2262327ce60b4a29504a20069f69e76c))
+- **Added:** Role is now recorded in the diagnostic for R8 ([#1504](https://github.com/Siteimprove/alfa/pull/1504))
 
-- **Breaking:** Diagnostics `WithPreviousHeading` and `WithNextHeading` have been replaced by `WithOtherHeading`. ([`e2fe7c6f2`](https://github.com/Siteimprove/alfa/commit/e2fe7c6f2262327ce60b4a29504a20069f69e76c))
+- **Breaking:** Diagnostics `WithPreviousHeading` and `WithNextHeading` have been replaced by `WithOtherHeading`. ([#1505](https://github.com/Siteimprove/alfa/pull/1505))
 
-- **Breaking:** Question `visible-focus-classes`, and question type `string[]` have been removed. ([`e2fe7c6f2`](https://github.com/Siteimprove/alfa/commit/e2fe7c6f2262327ce60b4a29504a20069f69e76c))
+- **Breaking:** Question `visible-focus-classes`, and question type `string[]` have been removed. ([#1497](https://github.com/Siteimprove/alfa/pull/1497))
 
 ### Patch Changes
 
-- **Fixed:** SIA-R70 ow accepts `<hgroup>`. ([`e2fe7c6f2`](https://github.com/Siteimprove/alfa/commit/e2fe7c6f2262327ce60b4a29504a20069f69e76c))
+- **Fixed:** SIA-R70 now accepts `<hgroup>`. ([#1506](https://github.com/Siteimprove/alfa/pull/1506))
 
   The element has been re-introduced in the HTML standard, with improved content model.
 

--- a/packages/alfa-style/CHANGELOG.md
+++ b/packages/alfa-style/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- **Breaking:** The `hasInlineStyleProperty` and `hasCascadedValueDeclaredInInlineStyleOf` predicates have been removed. ([`e2fe7c6f2`](https://github.com/Siteimprove/alfa/commit/e2fe7c6f2262327ce60b4a29504a20069f69e76c))
+- **Breaking:** The `hasInlineStyleProperty` and `hasCascadedValueDeclaredInInlineStyleOf` predicates have been removed. ([#1499](https://github.com/Siteimprove/alfa/pull/1499))
 
   These predicate were deprecated for a year, and the (deprecated) rules using them have already been removed.
 

--- a/packages/alfa-tree/CHANGELOG.md
+++ b/packages/alfa-tree/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Minor Changes
 
-- **Added:** Tree `Node`, and DOM `Node` can now have an `externalId` (`string`) and some `extraData` (`any`). ([`e2fe7c6f2`](https://github.com/Siteimprove/alfa/commit/e2fe7c6f2262327ce60b4a29504a20069f69e76c))
+- **Added:** Tree `Node`, and DOM `Node` can now have an `externalId` (`string`) and some `extraData` (`any`). ([#1498](https://github.com/Siteimprove/alfa/pull/1498))
 
   These are intended for callers that need to record some extra data during audits and retrieve it afterward. Especially, the `externalId` is intended for callers who already have an identifier for nodes and do not want to lose it during audits, nor maintain a map between these identifiers and Alfa nodes.
 
   Alfa is guaranteed to never interact with the `extraData` in any way; except that it will be typed as `any`, so any type guard or assertions must be re-applied afterward.
 
-  Alfa may, in the future, decide that `Node` with the same `externalId` can be identified in some way, e.g., because they represent two version of the same object that were turned into two different Alfa object. This can for example happen when two copies of the same page in different states (e.g., different tab opened) are audited; this creates two Alfa `Document`, but the external caller may have the extra knowledge that some of the nodes should be identified.
+  Alfa may, in the future, decide that `Node` with the same `externalId` can be identified in some way, e.g., because they represent two versions of the same object that were turned into two different Alfa object. This can for example happen when two copies of the same page in different states (e.g., different tab opened) are audited; this creates two Alfa `Document`, but the external caller may have the extra knowledge that some of the nodes should be identified.
 
   It is up to the callers to ensure that the `externalId` are unique, since they are meant to carry knowledge that Alfa cannot infer.
 


### PR DESCRIPTION
Resolves the mess of https://github.com/Siteimprove/alfa/commit/ea68e26852bd61c6e1cf74ea643d6f443d857b9c
