### PR TITLE
Fix tree traversal of flat tree

### DIFF
--- a/.changeset/dirty-lizards-explode.md
+++ b/.changeset/dirty-lizards-explode.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-dom": patch
+---
+
+**Fixed:** Parents of `Comment` inside a shadow tree now correctly skip over the shadow root when traversing the flat tree.

--- a/docs/review/api/alfa-dom.api.md
+++ b/docs/review/api/alfa-dom.api.md
@@ -289,8 +289,6 @@ export class Element<N extends string = string> extends Node<"element"> implemen
     // (undocumented)
     static of<N extends string = string>(namespace: Option<Namespace>, prefix: Option<string>, name: N, attributes?: Iterable_2<Attribute>, children?: Iterable_2<Node>, style?: Option<Block>, box?: Option<Rectangle>, device?: Option<Device>, externalId?: string, extraData?: any): Element<N>;
     // (undocumented)
-    parent(options?: Node.Traversal): Option<Node>;
-    // (undocumented)
     get prefix(): Option<string>;
     // (undocumented)
     get qualifiedName(): string;
@@ -1148,8 +1146,6 @@ export class Text extends Node<"text"> implements Slotable {
     protected _internalPath(options?: Node.Traversal): string;
     // (undocumented)
     static of(data: string, externalId?: string, extraData?: any): Text;
-    // (undocumented)
-    parent(options?: Node.Traversal): Option<Node>;
     // (undocumented)
     toJSON(): Text.JSON;
     // (undocumented)

--- a/packages/alfa-dom/src/node/element.ts
+++ b/packages/alfa-dom/src/node/element.ts
@@ -161,26 +161,6 @@ export class Element<N extends string = string>
     return this._boxes.get(device);
   }
 
