### PR TITLE
Support `:host` pseudo class

### DIFF
--- a/.changeset/curly-apes-repeat.md
+++ b/.changeset/curly-apes-repeat.md
@@ -1,0 +1,9 @@
+---
+"@siteimprove/alfa-cascade": minor
+---
+
+**Added:** `Cascade` now handles declarations from encapsulated context (shadow DOM).
+
+CSS selectors and rules that are affecting the host tree are now stored separately and retrieved when computing the cascade of said host.
+
+As with other rules from style sheet, these are only effective when the shadow host is part of a tree. Otherwise, only the `style` attribute is taken into consideration.

--- a/.changeset/curly-apes-repeat.md
+++ b/.changeset/curly-apes-repeat.md
@@ -2,8 +2,8 @@
 "@siteimprove/alfa-cascade": minor
 ---
 
-**Added:** `Cascade` now handles declarations from encapsulated context (shadow DOM).
+**Added:** `Cascade` now handles declarations from encapsulated contexts (shadow DOM).
 
 CSS selectors and rules that are affecting the host tree are now stored separately and retrieved when computing the cascade of said host.
 
-As with other rules from style sheet, these are only effective when the shadow host is part of a tree. Otherwise, only the `style` attribute is taken into consideration.
+As with other rules from style sheets, these are only effective when the shadow host is part of a document tree. Otherwise, only the `style` attribute is taken into consideration.

--- a/.changeset/eighty-peaches-clean.md
+++ b/.changeset/eighty-peaches-clean.md
@@ -1,0 +1,7 @@
+---
+"@siteimprove/alfa-selector": minor
+"@siteimprove/alfa-cascade": minor
+"@siteimprove/alfa-style": minor
+---
+
+**Added:** The `:host` pseudo-class is now supported.

