### PR TITLE
Update to WCAG 2.2

### DIFF
--- a/.changeset/hip-plums-dance.md
+++ b/.changeset/hip-plums-dance.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-wcag": minor
+---
+
+**Changed:** Update WCAG SC to get data from WCAG 2.2 by default.

--- a/docs/review/api/alfa-wcag.api.md
+++ b/docs/review/api/alfa-wcag.api.md
@@ -83,9 +83,9 @@ export namespace Criterion {
     export type Version = "2.0" | "2.1" | "2.2";
     // (undocumented)
     export namespace Version {
-        const Recommendation = "2.1";
-        export type Draft = typeof Draft;
-        const Draft = "2.2";
+        const Recommendation = "2.2";
+        export type Old = typeof Old;
+        const Old = "2.1";
         export type Recommendation = typeof Recommendation;
     }
 }

--- a/packages/alfa-wcag/scripts/criteria.js
+++ b/packages/alfa-wcag/scripts/criteria.js
@@ -3,10 +3,11 @@ const path = require("path");
 const prettier = require("prettier");
 const puppeteer = require("puppeteer");
 
+// We need to fetch 2.2 first to populate the data with its values.
 const specifications = [
+  ["2.2", "https://www.w3.org/TR/WCAG2/"],
+  ["2.1", "https://www.w3.org/TR/WCAG21/"],
   ["2.0", "https://www.w3.org/TR/WCAG20/"],
-  ["2.1", "https://www.w3.org/TR/WCAG2/"],
-  ["2.2", "https://www.w3.org/TR/WCAG22/"],
 ];
 
 puppeteer.launch().then(async (browser) => {
@@ -16,28 +17,41 @@ puppeteer.launch().then(async (browser) => {
   for (const [version, specification] of specifications) {
     await page.goto(specification);
 
-    const data = await page.evaluate(() =>
-      [...document.querySelectorAll(".sc")].map((criterion) => {
-        const heading = criterion.querySelector("h4, .sc-handle");
+    const data = await page.evaluate(
+      (version) =>
+        [
+          ...document.querySelectorAll(
+            version === "2.0"
+              ? ".sc"
+              : // Both guidelines and criteria are section.guideline, so we
+                // need more structure in the match.
+                "section.principle section.guideline section.guideline",
+          ),
+        ].map((criterion) => {
+          const heading = criterion.querySelector(
+            version === "2.0" ? ".sc-handle" : "h4",
+          );
 
-        const [, chapter, title] = heading.textContent.match(
-          /(\d\.\d\.\d{1,2}) ([^§:]+)/,
-        );
+          const [, chapter, title] = heading.textContent.match(
+            /(\d\.\d\.\d{1,2}) ([^§:]+)/,
+          );
 
-        const id = criterion.id;
+          const id = criterion.id;
 
-        const [, level] = criterion.textContent.match(/\(Level (A{1,3})\)/);
+          if (version === "2.2" && chapter === "4.1.1") {
+            return { chapter, id, title, level: "Obsolete" };
+          }
 
-        return {
-          chapter,
-          id,
-          title,
-          level,
-        };
-      }),
+          const [, level] = criterion.textContent.match(/\(Level (A{1,3})\)/);
+
+          return { chapter, id, title, level };
+        }),
+      version,
     );
 
-    for (const { chapter, id, title, level } of data) {
+    for (const { chapter, id, title, level } of data.filter(
+      ({ level }) => level !== "Obsolete",
+    )) {
       criteria[chapter] = criteria[chapter] ?? {
         title,
         versions: [],

--- a/packages/alfa-wcag/scripts/techniques.js
+++ b/packages/alfa-wcag/scripts/techniques.js
@@ -6,32 +6,34 @@ const puppeteer = require("puppeteer");
 puppeteer.launch().then(async (browser) => {
   const page = await browser.newPage();
 
-  await page.goto("https://www.w3.org/WAI/WCAG21/Techniques/");
+  await page.goto("https://www.w3.org/WAI/WCAG22/Techniques/");
 
   const techniques = await page.evaluate(() =>
     Object.fromEntries(
-      [...document.querySelectorAll("#toc ul li a")].map((technique) => {
-        const uri = technique.href;
+      [...document.querySelectorAll("ul.toc-wcag-docs li a")].map(
+        (technique) => {
+          const uri = technique.href;
 
-        const match = technique.textContent
-          .replace(/\s+/, " ")
-          .trim()
-          .match(/^(\w+\d+): (.+)/);
+          const match = technique.textContent
+            .replace(/\s+/, " ")
+            .trim()
+            .match(/^(\w+\d+): (.+)/);
 
-        if (match === null) {
-          return [];
-        }
+          if (match === null) {
+            return [];
+          }
 
-        const [, name, title] = match;
+          const [, name, title] = match;
 
-        return [
-          name,
-          {
-            title,
-            uri,
-          },
-        ];
-      }),
+          return [
+            name,
+            {
+              title,
+              uri,
+            },
+          ];
+        },
+      ),
     ),
   );
 

--- a/packages/alfa-wcag/src/criterion.ts
+++ b/packages/alfa-wcag/src/criterion.ts
@@ -44,14 +44,14 @@ export class Criterion<
    * URI and use that.
    */
   public get uri(): Criterion.URI<C, "2.1" | "2.2"> {
+    const versions = [...Criteria[this._chapter].versions];
     // Use the criterion URI from the recommendation, if available, otherwise
-    // use the URI from the draft. This ensures that the most stable identifier
+    // use the URI from the previous version. This ensures that the most recent identifier
     // is used when avaiable.
-    const [, { uri }] = [...Criteria[this._chapter].versions].find(
-      ([version]) =>
-        version === Criterion.Version.Recommendation ||
-        version === Criterion.Version.Draft,
-    )!;
+    const [, { uri }] =
+      versions.find(
+        ([version]) => version === Criterion.Version.Recommendation,
+      ) ?? versions.find(([version]) => version === Criterion.Version.Old)!;
 
     return uri as Criterion.URI<C, "2.1" | "2.2">;
   }
@@ -144,7 +144,7 @@ export namespace Criterion {
     /**
      * The current version of the WCAG Recommendation.
      */
-    export const Recommendation = "2.1";
+    export const Recommendation = "2.2";
 
     /**
      * The current version of the WCAG Recommendation.
@@ -154,37 +154,43 @@ export namespace Criterion {
     /**
      * The current version of the WCAG Working Draft.
      */
-    export const Draft = "2.2";
+    // export const Draft = "2.2";
 
     /**
      * The current version of the WCAG Working Draft.
      */
-    export type Draft = typeof Draft;
+    // export type Draft = typeof Draft;
+
+    /**
+     * The Old recommendation.
+     */
+    export const Old = "2.1";
+
+    /**
+     * The old recommendation.
+     */
+    export type Old = typeof Old;
   }
 
   /**
    * The URI of the specified criterion.
    */
-  export type URI<
-    C extends Chapter = Chapter,
-    V extends Version = Version,
-  > = Criteria[C]["versions"] extends Iterable<infer T>
-    ? T extends readonly [V, { readonly uri: infer U }]
-      ? U
-      : never
-    : never;
+  export type URI<C extends Chapter = Chapter, V extends Version = Version> =
+    Criteria[C]["versions"] extends Iterable<infer T>
+      ? T extends readonly [V, { readonly uri: infer U }]
+        ? U
+        : never
+      : never;
 
   /**
    * The level of the specified criterion under the specified version.
    */
-  export type Level<
-    C extends Chapter = Chapter,
-    V extends Version = Version,
-  > = Criteria[C]["versions"] extends Iterable<infer T>
-    ? T extends readonly [V, { readonly level: infer L }]
-      ? L
-      : never
-    : never;
+  export type Level<C extends Chapter = Chapter, V extends Version = Version> =
+    Criteria[C]["versions"] extends Iterable<infer T>
+      ? T extends readonly [V, { readonly level: infer L }]
+        ? L
+        : never
+      : never;
 
   export namespace Level {
     /**
@@ -230,10 +236,10 @@ export namespace Criterion {
     const rewrittenUri = uri
       // Keeping slashes in URL rewritting to ensure proper delimiting of path
       // pieces.
-      // rewrite WCAG21 -> WCAG2 since we only parse the latter.
+      // rewrite WCAG22 -> WCAG2 since this is how we store it.
       // We should use the shared way of tracking which version is the latest as
       // this will require manual updates.
-      .replace("/WCAG21/", "/WCAG2/")
+      .replace("/WCAG22/", "/WCAG2/")
       // rewrite WCAG -> WCAG2 since we only parse the latter.
       .replace("/WCAG/", "/WCAG2/");
 

--- a/packages/alfa-wcag/src/criterion/data.ts
+++ b/packages/alfa-wcag/src/criterion/data.ts
@@ -15,23 +15,23 @@ export const Criteria = {
     title: "Non-text Content",
     versions: [
       [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#text-equiv-all",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#non-text-content",
           level: "A",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#non-text-content",
+          uri: "https://www.w3.org/TR/WCAG21/#non-text-content",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#text-equiv-all",
           level: "A",
         },
       ],
@@ -41,23 +41,23 @@ export const Criteria = {
     title: "Audio-only and Video-only (Prerecorded)",
     versions: [
       [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#media-equiv-av-only-alt",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#audio-only-and-video-only-prerecorded",
           level: "A",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#audio-only-and-video-only-prerecorded",
+          uri: "https://www.w3.org/TR/WCAG21/#audio-only-and-video-only-prerecorded",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#media-equiv-av-only-alt",
           level: "A",
         },
       ],
@@ -67,23 +67,23 @@ export const Criteria = {
     title: "Captions (Prerecorded)",
     versions: [
       [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#media-equiv-captions",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#captions-prerecorded",
           level: "A",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#captions-prerecorded",
+          uri: "https://www.w3.org/TR/WCAG21/#captions-prerecorded",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#media-equiv-captions",
           level: "A",
         },
       ],
@@ -93,23 +93,23 @@ export const Criteria = {
     title: "Audio Description or Media Alternative (Prerecorded)",
     versions: [
       [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#audio-description-or-media-alternative-prerecorded",
           level: "A",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#audio-description-or-media-alternative-prerecorded",
+          uri: "https://www.w3.org/TR/WCAG21/#audio-description-or-media-alternative-prerecorded",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc",
           level: "A",
         },
       ],
@@ -119,23 +119,23 @@ export const Criteria = {
     title: "Captions (Live)",
     versions: [
       [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#media-equiv-real-time-captions",
-          level: "AA",
-        },
-      ],
-      [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#captions-live",
           level: "AA",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#captions-live",
+          uri: "https://www.w3.org/TR/WCAG21/#captions-live",
+          level: "AA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#media-equiv-real-time-captions",
           level: "AA",
         },
       ],
@@ -145,23 +145,23 @@ export const Criteria = {
     title: "Audio Description (Prerecorded)",
     versions: [
       [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc-only",
-          level: "AA",
-        },
-      ],
-      [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#audio-description-prerecorded",
           level: "AA",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#audio-description-prerecorded",
+          uri: "https://www.w3.org/TR/WCAG21/#audio-description-prerecorded",
+          level: "AA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc-only",
           level: "AA",
         },
       ],
@@ -171,49 +171,49 @@ export const Criteria = {
     title: "Sign Language (Prerecorded)",
     versions: [
       [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#media-equiv-sign",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#sign-language-prerecorded",
           level: "AAA",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#sign-language-prerecorded",
+          uri: "https://www.w3.org/TR/WCAG21/#sign-language-prerecorded",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#media-equiv-sign",
           level: "AAA",
         },
       ],
     ],
   },
   "1.2.7": {
-    title: "Extended Audio Description  (Prerecorded)",
+    title: "Extended Audio Description (Prerecorded)",
     versions: [
       [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#media-equiv-extended-ad",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#extended-audio-description-prerecorded",
           level: "AAA",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#extended-audio-description-prerecorded",
+          uri: "https://www.w3.org/TR/WCAG21/#extended-audio-description-prerecorded",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#media-equiv-extended-ad",
           level: "AAA",
         },
       ],
@@ -223,23 +223,23 @@ export const Criteria = {
     title: "Media Alternative (Prerecorded)",
     versions: [
       [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#media-equiv-text-doc",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#media-alternative-prerecorded",
           level: "AAA",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#media-alternative-prerecorded",
+          uri: "https://www.w3.org/TR/WCAG21/#media-alternative-prerecorded",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#media-equiv-text-doc",
           level: "AAA",
         },
       ],
@@ -249,23 +249,23 @@ export const Criteria = {
     title: "Audio-only (Live)",
     versions: [
       [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#media-equiv-live-audio-only",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#audio-only-live",
           level: "AAA",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#audio-only-live",
+          uri: "https://www.w3.org/TR/WCAG21/#audio-only-live",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#media-equiv-live-audio-only",
           level: "AAA",
         },
       ],
@@ -275,23 +275,23 @@ export const Criteria = {
     title: "Info and Relationships",
     versions: [
       [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#info-and-relationships",
           level: "A",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#info-and-relationships",
+          uri: "https://www.w3.org/TR/WCAG21/#info-and-relationships",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic",
           level: "A",
         },
       ],
@@ -301,23 +301,23 @@ export const Criteria = {
     title: "Meaningful Sequence",
     versions: [
       [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#content-structure-separation-sequence",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#meaningful-sequence",
           level: "A",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#meaningful-sequence",
+          uri: "https://www.w3.org/TR/WCAG21/#meaningful-sequence",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#content-structure-separation-sequence",
           level: "A",
         },
       ],
@@ -327,1271 +327,23 @@ export const Criteria = {
     title: "Sensory Characteristics",
     versions: [
       [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#content-structure-separation-understanding",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#sensory-characteristics",
           level: "A",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#sensory-characteristics",
+          uri: "https://www.w3.org/TR/WCAG21/#sensory-characteristics",
           level: "A",
         },
       ],
-    ],
-  },
-  "1.4.1": {
-    title: "Use of Color",
-    versions: [
       [
         "2.0",
         {
-          uri: "https://www.w3.org/TR/WCAG20/#visual-audio-contrast-without-color",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#use-of-color",
-          level: "A",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#use-of-color",
-          level: "A",
-        },
-      ],
-    ],
-  },
-  "1.4.2": {
-    title: "Audio Control",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#visual-audio-contrast-dis-audio",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#audio-control",
-          level: "A",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#audio-control",
-          level: "A",
-        },
-      ],
-    ],
-  },
-  "1.4.3": {
-    title: "Contrast (Minimum)",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast",
-          level: "AA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#contrast-minimum",
-          level: "AA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#contrast-minimum",
-          level: "AA",
-        },
-      ],
-    ],
-  },
-  "1.4.4": {
-    title: "Resize text",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#visual-audio-contrast-scale",
-          level: "AA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#resize-text",
-          level: "AA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#resize-text",
-          level: "AA",
-        },
-      ],
-    ],
-  },
-  "1.4.5": {
-    title: "Images of Text",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-presentation",
-          level: "AA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#images-of-text",
-          level: "AA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#images-of-text",
-          level: "AA",
-        },
-      ],
-    ],
-  },
-  "1.4.6": {
-    title: "Contrast (Enhanced)",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#visual-audio-contrast7",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#contrast-enhanced",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#contrast-enhanced",
-          level: "AAA",
-        },
-      ],
-    ],
-  },
-  "1.4.7": {
-    title: "Low or No Background Audio",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#visual-audio-contrast-noaudio",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#low-or-no-background-audio",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#low-or-no-background-audio",
-          level: "AAA",
-        },
-      ],
-    ],
-  },
-  "1.4.8": {
-    title: "Visual Presentation",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#visual-audio-contrast-visual-presentation",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#visual-presentation",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#visual-presentation",
-          level: "AAA",
-        },
-      ],
-    ],
-  },
-  "1.4.9": {
-    title: "Images of Text (No Exception)",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-images",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#images-of-text-no-exception",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#images-of-text-no-exception",
-          level: "AAA",
-        },
-      ],
-    ],
-  },
-  "2.1.1": {
-    title: "Keyboard",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#keyboard-operation-keyboard-operable",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#keyboard",
-          level: "A",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#keyboard",
-          level: "A",
-        },
-      ],
-    ],
-  },
-  "2.1.2": {
-    title: "No Keyboard Trap",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#keyboard-operation-trapping",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#no-keyboard-trap",
-          level: "A",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#no-keyboard-trap",
-          level: "A",
-        },
-      ],
-    ],
-  },
-  "2.1.3": {
-    title: "Keyboard (No Exception)",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#keyboard-operation-all-funcs",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#keyboard-no-exception",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#keyboard-no-exception",
-          level: "AAA",
-        },
-      ],
-    ],
-  },
-  "2.2.1": {
-    title: "Timing Adjustable",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#time-limits-required-behaviors",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#timing-adjustable",
-          level: "A",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#timing-adjustable",
-          level: "A",
-        },
-      ],
-    ],
-  },
-  "2.2.2": {
-    title: "Pause, Stop, Hide",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#time-limits-pause",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#pause-stop-hide",
-          level: "A",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#pause-stop-hide",
-          level: "A",
-        },
-      ],
-    ],
-  },
-  "2.2.3": {
-    title: "No Timing",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#time-limits-no-exceptions",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#no-timing",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#no-timing",
-          level: "AAA",
-        },
-      ],
-    ],
-  },
-  "2.2.4": {
-    title: "Interruptions",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#time-limits-postponed",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#interruptions",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#interruptions",
-          level: "AAA",
-        },
-      ],
-    ],
-  },
-  "2.2.5": {
-    title: "Re-authenticating",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#time-limits-server-timeout",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#re-authenticating",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#re-authenticating",
-          level: "AAA",
-        },
-      ],
-    ],
-  },
-  "2.3.1": {
-    title: "Three Flashes or Below Threshold",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#seizure-does-not-violate",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#three-flashes-or-below-threshold",
-          level: "A",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#three-flashes-or-below-threshold",
-          level: "A",
-        },
-      ],
-    ],
-  },
-  "2.3.2": {
-    title: "Three Flashes",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#seizure-three-times",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#three-flashes",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#three-flashes",
-          level: "AAA",
-        },
-      ],
-    ],
-  },
-  "2.4.1": {
-    title: "Bypass Blocks",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#bypass-blocks",
-          level: "A",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#bypass-blocks",
-          level: "A",
-        },
-      ],
-    ],
-  },
-  "2.4.2": {
-    title: "Page Titled",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#page-titled",
-          level: "A",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#page-titled",
-          level: "A",
-        },
-      ],
-    ],
-  },
-  "2.4.3": {
-    title: "Focus Order",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-order",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#focus-order",
-          level: "A",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#focus-order",
-          level: "A",
-        },
-      ],
-    ],
-  },
-  "2.4.4": {
-    title: "Link Purpose (In Context)",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#link-purpose-in-context",
-          level: "A",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#link-purpose-in-context",
-          level: "A",
-        },
-      ],
-    ],
-  },
-  "2.4.5": {
-    title: "Multiple Ways",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc",
-          level: "AA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#multiple-ways",
-          level: "AA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#multiple-ways",
-          level: "AA",
-        },
-      ],
-    ],
-  },
-  "2.4.6": {
-    title: "Headings and Labels",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive",
-          level: "AA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#headings-and-labels",
-          level: "AA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#headings-and-labels",
-          level: "AA",
-        },
-      ],
-    ],
-  },
-  "2.4.7": {
-    title: "Focus Visible",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-visible",
-          level: "AA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#focus-visible",
-          level: "AA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#focus-visible",
-          level: "A",
-        },
-      ],
-    ],
-  },
-  "2.4.8": {
-    title: "Location",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#navigation-mechanisms-location",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#location",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#location",
-          level: "AAA",
-        },
-      ],
-    ],
-  },
-  "2.4.9": {
-    title: "Link Purpose (Link Only)",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#navigation-mechanisms-link",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#link-purpose-link-only",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#link-purpose-link-only",
-          level: "AAA",
-        },
-      ],
-    ],
-  },
-  "2.4.10": {
-    title: "Section Headings",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#navigation-mechanisms-headings",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#section-headings",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#section-headings",
-          level: "AAA",
-        },
-      ],
-    ],
-  },
-  "3.1.1": {
-    title: "Language of Page",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#meaning-doc-lang-id",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#language-of-page",
-          level: "A",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#language-of-page",
-          level: "A",
-        },
-      ],
-    ],
-  },
-  "3.1.2": {
-    title: "Language of Parts",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#meaning-other-lang-id",
-          level: "AA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#language-of-parts",
-          level: "AA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#language-of-parts",
-          level: "AA",
-        },
-      ],
-    ],
-  },
-  "3.1.3": {
-    title: "Unusual Words",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#meaning-idioms",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#unusual-words",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#unusual-words",
-          level: "AAA",
-        },
-      ],
-    ],
-  },
-  "3.1.4": {
-    title: "Abbreviations",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#meaning-located",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#abbreviations",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#abbreviations",
-          level: "AAA",
-        },
-      ],
-    ],
-  },
-  "3.1.5": {
-    title: "Reading Level",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#meaning-supplements",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#reading-level",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#reading-level",
-          level: "AAA",
-        },
-      ],
-    ],
-  },
-  "3.1.6": {
-    title: "Pronunciation",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#meaning-pronunciation",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#pronunciation",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#pronunciation",
-          level: "AAA",
-        },
-      ],
-    ],
-  },
-  "3.2.1": {
-    title: "On Focus",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#consistent-behavior-receive-focus",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#on-focus",
-          level: "A",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#on-focus",
-          level: "A",
-        },
-      ],
-    ],
-  },
-  "3.2.2": {
-    title: "On Input",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#consistent-behavior-unpredictable-change",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#on-input",
-          level: "A",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#on-input",
-          level: "A",
-        },
-      ],
-    ],
-  },
-  "3.2.3": {
-    title: "Consistent Navigation",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-locations",
-          level: "AA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#consistent-navigation",
-          level: "AA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#consistent-navigation",
-          level: "AA",
-        },
-      ],
-    ],
-  },
-  "3.2.4": {
-    title: "Consistent Identification",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-functionality",
-          level: "AA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#consistent-identification",
-          level: "AA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#consistent-identification",
-          level: "AA",
-        },
-      ],
-    ],
-  },
-  "3.2.5": {
-    title: "Change on Request",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#consistent-behavior-no-extreme-changes-context",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#change-on-request",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#change-on-request",
-          level: "AAA",
-        },
-      ],
-    ],
-  },
-  "3.3.1": {
-    title: "Error Identification",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#minimize-error-identified",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#error-identification",
-          level: "A",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#error-identification",
-          level: "A",
-        },
-      ],
-    ],
-  },
-  "3.3.2": {
-    title: "Labels or Instructions",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#minimize-error-cues",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#labels-or-instructions",
-          level: "A",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#labels-or-instructions",
-          level: "A",
-        },
-      ],
-    ],
-  },
-  "3.3.3": {
-    title: "Error Suggestion",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#minimize-error-suggestions",
-          level: "AA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#error-suggestion",
-          level: "AA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#error-suggestion",
-          level: "AA",
-        },
-      ],
-    ],
-  },
-  "3.3.4": {
-    title: "Error Prevention (Legal, Financial, Data)",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#minimize-error-reversible",
-          level: "AA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#error-prevention-legal-financial-data",
-          level: "AA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#error-prevention-legal-financial-data",
-          level: "AA",
-        },
-      ],
-    ],
-  },
-  "3.3.5": {
-    title: "Help",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#minimize-error-context-help",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#help",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#help",
-          level: "AAA",
-        },
-      ],
-    ],
-  },
-  "3.3.6": {
-    title: "Error Prevention (All)",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#minimize-error-reversible-all",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#error-prevention-all",
-          level: "AAA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#error-prevention-all",
-          level: "AAA",
-        },
-      ],
-    ],
-  },
-  "4.1.1": {
-    title: "Parsing",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#ensure-compat-parses",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#parsing",
-          level: "A",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#parsing",
-          level: "A",
-        },
-      ],
-    ],
-  },
-  "4.1.2": {
-    title: "Name, Role, Value",
-    versions: [
-      [
-        "2.0",
-        {
-          uri: "https://www.w3.org/TR/WCAG20/#ensure-compat-rsv",
-          level: "A",
-        },
-      ],
-      [
-        "2.1",
-        {
-          uri: "https://www.w3.org/TR/WCAG2/#name-role-value",
-          level: "A",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#name-role-value",
+          uri: "https://www.w3.org/TR/WCAG20/#content-structure-separation-understanding",
           level: "A",
         },
       ],
@@ -1601,16 +353,16 @@ export const Criteria = {
     title: "Orientation",
     versions: [
       [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#orientation",
           level: "AA",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#orientation",
+          uri: "https://www.w3.org/TR/WCAG21/#orientation",
           level: "AA",
         },
       ],
@@ -1620,16 +372,16 @@ export const Criteria = {
     title: "Identify Input Purpose",
     versions: [
       [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#identify-input-purpose",
           level: "AA",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#identify-input-purpose",
+          uri: "https://www.w3.org/TR/WCAG21/#identify-input-purpose",
           level: "AA",
         },
       ],
@@ -1639,16 +391,250 @@ export const Criteria = {
     title: "Identify Purpose",
     versions: [
       [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#identify-purpose",
           level: "AAA",
         },
       ],
       [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#identify-purpose",
+          level: "AAA",
+        },
+      ],
+    ],
+  },
+  "1.4.1": {
+    title: "Use of Color",
+    versions: [
+      [
         "2.2",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#identify-purpose",
+          uri: "https://www.w3.org/TR/WCAG2/#use-of-color",
+          level: "A",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#use-of-color",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#visual-audio-contrast-without-color",
+          level: "A",
+        },
+      ],
+    ],
+  },
+  "1.4.2": {
+    title: "Audio Control",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#audio-control",
+          level: "A",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#audio-control",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#visual-audio-contrast-dis-audio",
+          level: "A",
+        },
+      ],
+    ],
+  },
+  "1.4.3": {
+    title: "Contrast (Minimum)",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#contrast-minimum",
+          level: "AA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#contrast-minimum",
+          level: "AA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast",
+          level: "AA",
+        },
+      ],
+    ],
+  },
+  "1.4.4": {
+    title: "Resize Text",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#resize-text",
+          level: "AA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#resize-text",
+          level: "AA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#visual-audio-contrast-scale",
+          level: "AA",
+        },
+      ],
+    ],
+  },
+  "1.4.5": {
+    title: "Images of Text",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#images-of-text",
+          level: "AA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#images-of-text",
+          level: "AA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-presentation",
+          level: "AA",
+        },
+      ],
+    ],
+  },
+  "1.4.6": {
+    title: "Contrast (Enhanced)",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#contrast-enhanced",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#contrast-enhanced",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#visual-audio-contrast7",
+          level: "AAA",
+        },
+      ],
+    ],
+  },
+  "1.4.7": {
+    title: "Low or No Background Audio",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#low-or-no-background-audio",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#low-or-no-background-audio",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#visual-audio-contrast-noaudio",
+          level: "AAA",
+        },
+      ],
+    ],
+  },
+  "1.4.8": {
+    title: "Visual Presentation",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#visual-presentation",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#visual-presentation",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#visual-audio-contrast-visual-presentation",
+          level: "AAA",
+        },
+      ],
+    ],
+  },
+  "1.4.9": {
+    title: "Images of Text (No Exception)",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#images-of-text-no-exception",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#images-of-text-no-exception",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-images",
           level: "AAA",
         },
       ],
@@ -1658,16 +644,16 @@ export const Criteria = {
     title: "Reflow",
     versions: [
       [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#reflow",
           level: "AA",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#reflow",
+          uri: "https://www.w3.org/TR/WCAG21/#reflow",
           level: "AA",
         },
       ],
@@ -1677,16 +663,16 @@ export const Criteria = {
     title: "Non-text Contrast",
     versions: [
       [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#non-text-contrast",
           level: "AA",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#non-text-contrast",
+          uri: "https://www.w3.org/TR/WCAG21/#non-text-contrast",
           level: "AA",
         },
       ],
@@ -1696,16 +682,16 @@ export const Criteria = {
     title: "Text Spacing",
     versions: [
       [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#text-spacing",
           level: "AA",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#text-spacing",
+          uri: "https://www.w3.org/TR/WCAG21/#text-spacing",
           level: "AA",
         },
       ],
@@ -1715,17 +701,95 @@ export const Criteria = {
     title: "Content on Hover or Focus",
     versions: [
       [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#content-on-hover-or-focus",
           level: "AA",
         },
       ],
       [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus",
+          level: "AA",
+        },
+      ],
+    ],
+  },
+  "2.1.1": {
+    title: "Keyboard",
+    versions: [
+      [
         "2.2",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#content-on-hover-or-focus",
-          level: "AA",
+          uri: "https://www.w3.org/TR/WCAG2/#keyboard",
+          level: "A",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#keyboard",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#keyboard-operation-keyboard-operable",
+          level: "A",
+        },
+      ],
+    ],
+  },
+  "2.1.2": {
+    title: "No Keyboard Trap",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#no-keyboard-trap",
+          level: "A",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#no-keyboard-trap",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#keyboard-operation-trapping",
+          level: "A",
+        },
+      ],
+    ],
+  },
+  "2.1.3": {
+    title: "Keyboard (No Exception)",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#keyboard-no-exception",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#keyboard-no-exception",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#keyboard-operation-all-funcs",
+          level: "AAA",
         },
       ],
     ],
@@ -1734,17 +798,147 @@ export const Criteria = {
     title: "Character Key Shortcuts",
     versions: [
       [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#character-key-shortcuts",
           level: "A",
         },
       ],
       [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#character-key-shortcuts",
+          level: "A",
+        },
+      ],
+    ],
+  },
+  "2.2.1": {
+    title: "Timing Adjustable",
+    versions: [
+      [
         "2.2",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#character-key-shortcuts",
+          uri: "https://www.w3.org/TR/WCAG2/#timing-adjustable",
           level: "A",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#timing-adjustable",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#time-limits-required-behaviors",
+          level: "A",
+        },
+      ],
+    ],
+  },
+  "2.2.2": {
+    title: "Pause, Stop, Hide",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#pause-stop-hide",
+          level: "A",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#pause-stop-hide",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#time-limits-pause",
+          level: "A",
+        },
+      ],
+    ],
+  },
+  "2.2.3": {
+    title: "No Timing",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#no-timing",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#no-timing",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#time-limits-no-exceptions",
+          level: "AAA",
+        },
+      ],
+    ],
+  },
+  "2.2.4": {
+    title: "Interruptions",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#interruptions",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#interruptions",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#time-limits-postponed",
+          level: "AAA",
+        },
+      ],
+    ],
+  },
+  "2.2.5": {
+    title: "Re-authenticating",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#re-authenticating",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#re-authenticating",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#time-limits-server-timeout",
+          level: "AAA",
         },
       ],
     ],
@@ -1753,16 +947,68 @@ export const Criteria = {
     title: "Timeouts",
     versions: [
       [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#timeouts",
           level: "AAA",
         },
       ],
       [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#timeouts",
+          level: "AAA",
+        },
+      ],
+    ],
+  },
+  "2.3.1": {
+    title: "Three Flashes or Below Threshold",
+    versions: [
+      [
         "2.2",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#timeouts",
+          uri: "https://www.w3.org/TR/WCAG2/#three-flashes-or-below-threshold",
+          level: "A",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#three-flashes-or-below-threshold",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#seizure-does-not-violate",
+          level: "A",
+        },
+      ],
+    ],
+  },
+  "2.3.2": {
+    title: "Three Flashes",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#three-flashes",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#three-flashes",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#seizure-three-times",
           level: "AAA",
         },
       ],
@@ -1772,16 +1018,312 @@ export const Criteria = {
     title: "Animation from Interactions",
     versions: [
       [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#animation-from-interactions",
           level: "AAA",
         },
       ],
       [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#animation-from-interactions",
+          level: "AAA",
+        },
+      ],
+    ],
+  },
+  "2.4.1": {
+    title: "Bypass Blocks",
+    versions: [
+      [
         "2.2",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#animation-from-interactions",
+          uri: "https://www.w3.org/TR/WCAG2/#bypass-blocks",
+          level: "A",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#bypass-blocks",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip",
+          level: "A",
+        },
+      ],
+    ],
+  },
+  "2.4.2": {
+    title: "Page Titled",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#page-titled",
+          level: "A",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#page-titled",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title",
+          level: "A",
+        },
+      ],
+    ],
+  },
+  "2.4.3": {
+    title: "Focus Order",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#focus-order",
+          level: "A",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#focus-order",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-order",
+          level: "A",
+        },
+      ],
+    ],
+  },
+  "2.4.4": {
+    title: "Link Purpose (In Context)",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#link-purpose-in-context",
+          level: "A",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#link-purpose-in-context",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs",
+          level: "A",
+        },
+      ],
+    ],
+  },
+  "2.4.5": {
+    title: "Multiple Ways",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#multiple-ways",
+          level: "AA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#multiple-ways",
+          level: "AA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc",
+          level: "AA",
+        },
+      ],
+    ],
+  },
+  "2.4.6": {
+    title: "Headings and Labels",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#headings-and-labels",
+          level: "AA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#headings-and-labels",
+          level: "AA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive",
+          level: "AA",
+        },
+      ],
+    ],
+  },
+  "2.4.7": {
+    title: "Focus Visible",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#focus-visible",
+          level: "AA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#focus-visible",
+          level: "AA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-visible",
+          level: "AA",
+        },
+      ],
+    ],
+  },
+  "2.4.8": {
+    title: "Location",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#location",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#location",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#navigation-mechanisms-location",
+          level: "AAA",
+        },
+      ],
+    ],
+  },
+  "2.4.9": {
+    title: "Link Purpose (Link Only)",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#link-purpose-link-only",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#link-purpose-link-only",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#navigation-mechanisms-link",
+          level: "AAA",
+        },
+      ],
+    ],
+  },
+  "2.4.10": {
+    title: "Section Headings",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#section-headings",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#section-headings",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#navigation-mechanisms-headings",
+          level: "AAA",
+        },
+      ],
+    ],
+  },
+  "2.4.11": {
+    title: "Focus Not Obscured (Minimum)",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#focus-not-obscured-minimum",
+          level: "AA",
+        },
+      ],
+    ],
+  },
+  "2.4.12": {
+    title: "Focus Not Obscured (Enhanced)",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#focus-not-obscured-enhanced",
+          level: "AAA",
+        },
+      ],
+    ],
+  },
+  "2.4.13": {
+    title: "Focus Appearance",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#focus-appearance",
           level: "AAA",
         },
       ],
@@ -1791,16 +1333,16 @@ export const Criteria = {
     title: "Pointer Gestures",
     versions: [
       [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#pointer-gestures",
           level: "A",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#pointer-gestures",
+          uri: "https://www.w3.org/TR/WCAG21/#pointer-gestures",
           level: "A",
         },
       ],
@@ -1810,16 +1352,16 @@ export const Criteria = {
     title: "Pointer Cancellation",
     versions: [
       [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#pointer-cancellation",
           level: "A",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#pointer-cancellation",
+          uri: "https://www.w3.org/TR/WCAG21/#pointer-cancellation",
           level: "A",
         },
       ],
@@ -1829,16 +1371,16 @@ export const Criteria = {
     title: "Label in Name",
     versions: [
       [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#label-in-name",
           level: "A",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#label-in-name",
+          uri: "https://www.w3.org/TR/WCAG21/#label-in-name",
           level: "A",
         },
       ],
@@ -1848,35 +1390,35 @@ export const Criteria = {
     title: "Motion Actuation",
     versions: [
       [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#motion-actuation",
           level: "A",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#motion-actuation",
+          uri: "https://www.w3.org/TR/WCAG21/#motion-actuation",
           level: "A",
         },
       ],
     ],
   },
   "2.5.5": {
-    title: "Target Size",
+    title: "Target Size (Enhanced)",
     versions: [
       [
-        "2.1",
+        "2.2",
         {
-          uri: "https://www.w3.org/TR/WCAG2/#target-size",
+          uri: "https://www.w3.org/TR/WCAG2/#target-size-enhanced",
           level: "AAA",
         },
       ],
       [
-        "2.2",
+        "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#target-size-enhanced",
+          uri: "https://www.w3.org/TR/WCAG21/#target-size",
           level: "AAA",
         },
       ],
@@ -1886,72 +1428,17 @@ export const Criteria = {
     title: "Concurrent Input Mechanisms",
     versions: [
       [
-        "2.1",
+        "2.2",
         {
           uri: "https://www.w3.org/TR/WCAG2/#concurrent-input-mechanisms",
           level: "AAA",
         },
       ],
       [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#concurrent-input-mechanisms",
-          level: "AAA",
-        },
-      ],
-    ],
-  },
-  "4.1.3": {
-    title: "Status Messages",
-    versions: [
-      [
         "2.1",
         {
-          uri: "https://www.w3.org/TR/WCAG2/#status-messages",
-          level: "AA",
-        },
-      ],
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#status-messages",
-          level: "AA",
-        },
-      ],
-    ],
-  },
-  "2.4.11": {
-    title: "Focus Appearance (Minimum)",
-    versions: [
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#focus-appearance-minimum",
-          level: "AA",
-        },
-      ],
-    ],
-  },
-  "2.4.12": {
-    title: "Focus Appearance (Enhanced)",
-    versions: [
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#focus-appearance-enhanced",
+          uri: "https://www.w3.org/TR/WCAG21/#concurrent-input-mechanisms",
           level: "AAA",
-        },
-      ],
-    ],
-  },
-  "2.4.13": {
-    title: "Page Break Navigation",
-    versions: [
-      [
-        "2.2",
-        {
-          uri: "https://www.w3.org/TR/WCAG22/#page-break-navigation",
-          level: "A",
         },
       ],
     ],
@@ -1962,7 +1449,7 @@ export const Criteria = {
       [
         "2.2",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#dragging-movements",
+          uri: "https://www.w3.org/TR/WCAG2/#dragging-movements",
           level: "AA",
         },
       ],
@@ -1974,8 +1461,294 @@ export const Criteria = {
       [
         "2.2",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#target-size-minimum",
+          uri: "https://www.w3.org/TR/WCAG2/#target-size-minimum",
           level: "AA",
+        },
+      ],
+    ],
+  },
+  "3.1.1": {
+    title: "Language of Page",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#language-of-page",
+          level: "A",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#language-of-page",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#meaning-doc-lang-id",
+          level: "A",
+        },
+      ],
+    ],
+  },
+  "3.1.2": {
+    title: "Language of Parts",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#language-of-parts",
+          level: "AA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#language-of-parts",
+          level: "AA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#meaning-other-lang-id",
+          level: "AA",
+        },
+      ],
+    ],
+  },
+  "3.1.3": {
+    title: "Unusual Words",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#unusual-words",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#unusual-words",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#meaning-idioms",
+          level: "AAA",
+        },
+      ],
+    ],
+  },
+  "3.1.4": {
+    title: "Abbreviations",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#abbreviations",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#abbreviations",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#meaning-located",
+          level: "AAA",
+        },
+      ],
+    ],
+  },
+  "3.1.5": {
+    title: "Reading Level",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#reading-level",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#reading-level",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#meaning-supplements",
+          level: "AAA",
+        },
+      ],
+    ],
+  },
+  "3.1.6": {
+    title: "Pronunciation",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#pronunciation",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#pronunciation",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#meaning-pronunciation",
+          level: "AAA",
+        },
+      ],
+    ],
+  },
+  "3.2.1": {
+    title: "On Focus",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#on-focus",
+          level: "A",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#on-focus",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#consistent-behavior-receive-focus",
+          level: "A",
+        },
+      ],
+    ],
+  },
+  "3.2.2": {
+    title: "On Input",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#on-input",
+          level: "A",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#on-input",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#consistent-behavior-unpredictable-change",
+          level: "A",
+        },
+      ],
+    ],
+  },
+  "3.2.3": {
+    title: "Consistent Navigation",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#consistent-navigation",
+          level: "AA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#consistent-navigation",
+          level: "AA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-locations",
+          level: "AA",
+        },
+      ],
+    ],
+  },
+  "3.2.4": {
+    title: "Consistent Identification",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#consistent-identification",
+          level: "AA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#consistent-identification",
+          level: "AA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-functionality",
+          level: "AA",
+        },
+      ],
+    ],
+  },
+  "3.2.5": {
+    title: "Change on Request",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#change-on-request",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#change-on-request",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#consistent-behavior-no-extreme-changes-context",
+          level: "AAA",
         },
       ],
     ],
@@ -1986,43 +1759,263 @@ export const Criteria = {
       [
         "2.2",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#consistent-help",
+          uri: "https://www.w3.org/TR/WCAG2/#consistent-help",
           level: "A",
         },
       ],
     ],
   },
-  "3.2.7": {
-    title: "Visible Controls",
+  "3.3.1": {
+    title: "Error Identification",
     versions: [
       [
         "2.2",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#visible-controls",
+          uri: "https://www.w3.org/TR/WCAG2/#error-identification",
+          level: "A",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#error-identification",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#minimize-error-identified",
+          level: "A",
+        },
+      ],
+    ],
+  },
+  "3.3.2": {
+    title: "Labels or Instructions",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#labels-or-instructions",
+          level: "A",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#labels-or-instructions",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#minimize-error-cues",
+          level: "A",
+        },
+      ],
+    ],
+  },
+  "3.3.3": {
+    title: "Error Suggestion",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#error-suggestion",
+          level: "AA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#error-suggestion",
+          level: "AA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#minimize-error-suggestions",
           level: "AA",
         },
       ],
     ],
   },
-  "3.3.7": {
-    title: "Accessible Authentication",
+  "3.3.4": {
+    title: "Error Prevention (Legal, Financial, Data)",
     versions: [
       [
         "2.2",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#accessible-authentication",
+          uri: "https://www.w3.org/TR/WCAG2/#error-prevention-legal-financial-data",
+          level: "AA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#error-prevention-legal-financial-data",
+          level: "AA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#minimize-error-reversible",
+          level: "AA",
+        },
+      ],
+    ],
+  },
+  "3.3.5": {
+    title: "Help",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#help",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#help",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#minimize-error-context-help",
+          level: "AAA",
+        },
+      ],
+    ],
+  },
+  "3.3.6": {
+    title: "Error Prevention (All)",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#error-prevention-all",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#error-prevention-all",
+          level: "AAA",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#minimize-error-reversible-all",
+          level: "AAA",
+        },
+      ],
+    ],
+  },
+  "3.3.7": {
+    title: "Redundant Entry",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#redundant-entry",
           level: "A",
         },
       ],
     ],
   },
   "3.3.8": {
-    title: "Redundant entry",
+    title: "Accessible Authentication (Minimum)",
     versions: [
       [
         "2.2",
         {
-          uri: "https://www.w3.org/TR/WCAG22/#redundant-entry",
+          uri: "https://www.w3.org/TR/WCAG2/#accessible-authentication-minimum",
+          level: "AA",
+        },
+      ],
+    ],
+  },
+  "3.3.9": {
+    title: "Accessible Authentication (Enhanced)",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#accessible-authentication-enhanced",
+          level: "AAA",
+        },
+      ],
+    ],
+  },
+  "4.1.2": {
+    title: "Name, Role, Value",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#name-role-value",
+          level: "A",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#name-role-value",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#ensure-compat-rsv",
+          level: "A",
+        },
+      ],
+    ],
+  },
+  "4.1.3": {
+    title: "Status Messages",
+    versions: [
+      [
+        "2.2",
+        {
+          uri: "https://www.w3.org/TR/WCAG2/#status-messages",
+          level: "AA",
+        },
+      ],
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#status-messages",
+          level: "AA",
+        },
+      ],
+    ],
+  },
+  "4.1.1": {
+    title: "Parsing",
+    versions: [
+      [
+        "2.1",
+        {
+          uri: "https://www.w3.org/TR/WCAG21/#parsing",
+          level: "A",
+        },
+      ],
+      [
+        "2.0",
+        {
+          uri: "https://www.w3.org/TR/WCAG20/#ensure-compat-parses",
           level: "A",
         },
       ],

--- a/packages/alfa-wcag/src/technique/data.ts
+++ b/packages/alfa-wcag/src/technique/data.ts
@@ -14,2141 +14,1977 @@ export const Techniques = {
   ARIA1: {
     title:
       "Using the aria-describedby property to provide a descriptive label for user interface",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA1",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA1",
   },
   ARIA2: {
     title: "Identifying a required field with the aria-required property",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA2",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA2",
   },
   ARIA4: {
     title:
       "Using a WAI-ARIA role to expose the role of a user interface component",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA4",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA4",
   },
   ARIA5: {
     title:
       "Using WAI-ARIA state and property attributes to expose the state of a user interface",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA5",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA5",
   },
   ARIA6: {
     title: "Using aria-label to provide labels for objects",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA6",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA6",
   },
   ARIA7: {
     title: "Using aria-labelledby for link purpose",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA7",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA7",
   },
   ARIA8: {
     title: "Using aria-label for link purpose",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA8",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA8",
   },
   ARIA9: {
     title:
       "Using aria-labelledby to concatenate a label from several text nodes",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA9",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA9",
   },
   ARIA10: {
     title:
       "Using aria-labelledby to provide a text alternative for non-text content",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA10",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA10",
   },
   ARIA11: {
     title: "Using ARIA landmarks to identify regions of a page",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA11",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA11",
   },
   ARIA12: {
     title: "Using role=heading to identify headings",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA12",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA12",
   },
   ARIA13: {
     title: "Using aria-labelledby to name regions and landmarks",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA13",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA13",
   },
   ARIA14: {
     title:
       "Using aria-label to provide an invisible label where a visible label cannot be used",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA14",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA14",
   },
   ARIA15: {
     title: "Using aria-describedby to provide descriptions of images",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA15",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA15",
   },
   ARIA16: {
     title:
       "Using aria-labelledby to provide a name for user interface controls",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA16",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA16",
   },
   ARIA17: {
     title: "Using grouping roles to identify related form controls",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA17",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA17",
   },
   ARIA18: {
     title: "Using aria-alertdialog to Identify Errors",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA18",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA18",
   },
   ARIA19: {
     title: "Using ARIA role=alert or Live Regions to Identify Errors",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA19",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA19",
   },
   ARIA20: {
     title: "Using the region role to identify a region of the page",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA20",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA20",
   },
   ARIA21: {
-    title: "Using Aria-Invalid to Indicate An Error Field",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA21",
+    title: "Using aria-invalid to Indicate An Error Field",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA21",
   },
   ARIA22: {
     title: "Using role=status to present status messages",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA22",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA22",
   },
   ARIA23: {
     title: "Using role=log to identify sequential information updates",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA23",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA23",
   },
   ARIA24: {
     title: 'Semantically identifying a font icon with role="img"',
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA24",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA24",
   },
   SCR1: {
     title: "Allowing the user to extend the default time limit",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR1",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR1",
   },
   SCR2: {
     title: "Using redundant keyboard and mouse event handlers",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR2",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR2",
   },
   SCR14: {
     title: "Using scripts to make nonessential alerts optional",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR14",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR14",
   },
   SCR16: {
     title:
       "Providing a script that warns the user a time limit is about to expire",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR16",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR16",
   },
   SCR18: {
     title: "Providing client-side validation and alert",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR18",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR18",
   },
   SCR19: {
     title:
       "Using an onchange event on a select element without causing a change of context",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR19",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR19",
   },
   SCR20: {
     title: "Using both keyboard and other device-specific functions",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR20",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR20",
   },
   SCR21: {
     title:
       "Using functions of the Document Object Model (DOM) to add content to a page",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR21",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR21",
   },
   SCR22: {
     title:
       "Using scripts to control blinking and stop it in five seconds or less",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR22",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR22",
   },
   SCR24: {
     title: "Using progressive enhancement to open new windows on user request",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR24",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR24",
   },
   SCR26: {
     title:
       "Inserting dynamic content into the Document Object Model immediately following its",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR26",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR26",
   },
   SCR27: {
     title: "Reordering page sections using the Document Object Model",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR27",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR27",
   },
   SCR28: {
     title:
       "Using an expandable and collapsible menu to bypass block of content",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR28",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR28",
   },
   SCR29: {
     title: "Adding keyboard-accessible actions to static HTML elements",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR29",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR29",
   },
   SCR30: {
     title: "Using scripts to change the link text",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR30",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR30",
   },
   SCR31: {
     title:
       "Using script to change the background color or border of the element with focus",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR31",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR31",
   },
   SCR32: {
     title: "Providing client-side validation and adding error text via the DOM",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR32",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR32",
   },
   SCR33: {
     title:
       "Using script to scroll content, and providing a mechanism to pause it",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR33",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR33",
   },
   SCR34: {
     title: "Calculating size and position in a way that scales with text size",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR34",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR34",
   },
   SCR35: {
     title:
       "Making actions keyboard accessible by using the onclick event of anchors and buttons",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR35",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR35",
   },
   SCR36: {
     title:
       "Providing a mechanism to allow users to display moving, scrolling, or auto-updating",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR36",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR36",
   },
   SCR37: {
-    title: "Creating Custom Dialogs in a Device Independent Way",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR37",
+    title: "Creating Custom Dialogs",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR37",
   },
   SCR38: {
     title:
       "Creating a conforming alternate version for a web page designed with progressive enhancement",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR38",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR38",
   },
   SCR39: {
     title:
       "Making content on focus or hover hoverable, dismissible, and persistent",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR39",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR39",
   },
   C6: {
     title: "Positioning content based on structural markup",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C6",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C6",
   },
   C7: {
     title: "Using CSS to hide a portion of the link text",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C7",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C7",
   },
   C8: {
     title: "Using CSS letter-spacing to control spacing within a word",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C8",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C8",
   },
   C9: {
     title: "Using CSS to include decorative images",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C9",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C9",
   },
   C12: {
     title: "Using percent for font sizes",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C12",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C12",
   },
   C13: {
     title: "Using named font sizes",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C13",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C13",
   },
   C14: {
     title: "Using em units for font sizes",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C14",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C14",
   },
   C15: {
     title:
       "Using CSS to change the presentation of a user interface component when it receives",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C15",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C15",
   },
   C17: {
     title: "Scaling form elements which contain text",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C17",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C17",
   },
   C18: {
     title:
       "Using CSS margin and padding rules instead of spacer images for layout design",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C18",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C18",
   },
   C19: {
-    title: "Specifying alignment either to the left OR right in CSS",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C19",
+    title: "Specifying alignment either to the left or right in CSS",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C19",
   },
   C20: {
     title:
       "Using relative measurements to set column widths so that lines can average 80 characters",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C20",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C20",
   },
   C21: {
     title: "Specifying line spacing in CSS",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C21",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C21",
   },
   C22: {
     title: "Using CSS to control visual presentation of text",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C22",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C22",
   },
   C23: {
     title:
       "Specifying text and background colors of secondary content such as banners, features",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C23",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C23",
   },
   C24: {
     title: "Using percentage values in CSS for container sizes",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C24",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C24",
   },
   C25: {
     title:
       "Specifying borders and layout in CSS to delineate areas of a Web page while not specifying",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C25",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C25",
   },
   C27: {
     title: "Making the DOM order match the visual order",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C27",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C27",
   },
   C28: {
     title: "Specifying the size of text containers using em units",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C28",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C28",
   },
   C29: {
     title: "Using a style switcher to provide a conforming alternate version",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C29",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C29",
   },
   C30: {
     title:
       "Using CSS to replace text with images of text and providing user interface controls",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C30",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C30",
   },
   C31: {
     title: "Using CSS Flexbox to reflow content",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C31",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C31",
   },
   C32: {
     title: "Using media queries and grid CSS to reflow columns",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C32",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C32",
   },
   C33: {
     title: "Allowing for Reflow with Long URLs and Strings of Text",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C33",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C33",
   },
   C34: {
     title: "Using media queries to un-fixing sticky headers / footers",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C34",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C34",
   },
   C35: {
     title: "Allowing for text spacing without wrapping",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C35",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C35",
   },
   C36: {
     title: "Allowing for text spacing override",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C36",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C36",
   },
   C37: {
     title: "Using CSS max-width and height to fit images",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C37",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C37",
   },
   C38: {
     title: "Using CSS width, max-width and flexbox to fit labels and inputs",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C38",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C38",
   },
   C39: {
     title: "Using the CSS reduce-motion query to prevent motion",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C39",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C39",
   },
   C40: {
     title:
       "Creating a two-color focus indicator to ensure sufficient contrast with all components",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C40",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C40",
   },
   C41: {
     title: "Creating a strong focus indicator within the component",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C41",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C41",
   },
   C42: {
     title: "Using min-height and min-width to ensure sufficient target spacing",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/css/C42",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C42",
+  },
+  C43: {
+    title: "Using CSS scroll-padding to un-obscure content",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/css/C43",
   },
   F1: {
     title:
       "Failure of Success Criterion 1.3.2 due to changing the meaning of content by positioning",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F1",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F1",
   },
   F2: {
     title:
       "Failure of Success Criterion 1.3.1 due to using changes in text presentation to convey",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F2",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F2",
   },
   F3: {
     title:
       "Failure of Success Criterion 1.1.1 due to using CSS to include images that convey",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F3",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F3",
   },
   F4: {
     title:
       "Failure of Success Criterion 2.2.2 due to using text-decoration:blink without a mechanism",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F4",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F4",
   },
   F7: {
     title:
       "Failure of Success Criterion 2.2.2 due to an object or applet for more than five seconds",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F7",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F7",
   },
   F8: {
     title:
       "Failure of Success Criterion 1.2.2 due to captions omitting some dialogue or important",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F8",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F8",
   },
   F9: {
     title:
       "Failure of Success Criterion 3.2.5 due to changing the context when the user removes",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F9",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F9",
   },
   F10: {
     title:
       "Failure of Success Criterion 2.1.2 and Conformance Requirement 5 due to combining",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F10",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F10",
   },
   F12: {
     title:
       "Failure of Success Criterion 2.2.5 due to having a session time limit without a mechanism",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F12",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F12",
   },
   F13: {
     title:
       "Failure of Success Criterion 1.1.1 and 1.4.1 due to having a text alternative that",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F13",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F13",
   },
   F14: {
     title:
       "Failure of Success Criterion 1.3.3 due to identifying content only by its shape or",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F14",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F14",
   },
   F15: {
     title:
       "Failure of Success Criterion 4.1.2 due to implementing custom controls that do not",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F15",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F15",
   },
   F16: {
     title:
       "Failure of Success Criterion 2.2.2 due to including scrolling content where movement",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F16",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F16",
   },
   F19: {
     title:
       "Failure of Conformance Requirement 1 due to not providing a method for the user to",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F19",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F19",
   },
   F20: {
     title:
       "Failure of Success Criterion 1.1.1 and 4.1.2 due to not updating text alternatives",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F20",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F20",
   },
   F22: {
     title:
       "Failure of Success Criterion 3.2.5 due to opening windows that are not requested by",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F22",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F22",
   },
   F23: {
     title:
       "Failure of 1.4.2 due to playing a sound longer than 3 seconds where              ",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F23",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F23",
   },
   F24: {
     title:
       "Failure of Success Criterion 1.4.3, 1.4.6 and 1.4.8 due to specifying foreground colors",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F24",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F24",
   },
   F25: {
     title:
       "Failure of Success Criterion 2.4.2 due to the title of a Web page not identifying",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F25",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F25",
   },
   F26: {
     title:
       "Failure of Success Criterion 1.3.3 due to using a graphical symbol alone to convey",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F26",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F26",
   },
   F30: {
     title:
       "Failure of Success Criterion 1.1.1 and 1.2.1 due to using text alternatives that are",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F30",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F30",
   },
   F31: {
     title:
       "Failure of Success Criterion 3.2.4 due to using two different labels for the same",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F31",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F31",
   },
   F32: {
     title:
       "Failure of Success Criterion 1.3.2 due to using white space characters to control",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F32",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F32",
   },
   F33: {
     title:
       "Failure of Success Criterion 1.3.1 and 1.3.2 due to using white space characters to",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F33",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F33",
   },
   F34: {
     title:
       "Failure of Success Criterion 1.3.1 and 1.3.2 due to using white space characters to",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F34",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F34",
   },
   F36: {
     title:
       "Failure of Success Criterion 3.2.2 due to automatically submitting a form and given",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F36",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F36",
   },
   F37: {
     title:
       "Failure of Success Criterion 3.2.2 due to launching a new window without prior warning",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F37",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F37",
   },
   F38: {
     title:
       "Failure of Success Criterion 1.1.1 due to not marking up decorative images in HTML",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F38",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F38",
   },
   F39: {
     title:
       "Failure of Success Criterion 1.1.1 due to providing a text alternative that is not",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F39",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F39",
   },
   F40: {
     title: "Failure due to using meta redirect with a time limit",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F40",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F40",
   },
   F41: {
     title:
       "Failure of Success Criterion 2.2.1, 2.2.4, and 3.2.5 due to using meta refresh to",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F41",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F41",
   },
   F42: {
     title:
       "Failure of Success Criteria 1.3.1, 2.1.1, 2.1.3, or 4.1.2 when emulating links",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F42",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F42",
   },
   F43: {
     title:
       "Failure of Success Criterion 1.3.1 due to using structural markup in a way that does",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F43",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F43",
   },
   F44: {
     title:
       "Failure of Success Criterion 2.4.3 due to using tabindex to create a tab order that",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F44",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F44",
   },
   F46: {
     title:
       "Failure of Success Criterion 1.3.1 due to using th elements, layout tables",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F46",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F46",
   },
   F47: {
     title: "Failure of Success Criterion 2.2.2 due to using the blink element",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F47",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F47",
   },
   F48: {
     title:
       "Failure of Success Criterion 1.3.1 due to using the pre element to markup tabular",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F48",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F48",
   },
   F49: {
     title:
       "Failure of Success Criterion 1.3.2 due to using an HTML layout table that does not",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F49",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F49",
   },
   F50: {
     title:
       "Failure of Success Criterion 2.2.2 due to a script that causes a blink effect without",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F50",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F50",
   },
   F52: {
     title:
       "Failure of Success Criterion 3.2.1 and 3.2.5 due to opening a new window as soon as",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F52",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F52",
   },
   F54: {
     title:
       "Failure of Success Criterion 2.1.1 due to using only pointing-device-specific event",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F54",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F54",
   },
   F55: {
     title:
       "Failure of Success Criteria 2.1.1, 2.4.7, and 3.2.1 due to using script to remove",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F55",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F55",
   },
   F58: {
     title:
       "Failure of Success Criterion 2.2.1 due to using server-side techniques to automatically",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F58",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F58",
   },
   F59: {
     title:
       "Failure of Success Criterion 4.1.2 due to using script to make div or span a user",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F59",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F59",
   },
   F60: {
     title:
       "Failure of Success Criterion 3.2.5 due to launching a new window when a user enters",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F60",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F60",
   },
   F61: {
     title:
       "Failure of Success Criterion 3.2.5 due to complete change of main content through",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F61",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F61",
   },
   F63: {
     title:
       "Failure of Success Criterion 2.4.4 due to providing link context only in content that",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F63",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F63",
   },
   F65: {
     title:
       "Failure of Success Criterion 1.1.1 due to omitting the alt attribute or text alternative",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F65",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F65",
   },
   F66: {
     title:
       "Failure of Success Criterion 3.2.3 due to presenting navigation links in a different",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F66",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F66",
   },
   F67: {
     title:
       "Failure of Success Criterion 1.1.1 and 1.2.1 due to providing long descriptions for",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F67",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F67",
   },
   F68: {
     title:
       "Failure of Success Criterion 4.1.2 due to a user interface control not having a programmatically",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F68",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F68",
   },
   F69: {
     title:
       "Failure of Success Criterion 1.4.4 when resizing visually rendered text up to 200",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F69",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F69",
   },
   F70: {
     title:
       "Failure of Success Criterion 4.1.1 due to incorrect use of start and end tags or attribute",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F70",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F70",
   },
   F71: {
     title:
       "Failure of Success Criterion 1.1.1 due to using text look-alikes to represent text",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F71",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F71",
   },
   F72: {
     title:
       "Failure of Success Criterion 1.1.1 due to using ASCII art without providing a text",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F72",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F72",
   },
   F73: {
     title:
       "Failure of Success Criterion 1.4.1 due to creating links that are not visually evident",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F73",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F73",
   },
   F74: {
     title:
       "Failure of Success Criterion 1.2.2 and 1.2.8 due to not labeling a synchronized media",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F74",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F74",
   },
   F75: {
     title:
       "Failure of Success Criterion 1.2.2 by providing synchronized media without captions",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F75",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F75",
   },
   F77: {
     title:
       "Failure of Success Criterion 4.1.1 due to duplicate values of type ID",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F77",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F77",
   },
   F78: {
     title:
       "Failure of Success Criterion 2.4.7 due to styling element outlines and borders in",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F78",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F78",
   },
   F79: {
     title:
       "Failure of Success Criterion 4.1.2 due to the focus state of a user interface component",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F79",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F79",
   },
   F80: {
     title:
       "Failure of Success Criterion 1.4.4 when text-based form controls do not resize when",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F80",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F80",
   },
   F81: {
     title:
       "Failure of Success Criterion 1.4.1 due to identifying required or error fields using",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F81",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F81",
   },
   F82: {
     title:
       "Failure of Success Criterion 3.3.2 by visually formatting a set of phone number fields",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F82",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F82",
   },
   F83: {
     title:
       "Failure of Success Criterion 1.4.3 and 1.4.6 due to using background images that do",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F83",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F83",
   },
   F84: {
     title:
       'Failure of Success Criterion 2.4.9 due to using a non-specific link such as "click',
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F84",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F84",
   },
   F85: {
     title:
       "Failure of Success Criterion 2.4.3 due to using dialogs or menus that are not adjacent",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F85",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F85",
   },
   F86: {
     title:
       "Failure of Success Criterion 4.1.2 due to not providing names for each part of a multi-part",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F86",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F86",
   },
   F87: {
     title:
       "Failure of Success Criterion 1.3.1 due to inserting non-decorative content by using",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F87",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F87",
   },
   F88: {
     title:
       "Failure of Success Criterion 1.4.8 due to using text that is justified (aligned to",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F88",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F88",
   },
   F89: {
     title:
       "Failure of Success Criteria 2.4.4, 2.4.9 and 4.1.2 due to not providing an accessible",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F89",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F89",
   },
   F90: {
     title:
       "Failure of Success Criterion 1.3.1 for incorrectly associating table headers and content",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F90",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F90",
   },
   F91: {
     title:
       "Failure of Success Criterion 1.3.1 for not correctly marking up table headers",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F91",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F91",
   },
   F92: {
     title:
       "Failure of Success Criterion 1.3.1 due to the use of role presentation on content",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F92",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F92",
   },
   F93: {
     title:
       "Failure of Success Criterion 1.4.2 for absence of a way to pause or stop an HTML5",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F93",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F93",
   },
   F94: {
     title:
       "Failure of Success Criterion 1.4.4 due to incorrect use of viewport units to resize",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F94",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F94",
   },
   F95: {
     title:
       "Failure of Success Criterion 1.4.13 due to content shown on hover not being hoverable",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F95",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F95",
   },
   F96: {
     title:
       "Failure due to the accessible name not containing the visible label text",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F96",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F96",
   },
   F97: {
     title:
       "Failure due to locking the orientation to landscape or portrait view",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F97",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F97",
   },
   F98: {
     title:
       "Failure due to interactions being limited to touch-only on touchscreen devices",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F98",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F98",
   },
   F99: {
     title:
       "Failure of Success Criterion 2.1.4 due to implementing character key shortcuts that",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F99",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F99",
   },
   F100: {
     title:
       "Failure of Success Criterion 1.3.4 due to showing a message asking to reorient device",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F100",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F100",
   },
   F101: {
     title:
       "Failure of Success Criterion 2.5.2 due to activating a control on the down-event",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F101",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F101",
   },
   F102: {
     title:
       "Failure of Success Criterion 1.4.10 due to content disappearing and not being available",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F102",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F102",
   },
   F103: {
     title:
       "Failure of Success Criterion 4.1.3 due to providing status messages that cannot be",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F103",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F103",
   },
   F104: {
     title:
       "Failure of Success Criterion 1.4.12 due to clipped or overlapped content when text",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F104",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F104",
   },
   F105: {
     title:
       "Failure of Success Criterion 2.5.1 due to providing functionality via a path-based",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F105",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F105",
   },
   F106: {
     title: "Failure due to inability to deactivate motion actuation",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F106",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F106",
   },
   F107: {
     title:
       "Failure of Success Criterion 1.3.5 due to incorrect autocomplete attribute values",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F107",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F107",
   },
   F108: {
     title:
-      "Failure of Success Criterion 2.5.X Dragging due to not providing a single pointer",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/failures/F108",
+      "Failure of Success Criterion 2.5.7 Dragging Movements due to not providing a single",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F108",
+  },
+  F109: {
+    title:
+      "Failure of Success Criterion 3.3.8 and 3.3.9 due to preventing password or code re-entry",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F109",
+  },
+  F110: {
+    title:
+      "Failure of Success Criterion 2.4.12 Focus Not Obscured (Minimum) due to a sticky footer",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/failures/F110",
   },
   G1: {
     title:
       "Adding a link at the top of each page that goes directly to the main content area",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G1",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G1",
   },
   G4: {
     title:
       "Allowing the content to be paused and restarted from where it was paused",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G4",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G4",
   },
   G5: {
     title: "Allowing users to complete an activity without any time limit",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G5",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G5",
   },
   G8: {
     title: "Providing a movie with extended audio descriptions",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G8",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G8",
   },
   G9: {
     title: "Creating captions for live synchronized media",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G9",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G9",
   },
   G10: {
     title:
       "Creating components using a technology that supports the accessibility notification",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G10",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G10",
   },
   G11: {
     title: "Creating content that blinks for less than 5 seconds",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G11",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G11",
   },
   G13: {
     title:
       "Describing what will happen before a change to a form control that causes a change",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G13",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G13",
   },
   G14: {
     title:
       "Ensuring that information conveyed by color differences is also available in text",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G14",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G14",
   },
   G15: {
     title:
       "Using a tool to ensure that content does not violate the general flash threshold or",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G15",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G15",
   },
   G17: {
     title:
       "Ensuring that a contrast ratio of at least 7:1 exists between text (and images of",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G17",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G17",
   },
   G18: {
     title:
       "Ensuring that a contrast ratio of at least 4.5:1 exists between text (and images of",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G18",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G18",
   },
   G19: {
     title:
       "Ensuring that no component of the content flashes more than three times in any 1-second",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G19",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G19",
   },
   G21: {
     title: "Ensuring that users are not trapped in content",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G21",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G21",
   },
   G53: {
     title:
       "Identifying the purpose of a link using link text combined with the text of the enclosing",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G53",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G53",
   },
   G54: {
     title: "Including a sign language interpreter in the video stream",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G54",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G54",
   },
   G55: {
     title: "Linking to definitions",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G55",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G55",
   },
   G56: {
     title:
       "Mixing audio files so that non-speech sounds are at least 20 decibels lower than the",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G56",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G56",
   },
   G57: {
     title: "Ordering the content in a meaningful sequence",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G57",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G57",
   },
   G58: {
     title:
       "Placing a link to the alternative for time-based media immediately next to the non-text",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G58",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G58",
   },
   G59: {
     title:
       "Placing the interactive elements in an order that follows sequences and relationships",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G59",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G59",
   },
   G60: {
     title: "Playing a sound that turns off automatically within three seconds",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G60",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G60",
   },
   G61: {
     title:
       "Presenting repeated components in the same relative order each time they appear",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G61",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G61",
   },
   G62: {
     title: "Providing a glossary",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G62",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G62",
   },
   G63: {
     title: "Providing a site map",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G63",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G63",
   },
   G64: {
     title: "Providing a Table of Contents",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G64",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G64",
   },
   G65: {
     title: "Providing a breadcrumb trail",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G65",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G65",
   },
   G68: {
     title:
       "Providing a short text alternative that describes the purpose of live audio-only and",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G68",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G68",
   },
   G69: {
     title: "Providing an alternative for time based media",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G69",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G69",
   },
   G70: {
     title: "Providing a function to search an online dictionary",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G70",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G70",
   },
   G71: {
     title: "Providing a help link on every Web page",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G71",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G71",
   },
   G73: {
     title:
       "Providing a long description in another location with a link to it that is immediately",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G73",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G73",
   },
   G74: {
     title:
       "Providing a long description in text near the non-text content, with a reference to",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G74",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G74",
   },
   G75: {
     title: "Providing a mechanism to postpone any updating of content",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G75",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G75",
   },
   G76: {
     title:
       "Providing a mechanism to request an update of the content instead of updating automatically",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G76",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G76",
   },
   G78: {
     title:
       "Providing a second, user-selectable, audio track that includes audio descriptions",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G78",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G78",
   },
   G79: {
     title: "Providing a spoken version of the text",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G79",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G79",
   },
   G80: {
     title: "Providing a submit button to initiate a change of context",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G80",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G80",
   },
   G81: {
     title:
       "Providing a synchronized video of the sign language interpreter that can be displayed",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G81",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G81",
   },
   G82: {
     title:
       "Providing a text alternative that identifies the purpose of the non-text content",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G82",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G82",
   },
   G83: {
     title:
       "Providing text descriptions to identify required fields that were not completed",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G83",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G83",
   },
   G84: {
     title:
       "Providing a text description when the user provides information that is not in the",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G84",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G84",
   },
   G85: {
     title:
       "Providing a text description when user input falls outside the required format or",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G85",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G85",
   },
   G86: {
     title:
       "Providing a text summary that can be understood by people with lower secondary education",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G86",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G86",
   },
   G87: {
     title: "Providing closed captions",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G87",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G87",
   },
   G88: {
     title: "Providing descriptive titles for Web pages",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G88",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G88",
   },
   G89: {
     title: "Providing expected data format and example",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G89",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G89",
   },
   G90: {
     title: "Providing keyboard-triggered event handlers",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G90",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G90",
   },
   G91: {
     title: "Providing link text that describes the purpose of a link",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G91",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G91",
   },
   G92: {
     title:
       "Providing long description for non-text content that serves the same purpose and presents",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G92",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G92",
   },
   G93: {
     title: "Providing open (always visible) captions",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G93",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G93",
   },
   G94: {
     title:
       "Providing short text alternative for non-text content that serves the same purpose",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G94",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G94",
   },
   G95: {
     title:
       "Providing short text alternatives that provide a brief description of the non-text",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G95",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G95",
   },
   G96: {
     title:
       "Providing textual identification of items that otherwise rely only on sensory information",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G96",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G96",
   },
   G97: {
     title:
       "Providing the first use of an abbreviation immediately before or after the expanded",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G97",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G97",
   },
   G98: {
     title:
       "Providing the ability for the user to review and correct answers before submitting",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G98",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G98",
   },
   G99: {
     title: "Providing the ability to recover deleted information",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G99",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G99",
   },
   G100: {
     title:
       "Providing a short text alternative which is the accepted name or a descriptive name",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G100",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G100",
   },
   G101: {
     title:
       "Providing the definition of a word or phrase used in an unusual or restricted way",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G101",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G101",
   },
   G102: {
     title: "Providing the expansion or explanation of an abbreviation",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G102",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G102",
   },
   G103: {
     title:
       "Providing visual illustrations, pictures, and symbols to help explain ideas, events,",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G103",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G103",
   },
   G105: {
     title: "Saving data so that it can be used after a user re-authenticates",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G105",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G105",
   },
   G107: {
     title:
       'Using "activate" rather than "focus" as a trigger for changes of context',
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G107",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G107",
   },
   G108: {
     title:
       "Using markup features to expose the name and role, allow user-settable properties",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G108",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G108",
   },
   G110: {
     title: "Using an instant client-side redirect",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G110",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G110",
   },
   G111: {
     title: "Using color and pattern",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G111",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G111",
   },
   G112: {
     title: "Using inline definitions",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G112",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G112",
   },
   G115: {
     title: "Using semantic elements to mark up structure",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G115",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G115",
   },
   G117: {
     title:
       "Using text to convey information that is conveyed by variations in presentation of",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G117",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G117",
   },
   G120: {
     title: "Providing the pronunciation immediately following the word",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G120",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G120",
   },
   G121: {
     title: "Linking to pronunciations",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G121",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G121",
   },
   G123: {
     title:
       "Adding a link at the beginning of a block of repeated content to go to the end of",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G123",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G123",
   },
   G124: {
     title: "Adding links at the top of the page to each area of the content",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G124",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G124",
   },
   G125: {
     title: "Providing links to navigate to related Web pages",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G125",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G125",
   },
   G126: {
     title: "Providing a list of links to all other Web pages",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G126",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G126",
   },
   G127: {
     title:
       "Identifying a Web page's relationship to a larger collection of Web pages",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G127",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G127",
   },
   G128: {
     title: "Indicating current location within navigation bars",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G128",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G128",
   },
   G130: {
     title: "Providing descriptive headings",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G130",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G130",
   },
   G131: {
     title: "Providing descriptive labels",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G131",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G131",
   },
   G133: {
     title:
       "Providing a checkbox on the first page of a multipart form that allows users to ask",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G133",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G133",
   },
   G134: {
     title: "Validating Web pages",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G134",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G134",
   },
   G135: {
     title:
       "Using the accessibility API features of a technology to expose names and notification",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G135",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G135",
   },
   G136: {
     title:
       "Providing a link at the beginning of a nonconforming Web page that points to a conforming",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G136",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G136",
   },
   G138: {
     title: "Using semantic markup whenever color cues are used",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G138",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G138",
   },
   G139: {
     title: "Creating a mechanism that allows users to jump to errors",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G139",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G139",
   },
   G140: {
     title:
       "Separating information and structure from presentation to enable different presentations",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G140",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G140",
   },
   G141: {
     title: "Organizing a page using headings",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G141",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G141",
   },
   G142: {
     title:
       "Using a technology that has commonly-available user agents that support zoom",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G142",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G142",
   },
   G143: {
     title:
       "Providing a text alternative that describes the purpose of the CAPTCHA",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G143",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G143",
   },
   G144: {
     title:
       "Ensuring that the Web Page contains another CAPTCHA serving the same purpose using",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G144",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G144",
   },
   G145: {
     title:
       "Ensuring that a contrast ratio of at least 3:1 exists between text (and images of",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G145",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G145",
   },
   G146: {
     title: "Using liquid layout",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G146",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G146",
   },
   G148: {
     title:
       "Not specifying background color, not specifying text color, and not using technology",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G148",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G148",
   },
   G149: {
     title:
       "Using user interface components that are highlighted by the user agent when they receive",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G149",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G149",
   },
   G150: {
     title: "Providing text based alternatives for live audio-only content",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G150",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G150",
   },
   G151: {
     title:
       "Providing a link to a text transcript of a prepared statement or script if the script",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G151",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G151",
   },
   G152: {
     title:
       "Setting animated gif images to stop blinking after n cycles (within 5 seconds)",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G152",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G152",
   },
   G153: {
     title: "Making the text easier to read",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G153",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G153",
   },
   G155: {
     title: "Providing a checkbox in addition to a submit button",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G155",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G155",
   },
   G156: {
     title:
       "Using a technology that has commonly-available user agents that can change the foreground",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G156",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G156",
   },
   G157: {
     title: "Incorporating a live audio captioning service into a Web page",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G157",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G157",
   },
   G158: {
     title:
       "Providing an alternative for time-based media for audio-only content",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G158",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G158",
   },
   G159: {
     title:
       "Providing an alternative for time-based media for video-only content",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G159",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G159",
   },
   G160: {
     title:
       "Providing sign language versions of information, ideas, and processes that must be",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G160",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G160",
   },
   G161: {
     title: "Providing a search function to help users find content",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G161",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G161",
   },
   G162: {
     title: "Positioning labels to maximize predictability of relationships",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G162",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G162",
   },
   G163: {
     title: "Using standard diacritical marks that can be turned off",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G163",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G163",
   },
   G164: {
     title:
       "Providing a stated time within which an online request (or transaction) may be amended",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G164",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G164",
   },
   G165: {
     title:
       "Using the default focus indicator for the platform so that high visibility default",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G165",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G165",
   },
   G166: {
     title:
       "Providing audio that describes the important video content and describing it as such",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G166",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G166",
   },
   G167: {
     title: "Using an adjacent button to label the purpose of a field",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G167",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G167",
   },
   G168: {
     title: "Requesting confirmation to continue with selected action",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G168",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G168",
   },
   G169: {
     title: "Aligning text on only one side",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G169",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G169",
   },
   G170: {
     title:
       "Providing a control near the beginning of the Web page that turns off sounds that",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G170",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G170",
   },
   G171: {
     title: "Playing sounds only on user request",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G171",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G171",
   },
   G172: {
     title: "Providing a mechanism to remove full justification of text",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G172",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G172",
   },
   G173: {
     title: "Providing a version of a movie with audio descriptions",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G173",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G173",
   },
   G174: {
     title:
       "Providing a control with a sufficient contrast ratio that allows users to switch to",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G174",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G174",
   },
   G175: {
     title:
       "Providing a multi color selection tool on the page for foreground and background colors",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G175",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G175",
   },
   G176: {
     title: "Keeping the flashing area small enough",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G176",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G176",
   },
   G177: {
     title: "Providing suggested correction text",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G177",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G177",
   },
   G178: {
     title:
       "Providing controls on the Web page that allow users to incrementally change the size",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G178",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G178",
   },
   G179: {
     title:
       "Ensuring that there is no loss of content or functionality when the text resizes and",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G179",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G179",
   },
   G180: {
     title:
       "Providing the user with a means to set the time limit to 10 times the default time",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G180",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G180",
   },
   G181: {
     title:
       "Encoding user data as hidden or encrypted data in a re-authorization page",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G181",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G181",
   },
   G182: {
     title:
       "Ensuring that additional visual cues are available when text color differences are",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G182",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G182",
   },
   G183: {
     title:
       "Using a contrast ratio of 3:1 with surrounding text and providing additional visual",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G183",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G183",
   },
   G184: {
     title:
       "Providing text instructions at the beginning of a form or set of fields that describes",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G184",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G184",
   },
   G185: {
     title: "Linking to all of the pages on the site from the home page",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G185",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G185",
   },
   G186: {
     title:
       "Using a control in the Web page that stops moving, blinking, or auto-updating content",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G186",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G186",
   },
   G187: {
     title:
       "Using a technology to include blinking content that can be turned off via the user",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G187",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G187",
   },
   G188: {
     title:
       "Providing a button on the page to increase line spaces and paragraph spaces",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G188",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G188",
   },
   G189: {
     title:
       "Providing a control near the beginning of the Web page that changes the link text",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G189",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G189",
   },
   G190: {
     title:
       "Providing a link adjacent to or associated with a non-conforming object that links",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G190",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G190",
   },
   G191: {
     title:
       "Providing a link, button, or other mechanism that reloads the page without any blinking",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G191",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G191",
   },
   G192: {
     title: "Fully conforming to specifications",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G192",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G192",
   },
   G193: {
     title: "Providing help by an assistant in the Web page",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G193",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G193",
   },
   G194: {
     title: "Providing spell checking and suggestions for text input",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G194",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G194",
   },
   G195: {
     title: "Using an author-supplied, visible focus indicator",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G195",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G195",
   },
   G196: {
     title:
       "Using a text alternative on one item within a group of images that describes all items",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G196",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G196",
   },
   G197: {
     title:
       "Using labels, names, and text alternatives consistently for content that has the same",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G197",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G197",
   },
   G198: {
     title: "Providing a way for the user to turn the time limit off",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G198",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G198",
   },
   G199: {
     title: "Providing success feedback when data is submitted successfully",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G199",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G199",
   },
   G200: {
     title: "Opening new windows and tabs from a link only when necessary",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G200",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G200",
   },
   G201: {
     title: "Giving users advanced warning when opening a new window",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G201",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G201",
   },
   G202: {
     title: "Ensuring keyboard control for all functionality",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G202",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G202",
   },
   G203: {
     title: "Using a static text alternative to describe a talking head video",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G203",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G203",
   },
   G204: {
     title:
       "Not interfering with the user agent's reflow of text as the viewing window is narrowed",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G204",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G204",
   },
   G205: {
     title: "Including a text cue for colored form control labels",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G205",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G205",
   },
   G206: {
     title:
       "Providing options within the content to switch to a layout that does not require the",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G206",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G206",
   },
   G207: {
     title: "Ensuring that a contrast ratio of 3:1 is provided for icons",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G207",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G207",
   },
   G208: {
     title:
       "Including the text of the visible label as part of the accessible name",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G208",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G208",
   },
   G209: {
     title:
       "Provide sufficient contrast at the boundaries between adjoining colors",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G209",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G209",
   },
   G210: {
     title: "Ensuring that drag-and-drop actions can be cancelled",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G210",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G210",
   },
   G211: {
     title: "Matching the accessible name to the visible label",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G211",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G211",
   },
   G212: {
     title:
       "Using native controls to ensure functionality is triggered on the up-event.",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G212",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G212",
   },
   G213: {
     title:
       "Provide conventional controls and an application setting for motion activated input",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G213",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G213",
   },
   G214: {
     title:
       "Using a control to allow access to content in different orientations which is otherwise",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G214",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G214",
   },
   G215: {
     title:
       "Providing controls to achieve the same result as path based or multipoint gestures",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G215",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G215",
   },
   G216: {
     title: "Providing single point activation for a control slider",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G216",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G216",
   },
   G217: {
     title:
       "Providing a mechanism to allow users to remap or turn off character key shortcuts",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G217",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G217",
   },
   G218: {
     title: "Email link authentication",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G218",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G218",
   },
   G219: {
     title:
-      "Ensuring that a single pointer alternative is available for dragging movements that",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G219",
+      "Ensuring that an alternative is available for dragging movements that operate on content",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G219",
   },
   G220: {
     title: "Provide a contact-us link in a consistent location",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G220",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G220",
   },
   G221: {
     title: "Provide data from a previous step in a process",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G221",
-  },
-  G222: {
-    title: "Provide persistently visible controls",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G222",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G221",
   },
   G223: {
     title: "Using an author-supplied, highly visible focus indicator",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/general/G223",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/general/G223",
   },
   H2: {
     title: "Combining adjacent image and text links for the same resource",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H2",
-  },
-  H4: {
-    title:
-      "Creating a logical tab order through links, form controls, and objects",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H4",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H2",
   },
   H24: {
     title: "Providing text alternatives for the area elements of image maps",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H24",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H24",
   },
   H25: {
     title: "Providing a title using the title element",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H25",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H25",
   },
   H28: {
     title: "Providing definitions for abbreviations by using the abbr element",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H28",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H28",
   },
   H30: {
     title:
       "Providing link text that describes the purpose of a link for anchor elements",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H30",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H30",
   },
   H32: {
     title: "Providing submit buttons",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H32",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H32",
   },
   H33: {
     title: "Supplementing link text with the title attribute",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H33",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H33",
   },
   H34: {
     title:
       "Using a Unicode right-to-left mark (RLM) or left-to-right mark (LRM) to mix text direction",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H34",
-  },
-  H35: {
-    title: "Providing text alternatives on applet elements",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H35",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H34",
   },
   H36: {
     title: "Using alt attributes on images used as submit buttons",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H36",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H36",
   },
   H37: {
     title: "Using alt attributes on img elements",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H37",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H37",
   },
   H39: {
     title:
       "Using caption elements to associate data table captions with data tables",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H39",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H39",
   },
   H40: {
     title: "Using description lists",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H40",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H40",
   },
   H42: {
     title: "Using h1-h6 to identify headings",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H42",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H42",
   },
   H43: {
     title:
       "Using id and headers attributes to associate data cells with header cells in data",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H43",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H43",
   },
   H44: {
     title: "Using label elements to associate text labels with form controls",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H44",
-  },
-  H45: {
-    title: "Using longdesc",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H45",
-  },
-  H46: {
-    title: "Using noembed with embed",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H46",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H44",
   },
   H48: {
     title: "Using ol, ul and dl for lists or groups of links",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H48",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H48",
   },
   H49: {
     title: "Using semantic markup to mark emphasized or special text",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H49",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H49",
   },
   H51: {
     title: "Using table markup to present tabular information",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H51",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H51",
   },
   H53: {
     title: "Using the body of the object element",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H53",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H53",
   },
   H54: {
     title: "Using the dfn element to identify the defining instance of a word",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H54",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H54",
   },
   H56: {
     title:
       "Using the dir attribute on an inline element to resolve problems with nested directional",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H56",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H56",
   },
   H57: {
     title: "Using the language attribute on the HTML element",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H57",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H57",
   },
   H58: {
     title:
       "Using language attributes to identify changes in the human language",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H58",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H58",
   },
   H59: {
     title: "Using the link element and navigation tools",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H59",
-  },
-  H60: {
-    title: "Using the link element to link to a glossary",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H60",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H59",
   },
   H62: {
     title: "Using the ruby element",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H62",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H62",
   },
   H63: {
     title:
       "Using the scope attribute to associate header cells and data cells in data tables",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H63",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H63",
   },
   H64: {
-    title: "Using the title attribute of the frame and iframe elements",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H64",
+    title: "Using the title attribute of the iframe element",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H64",
   },
   H65: {
     title:
       "Using the title attribute to identify form controls when the label element cannot",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H65",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H65",
   },
   H67: {
     title:
-      "Using null alt text and no title attribute on img elements for images that AT should",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H67",
+      "Using null alt text and no title attribute on img elements for images that assistive",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H67",
   },
   H69: {
     title:
       "Providing heading elements at the beginning of each section of content",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H69",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H69",
   },
   H70: {
     title: "Using frame elements to group blocks of repeated material",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H70",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H70",
   },
   H71: {
     title:
       "Providing a description for groups of form controls using fieldset and legend elements",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H71",
-  },
-  H73: {
-    title:
-      "Using the summary attribute of the table element to give an overview of data tables",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H73",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H71",
   },
   H74: {
     title:
       "Ensuring that opening and closing tags are used according to specification",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H74",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H74",
   },
   H75: {
     title: "Ensuring that Web pages are well-formed",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H75",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H75",
   },
   H76: {
     title: "Using meta refresh to create an instant client-side redirect",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H76",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H76",
   },
   H77: {
     title:
       "Identifying the purpose of a link using link text combined with its enclosing list",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H77",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H77",
   },
   H78: {
     title:
       "Identifying the purpose of a link using link text combined with its enclosing paragraph",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H78",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H78",
   },
   H79: {
     title:
       "Identifying the purpose of a link in a data table using the link text combined with",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H79",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H79",
   },
   H80: {
     title:
       "Identifying the purpose of a link using link text combined with the preceding heading",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H80",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H80",
   },
   H81: {
     title:
       "Identifying the purpose of a link in a nested list using link text combined with the",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H81",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H81",
   },
   H83: {
     title:
       "Using the target attribute to open a new window on user request and indicating this",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H83",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H83",
   },
   H84: {
     title: "Using a button with a select element to perform an action",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H84",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H84",
   },
   H85: {
-    title: "Using OPTGROUP to group OPTION elements inside a SELECT",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H85",
+    title: "Using optgroup to group option elements inside a select",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H85",
   },
   H86: {
     title:
-      "Providing text alternatives for ASCII art, emoticons, and leetspeak",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H86",
+      "Providing text alternatives for emojis, emoticons, ASCII art, and leetspeak",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H86",
   },
   H88: {
     title: "Using HTML according to spec",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H88",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H88",
   },
   H89: {
     title: "Using the title attribute to provide context-sensitive help",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H89",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H89",
   },
   H90: {
     title: "Indicating required form controls using label or legend",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H90",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H90",
   },
   H91: {
     title: "Using HTML form controls and links",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H91",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H91",
   },
   H93: {
     title: "Ensuring that id attributes are unique on a Web page",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H93",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H93",
   },
   H94: {
     title: "Ensuring that elements do not contain duplicate attributes",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H94",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H94",
   },
   H95: {
     title: "Using the track element to provide captions",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H95",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H95",
   },
   H96: {
     title: "Using the track element to provide audio descriptions",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H96",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H96",
   },
   H97: {
     title: "Grouping related links using the nav element",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H97",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H97",
   },
   H98: {
     title: "Using HTML 5.2 autocomplete attributes",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H98",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H98",
   },
   H99: {
     title: "Provide a page-selection mechanism",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/html/H99",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H99",
+  },
+  H100: {
+    title: "Providing properly marked up email and password inputs",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H100",
+  },
+  H101: {
+    title: "Using semantic HTML elements to identify regions of a page",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/html/H101",
   },
   PDF1: {
     title:
       "Applying text alternatives to images with the Alt entry in PDF documents",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF1",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF1",
   },
   PDF2: {
     title: "Creating bookmarks in PDF documents",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF2",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF2",
   },
   PDF3: {
     title: "Ensuring correct tab and reading order in PDF documents",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF3",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF3",
   },
   PDF4: {
     title: "Hiding decorative images with the Artifact tag in PDF documents",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF4",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF4",
   },
   PDF5: {
     title: "Indicating required form controls in PDF forms",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF5",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF5",
   },
   PDF6: {
     title: "Using table elements for table markup in PDF Documents",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF6",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF6",
   },
   PDF7: {
     title: "Performing OCR on a scanned PDF document to provide actual text",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF7",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF7",
   },
   PDF8: {
     title:
       "Providing definitions for abbreviations via an E entry for a structure element",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF8",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF8",
   },
   PDF9: {
     title:
       "Providing headings by marking content with heading tags in PDF documents",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF9",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF9",
   },
   PDF10: {
     title: "Providing labels for interactive form controls in PDF documents",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF10",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF10",
   },
   PDF11: {
     title:
       "Providing links and link text using the Link annotation and the /Link structure element",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF11",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF11",
   },
   PDF12: {
     title:
       "Providing name, role, value information for form fields in PDF documents",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF12",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF12",
   },
   PDF13: {
     title:
       "Providing replacement text using the /Alt entry for links in PDF documents",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF13",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF13",
   },
   PDF14: {
     title: "Providing running headers and footers in PDF documents",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF14",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF14",
   },
   PDF15: {
     title: "Providing submit buttons with the submit-form action in PDF forms",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF15",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF15",
   },
   PDF16: {
     title:
       "Setting the default language using the /Lang entry in the document catalog of a PDF",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF16",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF16",
   },
   PDF17: {
     title: "Specifying consistent page numbering for PDF documents",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF17",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF17",
   },
   PDF18: {
     title:
       "Specifying the document title using the Title entry in the document information dictionary",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF18",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF18",
   },
   PDF19: {
     title:
       "Specifying the language for a passage or phrase with the Lang entry in PDF documents",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF19",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF19",
   },
   PDF20: {
     title: "Using Adobe Acrobat Pro's Table Editor to repair mistagged tables",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF20",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF20",
   },
   PDF21: {
     title: "Using List tags for lists in PDF documents",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF21",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF21",
   },
   PDF22: {
     title:
       "Indicating when user input falls outside the required format or values in PDF forms",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF22",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF22",
   },
   PDF23: {
     title: "Providing interactive form controls in PDF documents",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF23",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF23",
   },
   SVR1: {
     title:
-      "Implementing automatic redirects on the server side instead of on the client side",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/server-side-script/SVR1",
+      "Implementing automatic redirects on the server side instead of on the\tclient side",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/server-side-script/SVR1",
   },
   SVR2: {
     title:
       "Using .htaccess to ensure that the only way to access non-conforming content is from",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/server-side-script/SVR2",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/server-side-script/SVR2",
   },
   SVR3: {
     title:
       "Using HTTP referer to ensure that the only way to access non-conforming content is",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/server-side-script/SVR3",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/server-side-script/SVR3",
   },
   SVR4: {
     title:
       "Allowing users to provide preferences for the display of conforming alternate versions",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/server-side-script/SVR4",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/server-side-script/SVR4",
   },
   SVR5: {
     title: "Specifying the default language in the HTTP header",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/server-side-script/SVR5",
-  },
-  SL1: {
-    title: "Accessing Alternate Audio Tracks in Silverlight Media",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL1",
-  },
-  SL2: {
-    title: "Changing The Visual Focus Indicator in Silverlight",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL2",
-  },
-  SL3: {
-    title: "Controlling Silverlight MediaElement Audio Volume",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL3",
-  },
-  SL4: {
-    title:
-      "Declaring Discrete Silverlight Objects to Specify Language Parts in the HTML DOM",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL4",
-  },
-  SL5: {
-    title: "Defining a Focusable Image Class for Silverlight",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL5",
-  },
-  SL6: {
-    title: "Defining a UI Automation Peer for a Custom Silverlight Control",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL6",
-  },
-  SL7: {
-    title: "Designing a Focused Visual State for Custom Silverlight Controls",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL7",
-  },
-  SL8: {
-    title: "Displaying HelpText in Silverlight User Interfaces",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL8",
-  },
-  SL9: {
-    title:
-      "Handling Key Events to Enable Keyboard Functionality in Silverlight",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL9",
-  },
-  SL10: {
-    title: "Implementing a Submit-Form Pattern in Silverlight",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL10",
-  },
-  SL11: {
-    title: "Pausing or Stopping A Decorative Silverlight Animation",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL11",
-  },
-  SL12: {
-    title: "Pausing, Stopping, or Playing Media in Silverlight MediaElements",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL12",
-  },
-  SL13: {
-    title: "Providing A Style Switcher To Switch To High Contrast",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL13",
-  },
-  SL14: {
-    title:
-      "Providing Custom Control Key Handling for Keyboard Functionality in Silverlight",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL14",
-  },
-  SL15: {
-    title:
-      "Providing Keyboard Shortcuts that Work Across the Entire Silverlight Application",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL15",
-  },
-  SL16: {
-    title: "Providing Script-Embedded Text Captions for MediaElement Content",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL16",
-  },
-  SL17: {
-    title:
-      "Providing Static Alternative Content for Silverlight Media Playing in a MediaElement",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL17",
-  },
-  SL18: {
-    title:
-      "Providing Text Equivalent for Nontext Silverlight Controls With AutomationProperties.Name",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL18",
-  },
-  SL19: {
-    title:
-      "Providing User Instructions With AutomationProperties.HelpText in Silverlight",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL19",
-  },
-  SL20: {
-    title:
-      "Relying on Silverlight AutomationPeer Behavior to Set AutomationProperties.Name",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL20",
-  },
-  SL21: {
-    title: "Replacing A Silverlight Timed Animation With a Nonanimated Element",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL21",
-  },
-  SL22: {
-    title: "Supporting Browser Zoom in Silverlight",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL22",
-  },
-  SL23: {
-    title:
-      "Using A Style Switcher to Increase Font Size of Silverlight Text Elements",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL23",
-  },
-  SL24: {
-    title:
-      "Using AutoPlay to Keep Silverlight Media from Playing Automatically",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL24",
-  },
-  SL25: {
-    title:
-      "Using Controls and Programmatic Focus to Bypass Blocks of Content in Silverlight",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL25",
-  },
-  SL26: {
-    title: "Using LabeledBy to Associate Labels and Targets in Silverlight",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL26",
-  },
-  SL27: {
-    title:
-      "Using Language/Culture Properties as Exposed by Silverlight Applications and Assistive",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL27",
-  },
-  SL28: {
-    title: "Using Separate Text-Format Text Captions for MediaElement Content",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL28",
-  },
-  SL29: {
-    title:
-      'Using Silverlight "List" Controls to Define Blocks that can be Bypassed',
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL29",
-  },
-  SL30: {
-    title:
-      "Using Silverlight Control Compositing and AutomationProperties.Name",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL30",
-  },
-  SL31: {
-    title: "Using Silverlight Font Properties to Control Text Presentation",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL31",
-  },
-  SL32: {
-    title: "Using Silverlight Text Elements for Appropriate Accessibility Role",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL32",
-  },
-  SL33: {
-    title: "Using Well-Formed XAML to Define a Silverlight User Interface",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL33",
-  },
-  SL34: {
-    title:
-      "Using the Silverlight Default Tab Sequence and Altering Tab Sequences With Properties",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL34",
-  },
-  SL35: {
-    title:
-      "Using the Validation and ValidationSummary APIs to Implement Client Side Forms Validation",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/silverlight/SL35",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/server-side-script/SVR5",
   },
   SM1: {
     title: "Adding extended audio description in SMIL 1.0",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/smil/SM1",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/smil/SM1",
   },
   SM2: {
     title: "Adding extended audio description in SMIL 2.0",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/smil/SM2",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/smil/SM2",
   },
   SM6: {
     title: "Providing audio description in SMIL 1.0",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/smil/SM6",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/smil/SM6",
   },
   SM7: {
     title: "Providing audio description in SMIL 2.0",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/smil/SM7",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/smil/SM7",
   },
   SM11: {
     title: "Providing captions through synchronized text streams in SMIL 1.0",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/smil/SM11",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/smil/SM11",
   },
   SM12: {
     title: "Providing captions through synchronized text streams in SMIL 2.0",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/smil/SM12",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/smil/SM12",
   },
   SM13: {
     title:
       "Providing sign language interpretation through synchronized video streams in SMIL",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/smil/SM13",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/smil/SM13",
   },
   SM14: {
     title:
       "Providing sign language interpretation through synchronized video streams in SMIL",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/smil/SM14",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/smil/SM14",
   },
   T1: {
     title: "Using standard text formatting conventions for paragraphs",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/text/T1",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/text/T1",
   },
   T2: {
     title: "Using standard text formatting conventions for lists",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/text/T2",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/text/T2",
   },
   T3: {
     title: "Using standard text formatting conventions for headings",
-    uri: "https://www.w3.org/WAI/WCAG21/Techniques/text/T3",
+    uri: "https://www.w3.org/WAI/WCAG22/Techniques/text/T3",
   },
 } as const;


### PR DESCRIPTION
* Update the data scripts to work with current version of WCAG 2.1 and 2.2.
* Update `Criterion` to output WCAG 2.2 data by default.
* Workaround 4.1.1 being deprecated in WCAG 2.2
