### PR TITLE
Make punctuation-only texts inapplicable in R69

### DIFF
--- a/.changeset/nine-cycles-search.md
+++ b/.changeset/nine-cycles-search.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-rules": minor
+---
+
+**Changed:** R69 is no longer applicable to text that only contains punctuation.

--- a/packages/alfa-rules/src/sia-r69/rule.ts
+++ b/packages/alfa-rules/src/sia-r69/rule.ts
@@ -39,5 +39,5 @@ export default Rule.Atomic.of<
 });
 
 function isOnlyPunctuation(text: Text): boolean {
-  return text.data.replace(/\p{P}|\p{S}|\p{Cf}/gu, "").length === 0;
+  return /^[\p{P}\p{S}\p{Cf}]+$/gu.test(text.data);
 }

--- a/packages/alfa-rules/src/sia-r69/rule.ts
+++ b/packages/alfa-rules/src/sia-r69/rule.ts
@@ -1,5 +1,6 @@
 import { Rule } from "@siteimprove/alfa-act";
 import { Element, Text } from "@siteimprove/alfa-dom";
+import { Predicate } from "@siteimprove/alfa-predicate";
 import { Criterion } from "@siteimprove/alfa-wcag";
 import { Page } from "@siteimprove/alfa-web";
 
@@ -10,6 +11,8 @@ import { nonDisabledTexts } from "../common/applicability/non-disabled-texts";
 import { hasSufficientContrast } from "../common/expectation/contrast";
 
 import { Scope, Stability, Version } from "../tags";
+
+const { not } = Predicate;
 
 export default Rule.Atomic.of<
   Page,
@@ -23,7 +26,9 @@ export default Rule.Atomic.of<
   evaluate({ device, document }) {
     return {
       applicability() {
-        return nonDisabledTexts(document, device);
+        return nonDisabledTexts(document, device).filter(
+          not(isOnlyPunctuation),
+        );
       },
 
       expectations(target) {
@@ -32,3 +37,7 @@ export default Rule.Atomic.of<
     };
   },
 });
+
+function isOnlyPunctuation(text: Text): boolean {
+  return text.data.replace(/\p{P}|\p{S}|\p{Cf}/gu, "").length === 0;
+}

--- a/packages/alfa-rules/src/sia-r69/rule.ts
+++ b/packages/alfa-rules/src/sia-r69/rule.ts
@@ -1,6 +1,5 @@
 import { Rule } from "@siteimprove/alfa-act";
 import { Element, Text } from "@siteimprove/alfa-dom";
-import { Predicate } from "@siteimprove/alfa-predicate";
 import { Criterion } from "@siteimprove/alfa-wcag";
 import { Page } from "@siteimprove/alfa-web";
 
@@ -11,8 +10,6 @@ import { nonDisabledTexts } from "../common/applicability/non-disabled-texts";
 import { hasSufficientContrast } from "../common/expectation/contrast";
 
 import { Scope, Stability, Version } from "../tags";
-
-const { not } = Predicate;
 
 export default Rule.Atomic.of<
   Page,
