### PR TITLE
Accessible name: add spaces around table cell content

### DIFF
--- a/.changeset/afraid-beers-share.md
+++ b/.changeset/afraid-beers-share.md
@@ -7,3 +7,4 @@
 * `<br>` elements add a space to the name.
 * Text nodes with leading or trailing spaces (including space only nodes) keep the space when concatenated.
 * Names of descendants with an `aria-label` are spaced, following browsers' behavior.
+* Names of descendants displayed as `table-cell` are spaced, following browsers' behavior. 

--- a/packages/alfa-aria/src/name/name.ts
+++ b/packages/alfa-aria/src/name/name.ts
@@ -358,11 +358,13 @@ export namespace Name {
       // was hidden, keep going.
     }
 
-    // If the element is a block element, record that it needs spaces when combined.
+    // If the element is a block element or a table cell, record that it needs
+    // spaces when combined.
     const spaced = test(
       hasComputedStyle(
         "display",
-        ({ values: [outside] }) => outside.value === "block",
+        ({ values: [outside] }) =>
+          outside.value === "block" || outside.value === "table-cell",
         device,
       ),
       element,

--- a/packages/alfa-aria/test/name-testable-statements.spec.tsx
+++ b/packages/alfa-aria/test/name-testable-statements.spec.tsx
@@ -3235,9 +3235,6 @@ test("Name text-title", (t) => {
 
 /**
  * {@link https://www.w3.org/wiki/AccName_1.1_Testable_Statements#Name_from_content}
- *
- * JSX emitter is too eager in trimming spaces on text nodes alone on a line
- * {@link https://github.com/microsoft/TypeScript/issues/57298}
  */
 test("Name from content", (t) => {
   const testCase = (
@@ -3254,7 +3251,7 @@ test("Name from content", (t) => {
           <span aria-label="Garaventa">Zambino</span>
         </span>
         <span>the weird.</span>
-        (QED)
+        {" (QED) "}
         <span class="hidden">
           <i>
             <b>and don't you forget it.</b>
@@ -3283,7 +3280,7 @@ test("Name from content", (t) => {
 
   const target = getTarget(document, "test");
 
-  t.notEqual(
+  t.equal(
     getName(target),
     "My name is Eli the weird. (QED) Where are my marbles?",
   );
@@ -3291,9 +3288,6 @@ test("Name from content", (t) => {
 
 /**
  * {@link https://www.w3.org/wiki/AccName_1.1_Testable_Statements#Name_from_content_of_labelledby_element}
- *
- * JSX emitter is too eager in trimming spaces on text nodes alone on a line
- * {@link https://github.com/microsoft/TypeScript/issues/57298}
  */
 test("Name from content of labelledby element", (t) => {
   const testCase = (
@@ -3311,7 +3305,7 @@ test("Name from content of labelledby element", (t) => {
           <span aria-label="Garaventa">Zambino</span>
         </span>
         <span>the weird.</span>
-        (QED)
+        {" (QED) "}
         <span class="hidden">
           <i>
             <b>and don't you forget it.</b>
@@ -3340,7 +3334,7 @@ test("Name from content of labelledby element", (t) => {
 
   const target = getTarget(document, "test");
 
-  t.notEqual(
+  t.equal(
     getName(target),
     "My name is Eli the weird. (QED) Where are my marbles?",
   );
@@ -3348,9 +3342,6 @@ test("Name from content of labelledby element", (t) => {
 
 /**
  * {@link https://www.w3.org/wiki/AccName_1.1_Testable_Statements#Name_from_content_of_label}
- *
- * JSX emitter is too eager in trimming spaces on text nodes alone on a line
- * {@link https://github.com/microsoft/TypeScript/issues/57298}
  */
 test("Name from content of label", (t) => {
   const testCase = (
@@ -3368,7 +3359,7 @@ test("Name from content of label", (t) => {
           <span aria-label="Garaventa">Zambino</span>
         </span>
         <span>the weird.</span>
-        (QED)
+        {" (QED) "}
         <span class="hidden">
           <i>
             <b>and don't you forget it.</b>
@@ -3397,7 +3388,7 @@ test("Name from content of label", (t) => {
 
   const target = getTarget(document, "test");
 
-  t.notEqual(
+  t.equal(
     getName(target),
     "My name is Eli the weird. (QED) Where are my marbles?",
   );
@@ -3440,7 +3431,7 @@ test("Name from content of labelledby elements one of which is hidden", (t) => {
             <span aria-label="Garaventa">Zambino</span>
           </span>
           <span>the weird.</span>
-          (QED)
+          {" (QED) "}
           <span class="hidden">
             <i>
               <b>and don't you forget it.</b>
@@ -3784,9 +3775,6 @@ test("Name file-label-owned-combobox", (t) => {
 
 /**
  * {@link https://www.w3.org/wiki/AccName_1.1_Testable_Statements#Name_link-mixed-content}
- *
- * JSX emitter is too eager in trimming spaces on text nodes alone on a line
- * {@link https://github.com/microsoft/TypeScript/issues/57298}
  */
 test("Name link-mixed-content", (t) => {
   const testCase = (
@@ -3803,7 +3791,7 @@ test("Name link-mixed-content", (t) => {
           <span aria-label="Garaventa">Zambino</span>
         </span>
         <span>the weird.</span>
-        (QED)
+        {" (QED) "}
         <span class="hidden">
           <i>
             <b>and don't you forget it.</b>
@@ -3820,7 +3808,7 @@ test("Name link-mixed-content", (t) => {
 
   const target = getTarget(document, "test");
 
-  t.notEqual(getName(target), "My name is Eli the weird. (QED)");
+  t.equal(getName(target), "My name is Eli the weird. (QED)");
 });
 
 /**

--- a/packages/alfa-aria/test/name-testable-statements.spec.tsx
+++ b/packages/alfa-aria/test/name-testable-statements.spec.tsx
@@ -3280,7 +3280,7 @@ test("Name from content", (t) => {
 
   const target = getTarget(document, "test");
 
-  t.equal(
+  t.notEqual(
     getName(target),
     "My name is Eli the weird. (QED) Where are my marbles?",
   );

--- a/packages/alfa-aria/test/name-testable-statements.spec.tsx
+++ b/packages/alfa-aria/test/name-testable-statements.spec.tsx
@@ -3280,7 +3280,7 @@ test("Name from content", (t) => {
 
   const target = getTarget(document, "test");
 
-  t.notEqual(
+  t.equal(
     getName(target),
     "My name is Eli the weird. (QED) Where are my marbles?",
   );


### PR DESCRIPTION
Following what browsers do, elements with a `display: table-cell` get spaced when part of an accessible name (like `display: block`).

Also improve JSX generation from the testable statements to cater from JSX eagerly consuming spaces that are significant in HTML.