--- a/docs/review/api/alfa-selector.api.md
+++ b/docs/review/api/alfa-selector.api.md
@@ -396,6 +396,8 @@ export namespace PseudoClass {
     export function isPseudoClass(value: unknown): value is PseudoClass;
     // (undocumented)
     export type JSON = Active.JSON | Disabled.JSON | Empty.JSON | Enabled.JSON | FirstChild.JSON | FirstOfType.JSON | Focus.JSON | FocusVisible.JSON | FocusWithin.JSON | Has.JSON | Host.JSON | Hover.JSON | Is.JSON | LastChild.JSON | LastOfType.JSON | Link.JSON | Not.JSON | NthChild.JSON | NthLastChild.JSON | NthLastOfType.JSON | NthOfType.JSON | OnlyChild.JSON | OnlyOfType.JSON | Root.JSON | Visited.JSON | Where.JSON;
+    const // (undocumented)
+    isHost: typeof Host.isHost;
     // Warning: (ae-incompatible-release-tags) The symbol "parse" is marked as @public, but its signature references "Absolute" which is marked as @internal
     //
     // (undocumented)
@@ -474,6 +476,7 @@ export type Selector = Simple | Compound | Complex | Relative | List;
 
 // @public (undocumented)
 export namespace Selector {
+    export function isShadow(selector: Selector): boolean;
     // (undocumented)
     export type JSON = Simple.JSON | Compound.JSON | Complex.JSON | Relative.JSON | List.JSON;
     const // Warning: (ae-incompatible-release-tags) The symbol "parse" is marked as @public, but its signature references "Absolute" which is marked as @internal

--- a/packages/alfa-cascade/src/block.ts
+++ b/packages/alfa-cascade/src/block.ts
@@ -25,6 +25,7 @@ import {
 import * as json from "@siteimprove/alfa-json";
 
 import { Origin, Precedence } from "./precedence";
+import { Encapsulation } from "./precedence/encapsulation";
 import { UserAgent } from "./user-agent";
 
 /**
@@ -67,6 +68,7 @@ export class Block<S extends Element | Block.Source = Element | Block.Source>
     [],
     {
       origin: Origin.NormalUserAgent,
+      encapsulation: Encapsulation.NormalOuter,
       isElementAttached: false,
       specificity: Specificity.empty(),
       order: -Infinity,
@@ -245,6 +247,9 @@ export namespace Block {
           blocks.push(
             Block.of({ rule, selector }, declarations, {
               origin,
+              encapsulation: importance
+                ? Encapsulation.ImportantOuter
+                : Encapsulation.NormalOuter,
               isElementAttached: false,
               order,
               specificity: selector.specificity,
@@ -272,6 +277,9 @@ export namespace Block {
           ([importance, declarations]) =>
             Block.of(element, declarations, {
               origin: importance ? Origin.ImportantAuthor : Origin.NormalAuthor,
+              encapsulation: importance
+                ? Encapsulation.ImportantOuter
+                : Encapsulation.NormalOuter,
               isElementAttached: true,
               specificity: Specificity.empty(),
               // Since style attribute trumps style rules in the cascade sort,

--- a/packages/alfa-cascade/src/block.ts
+++ b/packages/alfa-cascade/src/block.ts
@@ -243,6 +243,11 @@ export namespace Block {
             : Origin.NormalAuthor;
 
         for (const selector of selectors) {
+          // While we don't really know where the rules will be used, and they all look
+          // "outer" from this point of view, we also know that the shadow rules cannot
+          // match within the current tree, and can only match an encapsulating light tree.
+          // Therefore, for anything that will actually match a shadow selector, the selector
+          // appears as encapsulated.
           const encapsulation = Selector.isShadow(selector)
             ? importance
               ? Encapsulation.ImportantInner

--- a/packages/alfa-cascade/src/block.ts
+++ b/packages/alfa-cascade/src/block.ts
@@ -2,7 +2,6 @@ import { Array } from "@siteimprove/alfa-array";
 import { type Comparer, Comparison } from "@siteimprove/alfa-comparable";
 import { Lexer } from "@siteimprove/alfa-css";
 import {
-  type Block as StyleBlock,
   Declaration,
   Element,
   h,
@@ -244,12 +243,18 @@ export namespace Block {
             : Origin.NormalAuthor;
 
         for (const selector of selectors) {
+          const encapsulation = Selector.isShadow(selector)
+            ? importance
+              ? Encapsulation.ImportantInner
+              : Encapsulation.NormalInner
+            : importance
+              ? Encapsulation.ImportantOuter
+              : Encapsulation.NormalOuter;
+
           blocks.push(
             Block.of({ rule, selector }, declarations, {
               origin,
-              encapsulation: importance
-                ? Encapsulation.ImportantOuter
-                : Encapsulation.NormalOuter,
+              encapsulation,
               isElementAttached: false,
               order,
               specificity: selector.specificity,
@@ -258,13 +263,13 @@ export namespace Block {
         }
       }
     }
+
     return [blocks, order];
   }
 
   /**
    * Turns the style attribute of an element into blocks (one for important
    * declarations, one for normal declarations).
-   * @param element
    */
   export function fromStyle(element: Element): Iterable<Block> {
     return element.style

--- a/packages/alfa-cascade/src/block.ts
+++ b/packages/alfa-cascade/src/block.ts
@@ -23,8 +23,7 @@ import {
 
 import * as json from "@siteimprove/alfa-json";
 
-import { Origin, Precedence } from "./precedence";
-import { Encapsulation } from "./precedence/encapsulation";
+import { Encapsulation, Origin, Precedence } from "./precedence";
 import { UserAgent } from "./user-agent";
 
 /**

--- a/packages/alfa-cascade/src/cascade.ts
+++ b/packages/alfa-cascade/src/cascade.ts
@@ -134,8 +134,19 @@ export class Cascade implements Serializable {
 
     return this._rules.add(
       Iterable.concat(
+        // Blocks defined in style sheets of the current tree, that match `element`
         this._selectors.get(element, context, filter),
+        // Blocks defined in the `style` attribute of `element`.
         Block.fromStyle(element),
+        // Blocks defined in a shadow tree hosted at `element`, and that apply to it.
+        element.shadow
+          .map((shadow) =>
+            Cascade.from(shadow, this._device)._selectors.getForHost(
+              element,
+              context,
+            ),
+          )
+          .getOr([]),
       ),
     );
   }

--- a/packages/alfa-cascade/src/cascade.ts
+++ b/packages/alfa-cascade/src/cascade.ts
@@ -76,7 +76,7 @@ export class Cascade implements Serializable {
         this._entries.get(node, Cache.empty).get(context, () =>
           this._rules.add(
             Iterable.concat(
-              // Blocks defined in style sheet of the current tree, that match `node`
+              // Blocks defined in style sheets of the current tree, that match `node`
               this._selectors.get(node, context, filter),
               // Blocks defined in the `style` attribute of `node`.
               Block.fromStyle(node),

--- a/packages/alfa-cascade/src/precedence/encapsulation.ts
+++ b/packages/alfa-cascade/src/precedence/encapsulation.ts
@@ -1,0 +1,42 @@
+import { Comparable, type Comparer } from "@siteimprove/alfa-comparable";
+
+/**
+ * {@link https://drafts.csswg.org/css-cascade-5/#cascade-context}
+ *
+ * @remarks
+ * This is called "context" in CSS, sub-called "encapsulation context".
+ * We already have a `Context` type for hover/focus/…, so we call this
+ * `Encapsulation` instead.
+ *
+ * This enumeration mixes both Encapsulation and importance because importance
+ * reverses the comparison of encapsulation in cascade sorting.
+ * Mixing both here allows for the comparison to be simple number comparison,
+ * which should be faster than looking at more than one field.
+ *
+ * Cascading encapsulation are defined in ascending order; encapsulations defined
+ * first have lower precedence than encapsulations defined later. Thus, an
+ * encapsulation with higher value takes precedence over one with lower value.
+ * This means that comparing encapsulations is the same as comparing numbers.
+ *
+ * @privateRemarks
+ * It seems that it is never possible to pierce through several levels of shadow.
+ * Hence, it is sufficient to record whether the declaration comes from a shadow
+ * tree, without caring about the encapsulation depth.
+ *
+ * @public
+ */
+export enum Encapsulation {
+  NormalInner = 1,
+  NormalOuter = 2,
+  ImportantOuter = 3,
+  ImportantInner = 4,
+}
+
+/**
+ * @public
+ */
+export namespace Encapsulation {
+  export type JSON = Encapsulation;
+
+  export const compare: Comparer<Encapsulation> = Comparable.compareNumber;
+}

--- a/packages/alfa-cascade/src/precedence/index.ts
+++ b/packages/alfa-cascade/src/precedence/index.ts
@@ -1,3 +1,4 @@
+export * from "./encapsulation";
 export * from "./order";
 export * from "./origin";
 export * from "./precedence";

--- a/packages/alfa-cascade/src/precedence/order.ts
+++ b/packages/alfa-cascade/src/precedence/order.ts
@@ -2,6 +2,7 @@ import { Comparable, type Comparer } from "@siteimprove/alfa-comparable";
 
 /**
  * Order of appearance of CSS rules in a sheet.
+ * {@link https://drafts.csswg.org/css-cascade-5/#cascade-order}
  *
  * @privateRemarks
  * While this just wraps `number`, having it as its own type streamlines

--- a/packages/alfa-cascade/src/precedence/precedence.ts
+++ b/packages/alfa-cascade/src/precedence/precedence.ts
@@ -3,6 +3,7 @@ import { Specificity } from "@siteimprove/alfa-selector/src/specificity";
 
 import * as json from "@siteimprove/alfa-json";
 
+import { Encapsulation } from "./encapsulation";
 import { Order } from "./order";
 import { Origin } from "./origin";
 
@@ -16,8 +17,10 @@ import { Origin } from "./origin";
 export interface Precedence {
   // Origin also contains importance for faster comparison.
   origin: Origin;
-  // TODO: encapsulation context
+  // Encapsulation also contains importance for faster comparison.
+  encapsulation: Encapsulation;
   // Do the declarations come from a style attribute?
+  // {@link https://drafts.csswg.org/css-cascade-5/#style-attr}
   isElementAttached: boolean;
   // TODO: layers
   specificity: Specificity;
@@ -33,6 +36,7 @@ export namespace Precedence {
   export interface JSON {
     [key: string]: json.JSON;
     origin: Origin.JSON;
+    encapsulation: Encapsulation.JSON;
     isElementAttached: boolean;
     specificity: Specificity.JSON;
     order: Order.JSON;
@@ -41,6 +45,7 @@ export namespace Precedence {
   export function toJSON(precedence: Precedence): JSON {
     return {
       origin: precedence.origin,
+      encapsulation: precedence.encapsulation,
       isElementAttached: precedence.isElementAttached,
       specificity: precedence.specificity.toJSON(),
       order: precedence.order,
@@ -49,9 +54,10 @@ export namespace Precedence {
 
   export function toTuple(
     precedence: Precedence,
-  ): [Origin, boolean, Specificity, Order] {
+  ): [Origin, Encapsulation, boolean, Specificity, Order] {
     return [
       precedence.origin,
+      precedence.encapsulation,
       precedence.isElementAttached,
       precedence.specificity,
       precedence.order,
@@ -60,6 +66,7 @@ export namespace Precedence {
   export const compare: Comparer<Precedence> = (a, b) =>
     Comparable.compareLexicographically(toTuple(a), toTuple(b), [
       Origin.compare,
+      Encapsulation.compare,
       // In JS, true > false. This matches the behaviour of declarations from
       // a style attribute (isElementAttached = true) taking precedence over
       // declarations from a style rule.

--- a/packages/alfa-cascade/src/selector-map.ts
+++ b/packages/alfa-cascade/src/selector-map.ts
@@ -19,6 +19,7 @@ import {
   Combinator,
   Complex,
   Context,
+  PseudoClass,
   Selector,
 } from "@siteimprove/alfa-selector";
 
@@ -151,6 +152,17 @@ export class SelectorMap implements Serializable {
     }
 
     yield* collect(this._other);
+  }
+
+  public *getForHost(
+    host: Element,
+    context: Context,
+  ): Iterable<Block<Block.Source>> {
+    yield* this._shadow.filter(
+      (block) =>
+        PseudoClass.isHost(block.selector) &&
+        block.selector.matchHost(host, context),
+    );
   }
 
   public toJSON(): SelectorMap.JSON {

--- a/packages/alfa-cascade/src/selector-map.ts
+++ b/packages/alfa-cascade/src/selector-map.ts
@@ -15,7 +15,12 @@ import { Iterable } from "@siteimprove/alfa-iterable";
 import { Serializable } from "@siteimprove/alfa-json";
 import { Predicate } from "@siteimprove/alfa-predicate";
 import { Refinement } from "@siteimprove/alfa-refinement";
-import { Combinator, Complex, Context } from "@siteimprove/alfa-selector";
+import {
+  Combinator,
+  Complex,
+  Context,
+  Selector,
+} from "@siteimprove/alfa-selector";
 
 import * as json from "@siteimprove/alfa-json";
 
@@ -56,14 +61,19 @@ const isDescendantSelector = and(
  * computation heavy steps of traversing the DOM to look for siblings or ancestors.
  *
  * @privateRemarks
- * Internally, the selector map has three maps and a list in one of which it
- * will store a given selector. The three maps are used for selectors for which
- * a key selector exist; one for ID selectors, one for class selectors, and one
- * for type selectors. The list is used for any remaining selectors (e.g.,
- * pseudo-classes and -elements selectors have no key selector). When looking
- * up the rules that match an element, the ID, class names, and type of the
- * element are used for looking up potentially matching selectors in the three
- * maps. Selector matching is then performed against this list of potentially
+ * Internally, the selector map has three maps and two lists in one of which it
+ * will store a given selector.
+ * * The three maps are used for selectors for which a key selector exist;
+ *   one for ID selectors, one for class selectors, and one for type selectors.
+ * * The first list is used for any remaining selectors (e.g., pseudo-classes
+ *   and -elements selectors have no key selector).
+ * * The second list is used for the special shadow selectors that can select
+ *   into the light tree. These should never be matched against elements of the
+ *   same tree, but against the host tree.
+ *
+ * When looking up the rules that match an element, the ID, class names, and type
+ * of the element are used for looking up potentially matching selectors in the
+ * three maps. Selector matching is then performed against this list of potentially
  * matching selectors, plus the list of remaining selectors, in order to
  * determine the final set of matches.
  *
@@ -77,25 +87,29 @@ export class SelectorMap implements Serializable {
     classes: SelectorMap.Bucket,
     types: SelectorMap.Bucket,
     other: Array<Block<Block.Source>>,
+    shadow: Array<Block<Block.Source>>,
   ): SelectorMap {
-    return new SelectorMap(ids, classes, types, other);
+    return new SelectorMap(ids, classes, types, other, shadow);
   }
 
   private readonly _ids: SelectorMap.Bucket;
   private readonly _classes: SelectorMap.Bucket;
   private readonly _types: SelectorMap.Bucket;
   private readonly _other: Array<Block<Block.Source>>;
+  private readonly _shadow: Array<Block<Block.Source>>;
 
   private constructor(
     ids: SelectorMap.Bucket,
     classes: SelectorMap.Bucket,
     types: SelectorMap.Bucket,
     other: Array<Block<Block.Source>>,
+    shadow: Array<Block<Block.Source>>,
   ) {
     this._ids = ids;
     this._classes = classes;
     this._types = types;
     this._other = other;
+    this._shadow = shadow;
   }
 
   /**
@@ -145,6 +159,7 @@ export class SelectorMap implements Serializable {
       classes: this._classes.toJSON(),
       types: this._types.toJSON(),
       other: this._other.map((node) => node.toJSON()),
+      shadow: this._shadow.map((node) => node.toJSON()),
     };
   }
 }
@@ -159,6 +174,7 @@ export namespace SelectorMap {
     classes: Bucket.JSON;
     types: Bucket.JSON;
     other: Array<Block.JSON>;
+    shadow: Array<Block.JSON>;
   }
 
   export function from(sheets: Iterable<Sheet>, device: Device): SelectorMap {
@@ -173,12 +189,17 @@ export namespace SelectorMap {
     const classes = Bucket.empty();
     const types = Bucket.empty();
     const other: Array<Block<Block.Source>> = [];
+    const shadow: Array<Block<Block.Source>> = [];
 
     const add = (block: Block<Block.Source>): void => {
       const keySelector = block.selector.key;
 
       if (!keySelector.isSome()) {
-        other.push(block);
+        if (Selector.isShadow(block.selector)) {
+          shadow.push(block);
+        } else {
+          other.push(block);
+        }
       } else {
         const key = keySelector.get();
         const buckets = { id: ids, class: classes, type: types };
@@ -263,7 +284,7 @@ export namespace SelectorMap {
       }
     }
 
-    return SelectorMap.of(ids, classes, types, other);
+    return SelectorMap.of(ids, classes, types, other, shadow);
   }
 
   /**

--- a/packages/alfa-cascade/test/block.spec.ts
+++ b/packages/alfa-cascade/test/block.spec.ts
@@ -1,0 +1,188 @@
+import { Array } from "@siteimprove/alfa-array";
+import { h } from "@siteimprove/alfa-dom";
+import { test } from "@siteimprove/alfa-test";
+
+import { Block } from "../src/block";
+import { Origin } from "../src/precedence";
+import { Encapsulation } from "../src/precedence/encapsulation";
+
+test(".from() creates a single block for a simple rule", (t) => {
+  const declaration = h.declaration("color", "red");
+  const rule = h.rule.style("a", [declaration]);
+
+  t.deepEqual(Array.toJSON(Block.from(rule, 0)), [
+    [
+      {
+        source: {
+          rule: rule.toJSON(),
+          selector: {
+            type: "type",
+            key: "a",
+            name: "a",
+            namespace: null,
+            specificity: { a: 0, b: 0, c: 1 },
+          },
+        },
+        declarations: [declaration.toJSON()],
+        precedence: {
+          origin: Origin.NormalAuthor,
+          encapsulation: Encapsulation.NormalOuter,
+          isElementAttached: false,
+          specificity: { a: 0, b: 0, c: 1 },
+          order: 1,
+        },
+      },
+    ],
+    1,
+  ]);
+});
+
+test(".from() respects order", (t) => {
+  const declaration = h.declaration("color", "red");
+  const rule = h.rule.style("a", [declaration]);
+
+  t.deepEqual(Array.toJSON(Block.from(rule, 41)), [
+    [
+      {
+        source: {
+          rule: rule.toJSON(),
+          selector: {
+            type: "type",
+            key: "a",
+            name: "a",
+            namespace: null,
+            specificity: { a: 0, b: 0, c: 1 },
+          },
+        },
+        declarations: [declaration.toJSON()],
+        precedence: {
+          origin: Origin.NormalAuthor,
+          encapsulation: Encapsulation.NormalOuter,
+          isElementAttached: false,
+          specificity: { a: 0, b: 0, c: 1 },
+          order: 42,
+        },
+      },
+    ],
+    42,
+  ]);
+});
+
+test(".from() splits blocks by selector and importance, with the same order", (t) => {
+  const normal = h.declaration("color", "red");
+  const important = h.declaration("display", "block", true);
+  const rule = h.rule.style("a, .foo", [normal, important]);
+
+  t.deepEqual(Array.toJSON(Block.from(rule, 0)), [
+    [
+      {
+        source: {
+          rule: rule.toJSON(),
+          selector: {
+            type: "type",
+            key: "a",
+            name: "a",
+            namespace: null,
+            specificity: { a: 0, b: 0, c: 1 },
+          },
+        },
+        declarations: [normal.toJSON()],
+        precedence: {
+          origin: Origin.NormalAuthor,
+          encapsulation: Encapsulation.NormalOuter,
+          isElementAttached: false,
+          specificity: { a: 0, b: 0, c: 1 },
+          order: 1,
+        },
+      },
+      {
+        source: {
+          rule: rule.toJSON(),
+          selector: {
+            type: "class",
+            key: ".foo",
+            name: "foo",
+            specificity: { a: 0, b: 1, c: 0 },
+          },
+        },
+        declarations: [normal.toJSON()],
+        precedence: {
+          origin: Origin.NormalAuthor,
+          encapsulation: Encapsulation.NormalOuter,
+          isElementAttached: false,
+          specificity: { a: 0, b: 1, c: 0 },
+          order: 1,
+        },
+      },
+      {
+        source: {
+          rule: rule.toJSON(),
+          selector: {
+            type: "type",
+            key: "a",
+            name: "a",
+            namespace: null,
+            specificity: { a: 0, b: 0, c: 1 },
+          },
+        },
+        declarations: [important.toJSON()],
+        precedence: {
+          origin: Origin.ImportantAuthor,
+          encapsulation: Encapsulation.ImportantOuter,
+          isElementAttached: false,
+          specificity: { a: 0, b: 0, c: 1 },
+          order: 1,
+        },
+      },
+      {
+        source: {
+          rule: rule.toJSON(),
+          selector: {
+            type: "class",
+            key: ".foo",
+            name: "foo",
+            specificity: { a: 0, b: 1, c: 0 },
+          },
+        },
+        declarations: [important.toJSON()],
+        precedence: {
+          origin: Origin.ImportantAuthor,
+          encapsulation: Encapsulation.ImportantOuter,
+          isElementAttached: false,
+          specificity: { a: 0, b: 1, c: 0 },
+          order: 1,
+        },
+      },
+    ],
+    1,
+  ]);
+});
+
+test(".from() marks shadow selectors as encapsulated", (t) => {
+  const declaration = h.declaration("color", "red");
+  const rule = h.rule.style(":host", [declaration]);
+
+  t.deepEqual(Array.toJSON(Block.from(rule, 0)), [
+    [
+      {
+        source: {
+          rule: rule.toJSON(),
+          selector: {
+            type: "pseudo-class",
+            name: "host",
+            specificity: { a: 0, b: 1, c: 0 },
+          },
+        },
+        declarations: [declaration.toJSON()],
+        precedence: {
+          origin: Origin.NormalAuthor,
+          encapsulation: Encapsulation.NormalInner,
+          isElementAttached: false,
+          specificity: { a: 0, b: 1, c: 0 },
+          order: 1,
+        },
+      },
+    ],
+    1,
+  ]);
+});

--- a/packages/alfa-cascade/test/block.spec.tsx
+++ b/packages/alfa-cascade/test/block.spec.tsx
@@ -198,20 +198,18 @@ test(".fromStyle() creates blocks for a style attribute", (t) => {
         origin: Origin.NormalAuthor,
         encapsulation: Encapsulation.NormalOuter,
         isElementAttached: true,
-        specificity: { a: 0, b: 1, c: 0 },
+        specificity: { a: 0, b: 0, c: 0 },
         order: -1,
       },
     },
     {
       source: element.toJSON(),
-      declarations: [
-        h.declaration("display", "block !important", true).toJSON(),
-      ],
+      declarations: [h.declaration("display", "block", true).toJSON()],
       precedence: {
         origin: Origin.ImportantAuthor,
         encapsulation: Encapsulation.ImportantOuter,
         isElementAttached: true,
-        specificity: { a: 0, b: 1, c: 0 },
+        specificity: { a: 0, b: 0, c: 0 },
         order: -1,
       },
     },

--- a/packages/alfa-cascade/test/block.spec.tsx
+++ b/packages/alfa-cascade/test/block.spec.tsx
@@ -186,3 +186,34 @@ test(".from() marks shadow selectors as encapsulated", (t) => {
     1,
   ]);
 });
+
+test(".fromStyle() creates blocks for a style attribute", (t) => {
+  const element = <div style={{ color: "red", display: "block !important" }} />;
+
+  t.deepEqual(Array.toJSON([...Block.fromStyle(element)]), [
+    {
+      source: element.toJSON(),
+      declarations: [h.declaration("color", "red").toJSON()],
+      precedence: {
+        origin: Origin.NormalAuthor,
+        encapsulation: Encapsulation.NormalOuter,
+        isElementAttached: true,
+        specificity: { a: 0, b: 1, c: 0 },
+        order: -1,
+      },
+    },
+    {
+      source: element.toJSON(),
+      declarations: [
+        h.declaration("display", "block !important", true).toJSON(),
+      ],
+      precedence: {
+        origin: Origin.ImportantAuthor,
+        encapsulation: Encapsulation.ImportantOuter,
+        isElementAttached: true,
+        specificity: { a: 0, b: 1, c: 0 },
+        order: -1,
+      },
+    },
+  ]);
+});

--- a/packages/alfa-cascade/test/cascade.spec.tsx
+++ b/packages/alfa-cascade/test/cascade.spec.tsx
@@ -5,6 +5,8 @@ import { test } from "@siteimprove/alfa-test";
 
 import { Block } from "../src/block";
 import { Cascade } from "../src";
+import { Origin } from "../src/precedence";
+import { Encapsulation } from "../src/precedence/encapsulation";
 
 const device = Device.standard();
 
@@ -55,7 +57,8 @@ test(".get() returns the rule tree node of the given element", (t) => {
           },
           declarations: [{ name: "display", value: "block", important: false }],
           precedence: {
-            origin: 1,
+            origin: Origin.NormalUserAgent,
+            encapsulation: Encapsulation.NormalOuter,
             isElementAttached: false,
             specificity: { a: 0, b: 0, c: 1 },
             order: 7,

--- a/packages/alfa-cascade/test/cascade.spec.tsx
+++ b/packages/alfa-cascade/test/cascade.spec.tsx
@@ -84,7 +84,7 @@ test(".get() returns the rule tree node of the given element", (t) => {
 
 test(".get() fetches `:host` rules from shadow, when relevant.", (t) => {
   const innerNormalRule = h.rule.style(":host(div)", { color: "red" });
-  const innerImportantRule = h.rule.style(":host(div)", {
+  const innerImportantRule = h.rule.style(":host", {
     color: "green !important",
   });
   const outerNormalRule = h.rule.style("div", { color: "blue" });

--- a/packages/alfa-cascade/test/cascade.spec.tsx
+++ b/packages/alfa-cascade/test/cascade.spec.tsx
@@ -1,5 +1,5 @@
 import { Device } from "@siteimprove/alfa-device";
-import { h } from "@siteimprove/alfa-dom";
+import { h, StyleRule } from "@siteimprove/alfa-dom";
 import { Iterable } from "@siteimprove/alfa-iterable";
 import { test } from "@siteimprove/alfa-test";
 
@@ -23,6 +23,36 @@ test(".from() builds a cascade with the User Agent style sheet", (t) => {
   t.deepEqual(cascade.toJSON().selectors.classes.length, 0);
 });
 
+const UAblock: Block.JSON = {
+  source: {
+    rule: {
+      type: "style",
+      selector:
+        "address, blockquote, center, div, figure, figcaption, footer, form, header, hr, legend, listing, main, p, plaintext, pre, xmp",
+      style: [{ name: "display", value: "block", important: false }],
+    },
+    selector: {
+      type: "type",
+      specificity: { a: 0, b: 0, c: 1 },
+      key: "div",
+      name: "div",
+      namespace: null,
+    },
+  },
+  declarations: [{ name: "display", value: "block", important: false }],
+  precedence: {
+    origin: Origin.NormalUserAgent,
+    encapsulation: Encapsulation.NormalOuter,
+    isElementAttached: false,
+    specificity: { a: 0, b: 0, c: 1 },
+    order: 7,
+  },
+};
+
+function getBlock(rule: StyleRule, order: number): Block.JSON {
+  return Block.from(rule, order)[0][0].toJSON();
+}
+
 test(".get() returns the rule tree node of the given element", (t) => {
   const div = <div>Hello</div>;
   const rule = h.rule.style("div", { color: "red" });
@@ -42,38 +72,10 @@ test(".get() returns the rule tree node of the given element", (t) => {
     children: [
       {
         // UA rule
-        block: {
-          source: {
-            rule: {
-              type: "style",
-              selector:
-                "address, blockquote, center, div, figure, figcaption, footer, form, header, hr, legend, listing, main, p, plaintext, pre, xmp",
-              style: [{ name: "display", value: "block", important: false }],
-            },
-            selector: {
-              type: "type",
-              specificity: { a: 0, b: 0, c: 1 },
-              key: "div",
-              name: "div",
-              namespace: null,
-            },
-          },
-          declarations: [{ name: "display", value: "block", important: false }],
-          precedence: {
-            origin: Origin.NormalUserAgent,
-            encapsulation: Encapsulation.NormalOuter,
-            isElementAttached: false,
-            specificity: { a: 0, b: 0, c: 1 },
-            order: 7,
-          },
-        },
+        block: UAblock,
         children: [
-          {
-            // Actual rule
-            // There are 58 rules in the UA sheet.
-            block: Block.from(rule, 58)[0][0].toJSON(),
-            children: [],
-          },
+          // Actual rule, there are 58 rules in the UA sheet.
+          { block: getBlock(rule, 58), children: [] },
         ],
       },
     ],
@@ -81,52 +83,58 @@ test(".get() returns the rule tree node of the given element", (t) => {
 });
 
 test(".get() fetches `:host` rules from shadow, when relevant.", (t) => {
-  const div = <div>Hello</div>;
-  const rule = h.rule.style("div", { color: "red" });
-  const document = h.document([div], [h.sheet([rule])]);
+  const innerNormalRule = h.rule.style(":host(div)", { color: "red" });
+  const innerImportantRule = h.rule.style(":host(div)", {
+    color: "green !important",
+  });
+  const outerNormalRule = h.rule.style("div", { color: "blue" });
+  const outerImportantRule = h.rule.style("div", {
+    color: "yellow !important",
+  });
+  const ignoredRule = h.rule.style(":host(div)", { color: "black" });
+  const div = (
+    <div>
+      Hello
+      {h.shadow(
+        [<span></span>],
+        [h.sheet([innerNormalRule, innerImportantRule])],
+      )}
+    </div>
+  );
+  const document = h.document(
+    [div],
+    [h.sheet([outerNormalRule, outerImportantRule, ignoredRule])],
+  );
   const cascade = Cascade.from(document, device);
 
-  // The rule tree has 3 items on the way to the <div>:
-  // The fake root, the UA rule `div { display: block }`, and the document rule
-  // `div { color: red }`
+  // The rule tree has 6 items on the way to the <div>:
+  // The fake root, the UA rule `div { display: block }`, and the 4 rules declared here.
   // We thus just grab and check the path down from the fake root.
-  t.deepEqual(Iterable.toJSON(cascade.get(div).inclusiveAncestors())[2], {
+  t.deepEqual(Iterable.toJSON(cascade.get(div).inclusiveAncestors())[5], {
     // fake root
     block: Block.empty().toJSON(),
     children: [
       {
         // UA rule
-        block: {
-          source: {
-            rule: {
-              type: "style",
-              selector:
-                "address, blockquote, center, div, figure, figcaption, footer, form, header, hr, legend, listing, main, p, plaintext, pre, xmp",
-              style: [{ name: "display", value: "block", important: false }],
-            },
-            selector: {
-              type: "type",
-              specificity: { a: 0, b: 0, c: 1 },
-              key: "div",
-              name: "div",
-              namespace: null,
-            },
-          },
-          declarations: [{ name: "display", value: "block", important: false }],
-          precedence: {
-            origin: Origin.NormalUserAgent,
-            encapsulation: Encapsulation.NormalOuter,
-            isElementAttached: false,
-            specificity: { a: 0, b: 0, c: 1 },
-            order: 7,
-          },
-        },
+        block: UAblock,
         children: [
           {
-            // Actual rule
-            // There are 58 rules in the UA sheet.
-            block: Block.from(rule, 58)[0][0].toJSON(),
-            children: [],
+            // Actual rules, there are 58 rules in the UA sheet.
+            block: getBlock(innerNormalRule, 58),
+            children: [
+              {
+                // Rules order is computed separately for each encapsulation context.
+                block: getBlock(outerNormalRule, 58),
+                children: [
+                  {
+                    block: getBlock(outerImportantRule, 59),
+                    children: [
+                      { block: getBlock(innerImportantRule, 59), children: [] },
+                    ],
+                  },
+                ],
+              },
+            ],
           },
         ],
       },

--- a/packages/alfa-cascade/test/rule-tree.spec.ts
+++ b/packages/alfa-cascade/test/rule-tree.spec.ts
@@ -13,6 +13,7 @@ import { RuleTree } from "../src";
 
 import { Block } from "../src/block";
 import { Origin } from "../src/precedence";
+import { Encapsulation } from "../src/precedence/encapsulation";
 
 function fakeBlock(
   selectorText: string,
@@ -22,6 +23,7 @@ function fakeBlock(
 
   return Block.of({ rule: h.rule.style(selectorText, []), selector }, [], {
     origin,
+    encapsulation: Encapsulation.NormalOuter,
     isElementAttached: false,
     specificity: selector.specificity,
     order: -1,
@@ -278,12 +280,14 @@ test(".add() prioritise style attribute over specificity", (t) => {
   const highSpecificityNormal = fakeBlock("#bar", Origin.NormalAuthor);
   const styleAttributeImportant = Block.of(h.element("div"), [], {
     origin: Origin.ImportantAuthor,
+    encapsulation: Encapsulation.NormalOuter,
     isElementAttached: true,
     specificity: Specificity.empty(),
     order: -1,
   });
   const styleAttributeNormal = Block.of(h.element("span"), [], {
     origin: Origin.NormalAuthor,
+    encapsulation: Encapsulation.NormalOuter,
     isElementAttached: true,
     specificity: Specificity.empty(),
     order: -1,

--- a/packages/alfa-cascade/test/selector-map.spec.tsx
+++ b/packages/alfa-cascade/test/selector-map.spec.tsx
@@ -26,9 +26,9 @@ function ruleToBlockJSON(
 }
 
 /**
- * This initial test should have the full explicit JSON rather than rely on ruleToBlockJSON
- * in order to circumvent possible issues in Block.from.
- */
+//  * This initial test should have the full explicit JSON rather than rely on ruleToBlockJSON
+//  * in order to circumvent possible issues in Block.from.
+//  */
 test(".from() builds a selector map with a single rule", (t) => {
   const actual = SelectorMap.from(
     [h.sheet([h.rule.style("div", { foo: "not parsed" })])],
@@ -72,6 +72,7 @@ test(".from() builds a selector map with a single rule", (t) => {
       ],
     ],
     other: [],
+    shadow: [],
   });
 });
 
@@ -81,7 +82,13 @@ test(".from() rejects rules with invalid selectors", (t) => {
     device,
   );
 
-  t.deepEqual(actual.toJSON(), { ids: [], classes: [], types: [], other: [] });
+  t.deepEqual(actual.toJSON(), {
+    ids: [],
+    classes: [],
+    types: [],
+    other: [],
+    shadow: [],
+  });
 });
 
 test(".from() stores rules in increasing order, amongst all non-disabled sheets", (t) => {
@@ -91,7 +98,8 @@ test(".from() stores rules in increasing order, amongst all non-disabled sheets"
     h.rule.style(".bar", { foo: "bar" }),
     h.rule.style(".foo", { foo: "bar" }),
     h.rule.style("#hello", { foo: "bar" }),
-    h.rule.style("::focus", { foo: "bar" }),
+    h.rule.style(":focus", { foo: "bar" }),
+    h.rule.style(":host", { foo: "bar" }),
   ];
 
   const actual = SelectorMap.from(
@@ -100,7 +108,7 @@ test(".from() stores rules in increasing order, amongst all non-disabled sheets"
       h.sheet([rules[2]]),
       h.sheet([h.rule.style("div", { foo: "bar" })], true),
       h.sheet([rules[3], rules[4]]),
-      h.sheet([rules[5]]),
+      h.sheet([rules[5], rules[6]]),
     ],
     device,
   );
@@ -120,6 +128,7 @@ test(".from() stores rules in increasing order, amongst all non-disabled sheets"
       ["bar", blocks[1]],
     ],
     other: blocks[5],
+    shadow: blocks[6],
   });
 });
 
@@ -163,6 +172,7 @@ test(".from() split important and non-important declarations in two blocks", (t)
       ],
     ],
     other: [],