@@ -26,9 +23,7 @@ export default Rule.Atomic.of<
   evaluate({ device, document }) {
     return {
       applicability() {
-        return nonDisabledTexts(document, device).filter(
-          not(isOnlyPunctuation),
-        );
+        return nonDisabledTexts(document, device).reject(isOnlyPunctuation);
       },
 
       expectations(target) {

--- a/packages/alfa-rules/test/sia-r69/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r69/rule.spec.tsx
@@ -395,6 +395,40 @@ test(`evaluate() is inapplicable to the text that is part of a label of a disabl
   t.deepEqual(await evaluate(R69, { document }), [inapplicable(R69)]);
 });
 
+test("evaluate() is inapplicable to text that would otherwise pass if it was not only punctuation", async (t) => {
+  const target = h.text(",./;'[]\\-=?<>:\"{}|_+!@#$%^&*()");
+
+  const document = h.document([
+    <html
+      style={{
+        backgroundImage: "url('foo.png')",
+        color: "#000",
+      }}
+    >
+      {target}
+    </html>,
+  ]);
+
+  t.deepEqual(await evaluate(R69, { document }), [inapplicable(R69)]);
+});
+
+test("evaluate() is inapplicable to text that would otherwise fail if it was not only punctuation", async (t) => {
+  const target = h.text(",./;'[]\\-=?<>:\"{}|_+!@#$%^&*()");
+
+  const document = h.document([
+    <html
+      style={{
+        backgroundImage: "url('foo.png')",
+        color: "#000",
+      }}
+    >
+      {target}
+    </html>,
+  ]);
+
+  t.deepEqual(await evaluate(R69, { document }), [inapplicable(R69)]);
+});
+
 test("evaluate() passes when a background color with sufficient contrast is input", async (t) => {
   const target = h.text("Hello world");
 

--- a/packages/alfa-rules/test/sia-r69/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r69/rule.spec.tsx
@@ -401,8 +401,8 @@ test("evaluate() is inapplicable to text that would otherwise pass if it was not
   const document = h.document([
     <html
       style={{
-        backgroundImage: "url('foo.png')",
-        color: "#000",
+        backgroundColor: "black",
+        color: "white",
       }}
     >
       {target}
@@ -418,7 +418,8 @@ test("evaluate() is inapplicable to text that would otherwise fail if it was not
   const document = h.document([
     <html
       style={{
-        backgroundImage: "url('foo.png')",
+        backgroundImage: "linear-gradient(#000 50%, transparent 50%)",
+        backgroundColor: "#000",
         color: "#000",
       }}
     >

--- a/yarn.lock
+++ b/yarn.lock
@@ -406,9 +406,9 @@ __metadata:
   linkType: hard
 
 "@mdn/browser-compat-data@npm:^5.0.0":
-  version: 5.5.4
-  resolution: "@mdn/browser-compat-data@npm:5.5.4"
-  checksum: bdef5c85cc6e90bbf6e873033bfcf92dba2df699fb9fdd7390f5d1dc0e6d14fba9b8b3585370248a82913585eb1792c1afd20900efb6604c9e59122ba98060d7
+  version: 5.5.6
+  resolution: "@mdn/browser-compat-data@npm:5.5.6"
+  checksum: b22f1d9e69451c12295b0ead856dd5d12b08f43a068047bc8e40f365fd8b41207a96e2a5383048a0b6e87daa0edc4e8cbdaf70e1e593b653e347178a85b30530
   languageName: node
   linkType: hard
 
@@ -2092,11 +2092,11 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*, @types/node@npm:^20.5.9":
-  version: 20.10.7
-  resolution: "@types/node@npm:20.10.7"
+  version: 20.11.1
+  resolution: "@types/node@npm:20.11.1"
   dependencies:
     undici-types: "npm:~5.26.4"
-  checksum: d626cea1b7da4784ee7b335dcc54e64adba9725dab7ca51a690167de502ef89fec07b05ad8e25845d188d7ad7f72c192ec92964d456321ed5b9452113bf9351f
+  checksum: f665cdce28b0b6e57338d1f74e0599ee9b10eac74cff729921c8f473807398e9aba2f8cf74c74a4d3dfbc2d616c73267da7de3003ed3c8152ea366bf4c96a91a
   languageName: node
   linkType: hard
 
@@ -2660,13 +2660,6 @@ __metadata:
     escape-string-regexp: "npm:^1.0.5"
     supports-color: "npm:^5.3.0"
   checksum: e6543f02ec877732e3a2d1c3c3323ddb4d39fbab687c23f526e25bd4c6a9bf3b83a696e8c769d078e04e5754921648f7821b2a2acfd16c550435fd630026e073
-  languageName: node
-  linkType: hard
-
-"chalk@npm:^5.3.0":
-  version: 5.3.0
-  resolution: "chalk@npm:5.3.0"
-  checksum: 8297d436b2c0f95801103ff2ef67268d362021b8210daf8ddbe349695333eb3610a71122172ff3b0272f1ef2cf7cc2c41fdaa4715f52e49ffe04c56340feed09
   languageName: node
   linkType: hard
 
@@ -4593,8 +4586,8 @@ __metadata:
   linkType: hard
 
 "knip@npm:^3.0.0":
-  version: 3.12.0
-  resolution: "knip@npm:3.12.0"
+  version: 3.13.2
+  resolution: "knip@npm:3.13.2"
   dependencies:
     "@ericcornelissen/bash-parser": "npm:0.5.2"
     "@npmcli/map-workspaces": "npm:3.0.4"
@@ -4603,7 +4596,6 @@ __metadata:
     "@pnpm/logger": "npm:5.0.0"
     "@pnpm/workspace.pkgs-graph": "npm:^2.0.13"
     "@snyk/github-codeowners": "npm:1.1.0"
-    chalk: "npm:^5.3.0"
     easy-table: "npm:1.2.0"
     fast-glob: "npm:3.3.2"
     globby: "npm:^14.0.0"
@@ -4611,6 +4603,7 @@ __metadata:
     js-yaml: "npm:4.1.0"
     micromatch: "npm:4.0.5"
     minimist: "npm:1.2.8"
+    picocolors: "npm:1.0.0"
     pretty-ms: "npm:8.0.0"
     strip-json-comments: "npm:5.0.1"
     summary: "npm:2.1.0"
@@ -4621,7 +4614,7 @@ __metadata:
     typescript: ">=5.0.4"
   bin:
     knip: bin/knip.js
-  checksum: 29599ebb99d369154320aa6ab9bb0d24a1eb3ff8386593e8bef6fb5481eb1ed59a00bf490d43495a07a5164d21c8bbd3c5a79c24a74cdb1e12ae2855918c8901
+  checksum: 9221fa8d863d298ad642fd379e0e8df7f160663e773591e226b46d73219e9a3679528fdc405071b8a3741f7b87491017b496331179db272df2db1945ea91c40d
   languageName: node
   linkType: hard
 
@@ -5645,7 +5638,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.0.0":
+"picocolors@npm:1.0.0, picocolors@npm:^1.0.0":
   version: 1.0.0
   resolution: "picocolors@npm:1.0.0"
   checksum: 20a5b249e331c14479d94ec6817a182fd7a5680debae82705747b2db7ec50009a5f6648d0621c561b0572703f84dbef0858abcbd5856d3c5511426afcb1961f7
@@ -5697,11 +5690,11 @@ __metadata:
   linkType: hard
 
 "prettier@npm:^3.0.0":
-  version: 3.1.1
-  resolution: "prettier@npm:3.1.1"
+  version: 3.2.2
+  resolution: "prettier@npm:3.2.2"
   bin:
     prettier: bin/prettier.cjs
-  checksum: facc944ba20e194ff4db765e830ffbcb642803381f0d2033ed397e79904fa4ccc877dc25ad68f42d36985c01d051c990ca1b905fb83d2d7d65fe69e4386fa1a3
+  checksum: e84d0d2a4ce2b88ee1636904effbdf68b59da63d9f887128f2ed5382206454185432e7c0a9578bc4308bc25d099cfef47fd0b9c211066777854e23e65e34044d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves #1166

We just ignore text that only consists of punctuation.