-  public parent(options: Node.Traversal = Node.Traversal.empty): Option<Node> {
-    const parent = this._parent as Option<Node>;
-
-    if (options.isSet(Node.Traversal.flattened)) {
-      return parent.flatMap((parent) => {
-        if (Shadow.isShadow(parent)) {
-          return parent.host;
-        }
-
-        if (Element.isElement(parent) && parent.shadow.isSome()) {
-          return this.assignedSlot().flatMap((slot) => slot.parent(options));
-        }
-
-        return Option.of(parent);
-      });
-    }
-
-    return parent;
-  }
-
   public children(
     options: Node.Traversal = Node.Traversal.empty,
   ): Sequence<Node> {

--- a/packages/alfa-dom/src/node/shadow.ts
+++ b/packages/alfa-dom/src/node/shadow.ts
@@ -61,6 +61,8 @@ export class Shadow extends Node<"shadow"> {
   }
 
   public parent(options: Node.Traversal = Node.Traversal.empty): Option<Node> {
+    // We only "land" on Shadow roots when traversing the composed tree.
+    // Notably, flattening the tree "jumps" over them.
     if (options.isSet(Node.Traversal.composed)) {
       return this._host;
     }

--- a/packages/alfa-dom/src/node/text.ts
+++ b/packages/alfa-dom/src/node/text.ts
@@ -2,8 +2,6 @@ import { Option } from "@siteimprove/alfa-option";
 import { Trampoline } from "@siteimprove/alfa-trampoline";
 
 import { Node } from "../node";
-import { Element } from "./element";
-import { Shadow } from "./shadow";
 import { Slot } from "./slot";
 import { Slotable } from "./slotable";
 
@@ -29,26 +27,6 @@ export class Text extends Node<"text"> implements Slotable {
 
   public get data(): string {
     return this._data;
-  }
-
-  public parent(options: Node.Traversal = Node.Traversal.empty): Option<Node> {
-    const parent = this._parent as Option<Node>;
-
-    if (options.isSet(Node.Traversal.flattened)) {
-      return parent.flatMap((parent) => {
-        if (Shadow.isShadow(parent)) {
-          return parent.host;
-        }
-
-        if (Element.isElement(parent) && parent.shadow.isSome()) {
-          return this.assignedSlot().flatMap((slot) => slot.parent(options));
-        }
-
-        return Option.of(parent);
-      });
-    }
-
-    return parent;
   }
 
   public assignedSlot(): Option<Slot> {

--- a/packages/alfa-dom/src/node/traversal/get-nodes-between.ts
+++ b/packages/alfa-dom/src/node/traversal/get-nodes-between.ts
@@ -1,6 +1,6 @@
-import { Node } from "../..";
 import { Predicate } from "@siteimprove/alfa-predicate";
 import { Sequence } from "@siteimprove/alfa-sequence";
+import { Node } from "../..";
 
 import { lowestCommonAncestor } from "./lowest-common-ancestor";
 
@@ -43,7 +43,7 @@ export function getNodesBetween(
     // of the closest ancestor having one.
     between = first
       // Closest ancestor with a next sibling.
-      .closest((ancestor) => ancestor.next(treeOptions).isSome())
+      .closest((ancestor) => ancestor.next(treeOptions).isSome(), treeOptions)
       // Get that sibling.
       .flatMap((node) => node.next(treeOptions))
       // Skip everything until next.
@@ -71,7 +71,6 @@ function getNodesInclusivelyBetween(
 ): Sequence<Node> {
   const isFrontier = or(equals(node1), equals(node2));
 
-  // Get descendants of the LCA, and skip everything before and after both nodes.
   return lowestCommonAncestor(node1, node2, treeOptions)
     .map((context) =>
       context

--- a/packages/alfa-dom/test/traversal.spec.tsx
+++ b/packages/alfa-dom/test/traversal.spec.tsx
@@ -1,4 +1,4 @@
-import { None, Option } from "@siteimprove/alfa-option";
+import { None } from "@siteimprove/alfa-option";
 import { test } from "@siteimprove/alfa-test";
 
 import { h, Comment, Node } from "../src";

--- a/packages/alfa-dom/test/traversal.spec.tsx
+++ b/packages/alfa-dom/test/traversal.spec.tsx
@@ -1,0 +1,66 @@
+import { None, Option } from "@siteimprove/alfa-option";
+import { test } from "@siteimprove/alfa-test";
+
+import { h, Comment, Node } from "../src";
+
+const targets = [<span />, h.text("hello"), Comment.of("world")];
+const shadow = h.shadow(targets);
+const div = <div>{shadow}</div>;
+
+// Start with no flag.
+// For each of the three flags, duplicate existing list and add the flag to one side.
+// This ends up giving the eight possible options.
+const flags = [
+  Node.Traversal.composed,
+  Node.Traversal.flattened,
+  Node.Traversal.nested,
+].reduce(
+  (old, cur) => old.flatMap((flag) => [flag, flag.add(cur)]),
+  [Node.Traversal.of(Node.Traversal.none)],
+);
+
+test(".parent() of a shadow host returns None in composed traversal, the shadow root otherwise", (t) => {
+  for (const traversal of flags) {
+    if (traversal.has(Node.Traversal.composed)) {
+      t.deepEqual(shadow.parent(traversal).getUnsafe(), div);
+    } else {
+      t.deepEqual(shadow.parent(traversal), None);
+    }
+  }
+});
+
+test(".parent() of the children of a shadow root returns the shadow host in flat traversal, the shadow root otherwise", (t) => {
+  for (const target of targets) {
+    for (const traversal of flags) {
+      if (traversal.has(Node.Traversal.flattened)) {
+        t.deepEqual(target.parent(traversal).getUnsafe(), div);
+      } else {
+        t.deepEqual(target.parent(traversal).getUnsafe(), shadow);
+      }
+    }
+  }
+});
+
+test(".parent() of a slottable child of a shadow host returns the slot's parent in flat traversal, the light parent otherwise", (t) => {
+  const target = <span slot="foo" />;
+  const shadowDiv = (
+    <div>
+      <slot name="foo"></slot>
+    </div>
+  );
+  const shadow = h.shadow([shadowDiv]);
+  const lightDiv = (
+    <div>
+      {shadow}
+      {target}
+    </div>
+  );
+
+  for (const traversal of flags) {
+    if (traversal.has(Node.Traversal.flattened)) {
+      t.deepEqual(target.parent(traversal).getUnsafe(), shadowDiv);
+    } else {
+      t.deepEqual(target.parent(traversal).getUnsafe(), lightDiv);
+    }
+  }
+});

--- a/packages/alfa-dom/tsconfig.json
+++ b/packages/alfa-dom/tsconfig.json
@@ -86,7 +86,8 @@
     "test/node/traversal/get-nodes-between.spec.tsx",
     "test/node/traversal/lowest-common-ancestor.spec.tsx",
     "test/node/query/element-descendants.spec.tsx",
-    "test/node/query/element-id-map.spec.tsx"
+    "test/node/query/element-id-map.spec.tsx",
+    "test/traversal.spec.tsx"
   ],
   "references": [
     { "path": "../alfa-array" },
@@ -103,7 +104,7 @@
     { "path": "../alfa-map" },
     { "path": "../alfa-option" },
     { "path": "../alfa-predicate" },
-    { "path": "../alfa-rectangle"},
+    { "path": "../alfa-rectangle" },
     { "path": "../alfa-refinement" },
     { "path": "../alfa-sarif" },
     { "path": "../alfa-selective" },


### PR DESCRIPTION
Fix a bug in tree traversal of flat tree for the rare case of comments being direct child of the shadow root.

We had an exception for elements and text to skip over the shadow root and return the host instead when querying the parent in the flat tree. This is correct because in the flat tree the shadow tree has been inserted by "merging" the host and the root. However, that exception was missing for comments, creating an issue in these cases.

Additionally fixed a missing tree traversal option in `getNodeBetween`.
