### PR TITLE
Fix ownership of rules

### DIFF
--- a/.changeset/gentle-tomatoes-draw.md
+++ b/.changeset/gentle-tomatoes-draw.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-dom": patch
+---
+
+**Fixed:** Nested style rules now correctly get their sheet as owner.

--- a/docs/review/api/alfa-dom.api.md
+++ b/docs/review/api/alfa-dom.api.md
@@ -895,19 +895,19 @@ export namespace Query {
 export abstract class Rule<T extends string = string> implements Equatable, Serializable {
     protected constructor(type: T);
     // (undocumented)
-    ancestors(): Iterable<Rule>;
+    ancestors(): Iterable_2<Rule>;
     // @internal (undocumented)
     _attachOwner(owner: Sheet): boolean;
     // @internal (undocumented)
     _attachParent(parent: Rule): boolean;
     // (undocumented)
-    children(): Iterable<Rule>;
+    children(): Iterable_2<Rule>;
     // (undocumented)
-    descendants(): Iterable<Rule>;
+    descendants(): Iterable_2<Rule>;
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
-    inclusiveAncestors(): Iterable<Rule>;
+    inclusiveAncestors(): Iterable_2<Rule>;
     // (undocumented)
     get owner(): Option<Sheet>;
     // (undocumented)

--- a/packages/alfa-dom/src/style/rule.ts
+++ b/packages/alfa-dom/src/style/rule.ts
@@ -1,4 +1,5 @@
 import { Equatable } from "@siteimprove/alfa-equatable";
+import { Iterable } from "@siteimprove/alfa-iterable";
 import { Serializable } from "@siteimprove/alfa-json";
 import { None, Option } from "@siteimprove/alfa-option";
 import { Trampoline } from "@siteimprove/alfa-trampoline";
@@ -84,7 +85,10 @@ export abstract class Rule<T extends string = string>
 
     this._owner = Option.of(owner);
 
-    return true;
+    // Recursively attach the owner to all descendants.
+    return Iterable.every(this.descendants(), (rule) =>
+      rule._attachOwner(owner),
+    );
   }
 
   /**

--- a/packages/alfa-dom/src/style/rule.ts
+++ b/packages/alfa-dom/src/style/rule.ts
@@ -85,10 +85,8 @@ export abstract class Rule<T extends string = string>
 
     this._owner = Option.of(owner);
 
-    // Recursively attach the owner to all descendants.
-    return Iterable.every(this.descendants(), (rule) =>
-      rule._attachOwner(owner),
-    );
+    // Recursively attach the owner to all children.
+    return Iterable.every(this.children(), (rule) => rule._attachOwner(owner));
   }
 
   /**

--- a/packages/alfa-dom/test/style.spec.ts
+++ b/packages/alfa-dom/test/style.spec.ts
@@ -1,0 +1,10 @@
+import { test } from "@siteimprove/alfa-test";
+
+import { h } from "../src";
+
+test("Sheet.of assigns owner to descendants of condition rules", (t) => {
+  const rule = h.rule.style("foo", { foo: "bar" });
+  const sheet = h.sheet([h.rule.media("screen", [rule])]);
+
+  t.equal(rule.owner.getUnsafe(), sheet);
+});

--- a/packages/alfa-dom/test/style.spec.ts
+++ b/packages/alfa-dom/test/style.spec.ts
@@ -4,7 +4,9 @@ import { h } from "../src";
 
 test("Sheet.of assigns owner to descendants of condition rules", (t) => {
   const rule = h.rule.style("foo", { foo: "bar" });
-  const sheet = h.sheet([h.rule.media("screen", [rule])]);
+  const sheet = h.sheet([
+    h.rule.supports("foo", [h.rule.media("screen", [rule])]),
+  ]);
 
   t.equal(rule.owner.getUnsafe(), sheet);
 });

--- a/packages/alfa-dom/tsconfig.json
+++ b/packages/alfa-dom/tsconfig.json
@@ -87,6 +87,7 @@
     "test/node/traversal/lowest-common-ancestor.spec.tsx",
     "test/node/query/element-descendants.spec.tsx",
     "test/node/query/element-id-map.spec.tsx",
+    "test/style.spec.ts",
     "test/traversal.spec.tsx"
   ],
   "references": [


### PR DESCRIPTION
Randomly found that bug 🤷 
This notably caused https://github.com/Siteimprove/alfa/blob/main/packages/alfa-cascade/src/user-agent.ts#L40-L44 to not be considered as a User Agent rule due to the nesting, and therefore lose cascade versus important Author rules.