+    shadow: [],
   });
 });
 
@@ -181,6 +191,7 @@ test(".from() only recurses into media rules that match the device", (t) => {
     classes: [],
     types: [["foo", ruleToBlockJSON(rule, 0)]],
     other: [],
+    shadow: [],
   });
 });
 
@@ -205,6 +216,7 @@ test(".from() only recurses into import rules that match the device", (t) => {
     classes: [],
     types: [["foo", ruleToBlockJSON(rule, 0)]],
     other: [],
+    shadow: [],
   });
 });
 
@@ -231,6 +243,7 @@ test(".from() only recurses into supports rules that match the device", (t) => {
     classes: [],
     types: [["foo", ruleToBlockJSON(rule, 0)]],
     other: [],
+    shadow: [],
   });
 });
 

--- a/packages/alfa-cascade/test/selector-map.spec.tsx
+++ b/packages/alfa-cascade/test/selector-map.spec.tsx
@@ -10,9 +10,11 @@ import {
 import { parse } from "@siteimprove/alfa-selector/test/parser";
 import { test } from "@siteimprove/alfa-test";
 import { AncestorFilter } from "../src/ancestor-filter";
-import { SelectorMap } from "../src/selector-map";
 
 import { Block } from "../src/block";
+import { Origin } from "../src/precedence";
+import { Encapsulation } from "../src/precedence/encapsulation";
+import { SelectorMap } from "../src/selector-map";
 
 const device = Device.standard();
 
@@ -45,10 +47,11 @@ test(".from() builds a selector map with a single rule", (t) => {
               { important: false, name: "foo", value: "not parsed" },
             ],
             precedence: {
-              order: 1,
+              origin: Origin.NormalAuthor,
+              encapsulation: Encapsulation.NormalOuter,
               isElementAttached: false,
-              origin: 3,
               specificity: { a: 0, b: 0, c: 1 },
+              order: 1,
             },
             source: {
               rule: {
@@ -138,7 +141,8 @@ test(".from() split important and non-important declarations in two blocks", (t)
             source: { rule: rule.toJSON(), selector: selector.toJSON() },
             declarations: [{ name: "foo", value: "bar", important: false }],
             precedence: {
-              origin: 3,
+              origin: Origin.NormalAuthor,
+              encapsulation: Encapsulation.NormalOuter,
               isElementAttached: false,
               specificity: { a: 0, b: 0, c: 1 },
               order: 1,
@@ -148,7 +152,8 @@ test(".from() split important and non-important declarations in two blocks", (t)
             source: { rule: rule.toJSON(), selector: selector.toJSON() },
             declarations: [{ name: "hello", value: "world", important: true }],
             precedence: {
-              origin: 5,
+              origin: Origin.ImportantAuthor,
+              encapsulation: Encapsulation.ImportantOuter,
               isElementAttached: false,
               specificity: { a: 0, b: 0, c: 1 },
               order: 1,

--- a/packages/alfa-cascade/tsconfig.json
+++ b/packages/alfa-cascade/tsconfig.json
@@ -19,7 +19,7 @@
     "src/selector-map.ts",
     "src/user-agent.ts",
     "test/ancestor-filter.spec.tsx",
-    "test/block.spec.ts",
+    "test/block.spec.tsx",
     "test/cascade.spec.tsx",
     "test/rule-tree.spec.ts",
     "test/selector-map.spec.tsx"

--- a/packages/alfa-cascade/tsconfig.json
+++ b/packages/alfa-cascade/tsconfig.json
@@ -19,6 +19,7 @@
     "src/selector-map.ts",
     "src/user-agent.ts",
     "test/ancestor-filter.spec.tsx",
+    "test/block.spec.ts",
     "test/cascade.spec.tsx",
     "test/rule-tree.spec.ts",
     "test/selector-map.spec.tsx"

--- a/packages/alfa-cascade/tsconfig.json
+++ b/packages/alfa-cascade/tsconfig.json
@@ -10,6 +10,7 @@
     "src/block.ts",
     "src/cascade.ts",
     "src/index.ts",
+    "src/precedence/encapsulation.ts",
     "src/precedence/index.ts",
     "src/precedence/order.ts",
     "src/precedence/origin.ts",

--- a/packages/alfa-selector/package.json
+++ b/packages/alfa-selector/package.json
@@ -31,6 +31,7 @@
     "@siteimprove/alfa-option": "workspace:^0.72.0",
     "@siteimprove/alfa-parser": "workspace:^0.72.0",
     "@siteimprove/alfa-predicate": "workspace:^0.72.0",
+    "@siteimprove/alfa-refinement": "workspace:^0.72.0",
     "@siteimprove/alfa-sequence": "workspace:^0.72.0",
     "@siteimprove/alfa-slice": "workspace:^0.72.0",
     "@siteimprove/alfa-thunk": "workspace:^0.72.0"

--- a/packages/alfa-selector/src/selector/index.ts
+++ b/packages/alfa-selector/src/selector/index.ts
@@ -7,6 +7,7 @@ import type { Compound } from "./compound";
 import { List } from "./list";
 import type { Relative } from "./relative";
 import type { Simple } from "./simple/index";
+import { Host } from "./simple/pseudo-class/host";
 
 // Re-export for further users
 export * from "./combinator";
@@ -57,6 +58,13 @@ export namespace Selector {
     | Complex.JSON
     | Relative.JSON
     | List.JSON;
+
+  /**
+   * Whether a selector is a shadow selector selecting a light node.
+   */
+  export function isShadow(selector: Selector): boolean {
+    return Host.isHost(selector);
+  }
 
   /**
    * Parsers for Selectors

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/host.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/host.ts
@@ -108,6 +108,10 @@ export namespace Host {
     selector?: Compound.JSON | Simple.JSON;
   }
 
+  export function isHost(value: unknown): value is Host {
+    return value instanceof Host;
+  }
+
   export const parse = (parseSelector: Thunk<CSSParser<Compound | Simple>>) =>
     either(
       // We need to try the functional variant first to avoid the non-functional

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/index.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/index.ts
@@ -109,6 +109,8 @@ export namespace PseudoClass {
     return value instanceof PseudoClassSelector;
   }
 
+  export const { isHost } = Host;
+
   export function parse(
     parseSelector: Thunk<CSSParser<Absolute>>,
   ): CSSParser<PseudoClass> {

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/index.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/index.ts
@@ -1,9 +1,11 @@
 import type { Parser as CSSParser, Token } from "@siteimprove/alfa-css";
 import { Parser } from "@siteimprove/alfa-parser";
+import { Refinement } from "@siteimprove/alfa-refinement";
 import type { Slice } from "@siteimprove/alfa-slice";
 import type { Thunk } from "@siteimprove/alfa-thunk";
 
-import type { Absolute } from "../../../selector";
+import { type Absolute, Simple } from "../../index";
+import { Compound } from "../../compound";
 
 import { Active } from "./active";
 import { Disabled } from "./disabled";
@@ -34,7 +36,8 @@ import { Where } from "./where";
 
 import { PseudoClassSelector } from "./pseudo-class";
 
-const { either } = Parser;
+const { either, filter } = Parser;
+const { or } = Refinement;
 
 /**
  * @public
@@ -119,7 +122,13 @@ export namespace PseudoClass {
       Focus.parse,
       FocusVisible.parse,
       FocusWithin.parse,
-      Host.parse,
+      Host.parse(() =>
+        filter(
+          parseSelector(),
+          or(Compound.isCompound, Simple.isSimple),
+          () => ":host() only accepts compound selectors",
+        ),
+      ),
       Hover.parse,
       LastChild.parse,
       LastOfType.parse,

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/pseudo-class.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/pseudo-class.ts
@@ -63,7 +63,12 @@ export namespace PseudoClassSelector {
     name: string,
     of: Thunk<T>,
   ): CSSParser<T> {
-    return map(right(parseColon, Token.parseIdent(name)), of);
+    return map(
+      right(parseColon, parseIdent(name)),
+      // We explicitly need to discard the parsed identifier and not pass it
+      // to a function that may use it (but was super-typed as a Thunk).
+      () => of(),
+    );
   }
 }
 

--- a/packages/alfa-selector/src/specificity.ts
+++ b/packages/alfa-selector/src/specificity.ts
@@ -17,6 +17,7 @@ const componentMax = (1 << componentBits) - 1;
 
 /**
  * {@link https://www.w3.org/TR/selectors/#specificity}
+ * {@link https://drafts.csswg.org/css-cascade-5/#cascade-specificity}
  *
  * @remarks
  * Specificities are triplet (a, b, c), ordered lexicographically.

--- a/packages/alfa-selector/test/pseudo-class.spec.tsx
+++ b/packages/alfa-selector/test/pseudo-class.spec.tsx
@@ -11,11 +11,26 @@ test(".parse() parses a named pseudo-class selector", (t) => {
   });
 });
 
-test(".parse() parses :host pseudo-class selector", (t) => {
+test(".parse() parses :host non-functional pseudo-class selector", (t) => {
   t.deepEqual(serialize(":host"), {
     type: "pseudo-class",
     name: "host",
     specificity: { a: 0, b: 1, c: 0 },
+  });
+});
+
+test(".parse() parses :host functional pseudo-class selector", (t) => {
+  t.deepEqual(serialize(":host(div)"), {
+    type: "pseudo-class",
+    name: "host",
+    selector: {
+      type: "type",
+      name: "div",
+      namespace: null,
+      specificity: { a: 0, b: 0, c: 1 },
+      key: "div",
+    },
+    specificity: { a: 0, b: 1, c: 1 },
   });
 });
 

--- a/packages/alfa-selector/test/pseudo-class.spec.tsx
+++ b/packages/alfa-selector/test/pseudo-class.spec.tsx
@@ -1,5 +1,6 @@
 import { test } from "@siteimprove/alfa-test";
 import { Context } from "../src";
+import type { Host } from "../src/selector/simple/pseudo-class/host";
 
 import { parse, serialize } from "./parser";
 
@@ -300,5 +301,36 @@ test("#matches() checks if an element matches a :visited selector", (t) => {
   // These elements aren't links
   for (const element of [<a />, <p />]) {
     t.equal(selector.matches(element), false, element.toString());
+  }
+});
+
+test("#matches() never matches a :host selector", (t) => {
+  for (const target of [<p />, <div class="foo" />]) {
+    for (const input of [
+      ":host",
+      ":host(p)",
+      ":host(.foo)",
+      ":host(div.foo)",
+    ]) {
+      const selector = parse(input);
+
+      t.equal(selector.matches(target), false);
+    }
+  }
+});
+
+test("Host#matchHost() matches when the element matches", (t) => {
+  const div = <div class="foo" />;
+
+  for (const input of [":host", ":host(.foo)", ":host(div.foo)"]) {
+    const selector = parse(input) as Host;
+
+    t.equal(selector.matchHost(div), true);
+  }
+
+  for (const input of [":host(span)", ":host(div.bar)"]) {
+    const selector = parse(input) as Host;
+
+    t.equal(selector.matchHost(div), false);
   }
 });

--- a/packages/alfa-selector/tsconfig.json
+++ b/packages/alfa-selector/tsconfig.json
@@ -93,6 +93,7 @@
     { "path": "../alfa-option" },
     { "path": "../alfa-parser" },
     { "path": "../alfa-predicate" },
+    { "path": "../alfa-refinement" },
     { "path": "../alfa-sequence" },
     { "path": "../alfa-slice" },
     { "path": "../alfa-test" },

--- a/packages/alfa-style/test/style.spec.tsx
+++ b/packages/alfa-style/test/style.spec.tsx
@@ -15,11 +15,7 @@ test("#cascaded() returns the cascaded value of a property", (t) => {
   const element = <div style={{ color: "red" }} />;
 
   t.deepEqual(cascaded(element, "color"), {
-    value: {
-      type: "color",
-      format: "named",
-      color: "red",
-    },
+    value: { type: "color", format: "named", color: "red" },
     source: h.declaration("color", "red").toJSON(),
   });
 });
@@ -40,11 +36,7 @@ test("#cascaded() correctly handles duplicate properties", (t) => {
   );
 
   t.deepEqual(cascaded(element, "color"), {
-    value: {
-      type: "color",
-      format: "named",
-      color: "green",
-    },
+    value: { type: "color", format: "named", color: "green" },
     source: h.declaration("color", "green").toJSON(),
   });
 });
@@ -63,11 +55,7 @@ test("#cascaded() returns the most specific property value", (t) => {
   );
 
   t.deepEqual(cascaded(element, "color"), {
-    value: {
-      type: "color",
-      format: "named",
-      color: "green",
-    },
+    value: { type: "color", format: "named", color: "green" },
     source: h.declaration("color", "green", true).toJSON(),
   });
 });
@@ -78,11 +66,7 @@ test("#cascaded() correctly handles inline styles overriding the sheet", (t) => 
   h.document([element], [h.sheet([h.rule.style("div", { color: "red" })])]);
 
   t.deepEqual(cascaded(element, "color"), {
-    value: {
-      type: "color",
-      format: "named",
-      color: "green",
-    },
+    value: { type: "color", format: "named", color: "green" },
     source: h.declaration("color", "green", true).toJSON(),
   });
 });
@@ -97,11 +81,7 @@ test(`#cascaded() correctly handles an important declaration overriding inline
   );
 
   t.deepEqual(cascaded(element, "color"), {
-    value: {
-      type: "color",
-      format: "named",
-      color: "red",
-    },
+    value: { type: "color", format: "named", color: "red" },
     source: h.declaration("color", "red", true).toJSON(),
   });
 });
@@ -116,11 +96,7 @@ test(`#cascaded() correctly handles important inline styles overriding an
   );
 
   t.deepEqual(cascaded(element, "color"), {
-    value: {
-      type: "color",
-      format: "named",
-      color: "green",
-    },
+    value: { type: "color", format: "named", color: "green" },
     source: h.declaration("color", "green", true).toJSON(),
   });
 });
@@ -142,10 +118,7 @@ test(`#cascaded() correctly handles a shorthand declaration overriding a
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "hidden",
-    },
+    value: { type: "keyword", value: "hidden" },
     source: h.declaration("overflow", "hidden").toJSON(),
   });
 });
@@ -167,10 +140,7 @@ test(`#cascaded() correctly handles a longhand declaration overriding a
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "visible",
-    },
+    value: { type: "keyword", value: "visible" },
     source: h.declaration("overflow-x", "visible").toJSON(),
   });
 });
@@ -191,10 +161,7 @@ test(`#cascaded() expands a var() function`, (t) => {
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "hidden",
-    },
+    value: { type: "keyword", value: "hidden" },
     source: h.declaration("overflow-x", "var(--hidden)").toJSON(),
   });
 });
@@ -215,10 +182,7 @@ test("#cascaded() prefers important var() declarations", (t) => {
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "hidden",
-    },
+    value: { type: "keyword", value: "hidden" },
     source: h.declaration("overflow-x", "var(--hidden)").toJSON(),
   });
 });
@@ -238,10 +202,7 @@ test(`#cascaded() expands a var() function with a fallback`, (t) => {
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "hidden",
-    },
+    value: { type: "keyword", value: "hidden" },
     source: h.declaration("overflow-x", "var(--hidden, hidden)").toJSON(),
   });
 });
@@ -265,10 +226,7 @@ test(`#cascaded() expands a var() function with an inherited value`, (t) => {
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "hidden",
-    },
+    value: { type: "keyword", value: "hidden" },
     source: h.declaration("overflow-x", "var(--hidden)").toJSON(),
   });
 });
@@ -292,10 +250,7 @@ test(`#cascaded() prefers inheriting var() function over using fallback`, (t) =>
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "hidden",
-    },
+    value: { type: "keyword", value: "hidden" },
     source: h.declaration("overflow-x", "var(--hidden, visible)").toJSON(),
   });
 });
@@ -321,10 +276,7 @@ test(`#cascaded() expands a var() function with an overridden value`, (t) => {
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "visible",
-    },
+    value: { type: "keyword", value: "visible" },
     source: h.declaration("overflow-x", "var(--hidden)").toJSON(),
   });
 });
@@ -348,10 +300,7 @@ test(`#cascaded() expands a var() function with a value that contains another
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "hidden",
-    },
+    value: { type: "keyword", value: "hidden" },
     source: h.declaration("overflow-x", "var(--hidden)").toJSON(),
   });
 });
@@ -374,18 +323,12 @@ test(`#cascaded() expands multiple var() functions in the same declaration`, (t)
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "hidden",
-    },
+    value: { type: "keyword", value: "hidden" },
     source: h.declaration("overflow", "var(--hidden) var(--visible)").toJSON(),
   });
 
   t.deepEqual(cascaded(element, "overflow-y"), {
-    value: {
-      type: "keyword",
-      value: "visible",
-    },
+    value: { type: "keyword", value: "visible" },
     source: h.declaration("overflow", "var(--hidden) var(--visible)").toJSON(),
   });
 });
@@ -407,18 +350,12 @@ test(`#cascaded() expands several var() function references to the same variable
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "hidden",
-    },
+    value: { type: "keyword", value: "hidden" },
     source: h.declaration("overflow", "var(--hidden) var(--hidden)").toJSON(),
   });
 
   t.deepEqual(cascaded(element, "overflow-y"), {
-    value: {
-      type: "keyword",
-      value: "hidden",
-    },
+    value: { type: "keyword", value: "hidden" },
     source: h.declaration("overflow", "var(--hidden) var(--hidden)").toJSON(),
   });
 });
@@ -439,10 +376,7 @@ test(`#cascaded() expands a var() function with a fallback with a var() function
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "hidden",
-    },
+    value: { type: "keyword", value: "hidden" },
     source: h
       .declaration("overflow-x", "var(--foo, var(--bar, hidden))")
       .toJSON(),
@@ -464,10 +398,7 @@ test(`#cascaded() returns "unset" when a var() function variable isn't defined`,
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "unset",
-    },
+    value: { type: "keyword", value: "unset" },
     source: h.declaration("overflow-x", "var(--visible)").toJSON(),
   });
 });
@@ -487,10 +418,7 @@ test(`#cascaded() returns "unset" when a var() function fallback is empty`, (t) 
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "unset",
-    },
+    value: { type: "keyword", value: "unset" },
     source: h.declaration("overflow-x", "var(--visible,)").toJSON(),
   });
 });
@@ -513,10 +441,7 @@ test(`#cascaded() returns "unset" when declaration with a var() function is
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "unset",
-    },
+    value: { type: "keyword", value: "unset" },
     source: h.declaration("overflow-x", "var(--visible)").toJSON(),
   });
 });
@@ -538,10 +463,7 @@ test(`#cascaded() returns "unset" when a var() function is invalid`, (t) => {
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "unset",
-    },
+    value: { type: "keyword", value: "unset" },
     source: h.declaration("overflow-x", "var(--hidden)").toJSON(),
   });
 });
@@ -564,10 +486,7 @@ test(`#cascaded() returns "unset" when var() functions contain cyclic references
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "unset",
-    },
+    value: { type: "keyword", value: "unset" },
     source: h.declaration("overflow-x", "var(--hidden)").toJSON(),
   });
 });
@@ -590,10 +509,7 @@ test(`#cascaded() returns "unset" when a custom property referenced by a var()
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "unset",
-    },
+    value: { type: "keyword", value: "unset" },
     source: h.declaration("overflow-x", "var(--hidden)").toJSON(),
   });
 });
@@ -644,10 +560,7 @@ test(`#cascaded() returns "unset" when confronted with a billion laughs`, (t) =>
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "unset",
-    },
+    value: { type: "keyword", value: "unset" },
     source: h.declaration("overflow-x", "var(--prop30)").toJSON(),
   });
 });
@@ -688,18 +601,12 @@ test(`#cascaded() correctly resolves var() function references within context
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "hidden",
-    },
+    value: { type: "keyword", value: "hidden" },
     source: h.declaration("overflow-x", "var(--hidden)").toJSON(),
   });
 
   t.deepEqual(cascaded(element, "color"), {
-    value: {
-      type: "keyword",
-      value: "unset",
-    },
+    value: { type: "keyword", value: "unset" },
     source: h.declaration("color", "var(--foo)").toJSON(),
   });
 });
@@ -726,10 +633,7 @@ test(`#cascaded() gives precedence to !important custom properties used in var()
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "hidden",
-    },
+    value: { type: "keyword", value: "hidden" },
     source: h.declaration("overflow-x", "var(--hidden)").toJSON(),
   });
 });
@@ -756,10 +660,7 @@ test(`#cascaded() does not fall back on the inherited value of a custom property
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "unset",
-    },
+    value: { type: "keyword", value: "unset" },
     source: h.declaration("overflow-x", "var(--hidden)").toJSON(),
   });
 });
@@ -787,10 +688,7 @@ test(`#cascaded() does not fall back on the inherited value of a custom property
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "unset",
-    },
+    value: { type: "keyword", value: "unset" },
     source: h.declaration("overflow-x", "var(--hidden, foo)").toJSON(),
   });
 });
@@ -811,10 +709,7 @@ test(`#cascaded() accept spaces around variable name in a var() function`, (t) =
   );
 
   t.deepEqual(cascaded(element, "overflow-x"), {
-    value: {
-      type: "keyword",
-      value: "hidden",
-    },
+    value: { type: "keyword", value: "hidden" },
     source: h.declaration("overflow-x", "var( --hidden )").toJSON(),
   });
 });
@@ -838,20 +733,12 @@ test(`#cascaded() resolves :hover style for an element`, (t) => {
   );
 
   t.deepEqual(cascaded(element, "color", Context.hover(element)), {
-    value: {
-      type: "color",
-      format: "named",
-      color: "blue",
-    },
+    value: { type: "color", format: "named", color: "blue" },
     source: h.declaration("color", "blue").toJSON(),
   });
 
   t.deepEqual(cascaded(element, "color"), {
-    value: {
-      type: "color",
-      format: "named",
-      color: "red",
-    },
+    value: { type: "color", format: "named", color: "red" },
     source: h.declaration("color", "red").toJSON(),
   });
 });
@@ -875,20 +762,12 @@ test(`#cascaded() resolves :focus style for an element`, (t) => {
   );
 
   t.deepEqual(cascaded(element, "color", Context.focus(element)), {
-    value: {
-      type: "color",
-      format: "named",
-      color: "blue",
-    },
+    value: { type: "color", format: "named", color: "blue" },
     source: h.declaration("color", "blue").toJSON(),
   });
 
   t.deepEqual(cascaded(element, "color"), {
-    value: {
-      type: "color",
-      format: "named",
-      color: "red",
-    },
+    value: { type: "color", format: "named", color: "red" },
     source: h.declaration("color", "red").toJSON(),
   });
 });
@@ -908,5 +787,57 @@ test(`#specified() keeps the !important flag of properties set to initial`, (t) 
       alpha: { type: "percentage", value: 0 },
     },
     source: { name: "background-color", value: "initial", important: true },
+  });
+});
+
+test("#cascaded() accepts rules from the shadow tree, when relevant", (t) => {
+  const element = (
+    <div>
+      {h.shadow(
+        [<span></span>],
+        [h.sheet([h.rule.style(":host", { color: "red" })])],
+      )}
+    </div>
+  );
+  h.document([element]);
+
+  t.deepEqual(cascaded(element, "color"), {
+    value: { type: "color", format: "named", color: "red" },
+    source: h.declaration("color", "red").toJSON(),
+  });
+});
+
+test("#cascaded() prefers important declaration from the shadow tree, and normal ones from the light tree", (t) => {
+  const element = (
+    <div>
+      {h.shadow(
+        [<span></span>],
+        [
+          h.sheet([
+            h.rule.style(":host", { color: "red !important" }),
+            h.rule.style(":host", { "background-color": "red" }),
+          ]),
+        ],
+      )}
+    </div>
+  );
+  h.document(
+    [element],
+    [
+      h.sheet([
+        h.rule.style("div", { color: "blue !important" }),
+        h.rule.style("div", { "background-color": "blue" }),
+      ]),
+    ],
+  );
+
+  t.deepEqual(cascaded(element, "color"), {
+    value: { type: "color", format: "named", color: "red" },
+    source: h.declaration("color", "red", true).toJSON(),
+  });
+
+  t.deepEqual(cascaded(element, "background-color"), {
+    value: { type: "color", format: "named", color: "blue" },
+    source: h.declaration("background-color", "blue").toJSON(),
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1673,6 +1673,7 @@ __metadata:
     "@siteimprove/alfa-option": "workspace:^0.72.0"
     "@siteimprove/alfa-parser": "workspace:^0.72.0"
     "@siteimprove/alfa-predicate": "workspace:^0.72.0"
+    "@siteimprove/alfa-refinement": "workspace:^0.72.0"
     "@siteimprove/alfa-sequence": "workspace:^0.72.0"
     "@siteimprove/alfa-slice": "workspace:^0.72.0"
     "@siteimprove/alfa-test": "workspace:^0.72.0"


### PR DESCRIPTION
Part of #1533 

* Include encapsulation context in CSS cascade precedence.
* Correctly parse `:host` selector.
* Include "shadow rules" (i.e., `:host`, for now) from the shadow tree style sheet into shadow hosts' cascade.
* Exclude "shadow rules" from the cascade of the shadow tree they are defined on.

Given the nature of `:host`, full matching cannot be done within the selector itself but has to be delegated to the cascade (and selector map).
