### PR TITLE
Taborder fix

### DIFF
--- a/.changeset/strong-adults-clap.md
+++ b/.changeset/strong-adults-clap.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-dom": patch
+---
+
+**Fixed:** `Node.tabOrder()` now correctly inserts shadow tree content in its place, instead of at the start.

--- a/packages/alfa-dom/package.json
+++ b/packages/alfa-dom/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@siteimprove/alfa-array": "workspace:^0.78.2",
     "@siteimprove/alfa-cache": "workspace:^0.78.2",
+    "@siteimprove/alfa-comparable": "workspace:^0.78.2",
     "@siteimprove/alfa-css": "workspace:^0.78.2",
     "@siteimprove/alfa-css-feature": "workspace:^0.78.2",
     "@siteimprove/alfa-device": "workspace:^0.78.2",

--- a/packages/alfa-dom/src/node.ts
+++ b/packages/alfa-dom/src/node.ts
@@ -1,19 +1,22 @@
-import { type Comparer, Comparison } from "@siteimprove/alfa-comparable";
+import {
+  Comparable,
+  type Comparer,
+  Comparison,
+} from "@siteimprove/alfa-comparable";
 import { Device } from "@siteimprove/alfa-device";
-
-import * as earl from "@siteimprove/alfa-earl";
 import { Flags } from "@siteimprove/alfa-flags";
-import * as json from "@siteimprove/alfa-json";
 import { Lazy } from "@siteimprove/alfa-lazy";
 import { Option } from "@siteimprove/alfa-option";
 import { Predicate } from "@siteimprove/alfa-predicate";
 import { Refinement } from "@siteimprove/alfa-refinement";
-import * as sarif from "@siteimprove/alfa-sarif";
 import { Selective } from "@siteimprove/alfa-selective";
 import { Sequence } from "@siteimprove/alfa-sequence";
 import { String } from "@siteimprove/alfa-string";
 import { Trampoline } from "@siteimprove/alfa-trampoline";
 
+import * as earl from "@siteimprove/alfa-earl";
+import * as json from "@siteimprove/alfa-json";
+import * as sarif from "@siteimprove/alfa-sarif";
 import * as tree from "@siteimprove/alfa-tree";
 
 import {
@@ -72,8 +75,8 @@ export abstract class Node<T extends string = string>
      *
      * @remarks
      * These are all elements that are keyboard focusable (non-negative
-     *   tabIndex), plus the shadow hosts and content elements that may contain
-     *   focusable descendants.
+     * tabIndex), plus the shadow hosts and content elements that may contain
+     * focusable descendants.
      *
      * It is important that the traversal is done here on the DOM tree only.
      * The shadow trees and content documents will be expanded later. Doing it
@@ -129,31 +132,25 @@ export abstract class Node<T extends string = string>
      *
      * @remarks
      * Due to non-focusable shadow hosts being candidates (for shadow DOM
-     *   expansion), we may have some indexes being None. These must be treated
-     *   as 0 (insert in DOM order), rather than smaller than actual indexes
-     *   (insert at start). Therefore, we cannot use Option.compareWith.
+     * expansion), we may have some indexes being None. These must be treated
+     * as 0 (insert in DOM order), rather than smaller than actual indexes
+     * (insert at start). Therefore, we cannot use Option.compareWith.
      */
     const comparer: Comparer<[Element, Option<number>]> = ([, a], [, b]) => {
       const aValue = a.getOr(0);
       const bValue = b.getOr(0);
 
-      if (aValue === 0) {
-        // "normal order" must come after any "specific order",
-        // i.e., 0 is greater than any positive number.
-        return bValue === 0 ? Comparison.Equal : Comparison.Greater;
-      }
-
-      if (bValue === 0) {
-        // a cannot be 0 anymore.
-        return Comparison.Less;
-      }
-
-      // If none are 0, simply compare the values.
-      return aValue < bValue
-        ? Comparison.Less
-        : aValue > bValue
-          ? Comparison.Greater
-          : Comparison.Equal;
+      return aValue === 0
+        ? // "normal order" must come after any "specific order",
+          // i.e., 0 is greater than any positive number.
+          bValue === 0
+          ? Comparison.Equal
+          : Comparison.Greater
+        : bValue === 0
+          ? // aValue cannot be 0 anymore.
+            Comparison.Less
+          : // If none are 0, simply compare the values.
+            Comparable.compare(aValue, bValue);
     };
 
     /**
@@ -161,12 +158,11 @@ export abstract class Node<T extends string = string>
      * shadow tree or content document.
      *
      * @remarks
-     * It is important that this expansion happens **after** sorting by
-     *   tabindex
+     * It is important that this expansion happens **after** sorting by tabindex
      * since shadow DOM and content documents build their own sequential focus
-     * order that is inserted as-is in the light tree or parent browsing
-     *   context. That is, a tabindex of 1 in a shadow tree or content document
-     *   does **not** come before a tabindex of 2 in the main document.
+     * order that is inserted as-is in the light tree or parent browsing context.
+     * That is, a tabindex of 1 in a shadow tree or content document does
+     * **not** come before a tabindex of 2 in the main document.
      */
     function expand([element, tabIndex]: [
       Element,
@@ -191,7 +187,7 @@ export abstract class Node<T extends string = string>
         return content.tabOrder();
       }
 
-      // If no shadow or content document, just keep the document.
+      // If no shadow or content document, just keep the element.
       return Sequence.of(element);
     }
 
@@ -485,7 +481,7 @@ export namespace Node {
    * @remarks
    * The clone will have the same `externalId` as the original.
    * The clone will *not* get `extraData` from the original, instead it will be
-   *   `undefined`.
+   * `undefined`.
    */
   export function clone(
     node: Element,
@@ -500,7 +496,7 @@ export namespace Node {
    * @remarks
    * The clone will have the same `externalId` as the original.
    * The clone will *not* get `extraData` from the original, instead it will be
-   *   `undefined`.
+   * `undefined`.
    */
   export function clone(
     node: Attribute,
@@ -515,7 +511,7 @@ export namespace Node {
    * @remarks
    * The clone will have the same `externalId` as the original.
    * The clone will *not* get `extraData` from the original, instead it will be
-   *   `undefined`.
+   * `undefined`.
    */
   export function clone(
     node: Text,
@@ -530,7 +526,7 @@ export namespace Node {
    * @remarks
    * The clone will have the same `externalId` as the original.
    * The clone will *not* get `extraData` from the original, instead it will be
-   *   `undefined`.
+   * `undefined`.
    */
   export function clone(
     node: Comment,
@@ -546,7 +542,7 @@ export namespace Node {
    * @remarks
    * The clone will have the same `externalId` as the original.
    * The clone will *not* get `extraData` from the original, instead it will be
-   *   `undefined`.
+   * `undefined`.
    */
   export function clone(
     node: Document,
@@ -561,7 +557,7 @@ export namespace Node {
    * @remarks
    * The clone will have the same `externalId` as the original.
    * The clone will *not* get `extraData` from the original, instead it will be
-   *   `undefined`.
+   * `undefined`.
    */
   export function clone(
     node: Type,
@@ -577,7 +573,7 @@ export namespace Node {
    * @remarks
    * The clone will have the same `externalId` as the original.
    * The clone will *not* get `extraData` from the original, instead it will be
-   *   `undefined`.
+   * `undefined`.
    */
   export function clone(
     node: Fragment,
@@ -593,7 +589,7 @@ export namespace Node {
    * @remarks
    * The clone will have the same `externalId` as the original.
    * The clone will *not* get `extraData` from the original, instead it will be
-   *   `undefined`.
+   * `undefined`.
    */
   export function clone(
     node: Shadow,

--- a/packages/alfa-dom/src/node/element/predicate/is-suggested-focusable.ts
+++ b/packages/alfa-dom/src/node/element/predicate/is-suggested-focusable.ts
@@ -1,7 +1,7 @@
 import { Element } from "../../element";
 
 /**
- * {@link https://html.spec.whatwg.org/#tabindex-value}
+ * {@link https://html.spec.whatwg.org/multipage/#tabindex-value}
  *
  * @remarks
  * Draggable elements for which the user agent supports drag operations without

--- a/packages/alfa-dom/test/node.spec.tsx
+++ b/packages/alfa-dom/test/node.spec.tsx
@@ -34,6 +34,42 @@ test("#tabOrder() correctly handles explicitly ordered tab indices", (t) => {
   t.deepEqual([...div.tabOrder()], [b, a, c]);
 });
 
+test(`#tabOrder() correctly orders light and shadow elements`, (t) => {
+  const a = <button />;
+  const b = <button />;
+
+  const div = (
+    <div>
+      {a}
+      <div>{h.shadow([b])}</div>
+    </div>
+  );
+
+  t.deepEqual([...div.tabOrder()], [a, b]);
+});
+
+test(`#tabOrder() does not mix explicit taborder between trees`, (t) => {
+  const a = <button tabindex="1" />;
+  const b = <button tabindex="2" />;
+  const c = <button tabindex="3" />;
+  const d = <button tabindex="4" />;
+  const e = <button tabindex="1" />;
+  const f = <button />;
+
+  const div = (
+    <div>
+      {c}
+      <div>{h.shadow([d, e])}</div>
+      <iframe>{h.document([b])}</iframe>
+      {a}
+      {f}
+    </div>
+  );
+
+  // a and b, with >0 tabindex, come before the hosts and e.
+  t.deepEqual([...div.tabOrder()], [a, c, e, d, b, f]);
+});
+
 test(`#tabOrder() correctly handles shadow roots with slotted elements before
       the shadow contents`, (t) => {
   const a = <button />;

--- a/packages/alfa-dom/test/node.spec.tsx
+++ b/packages/alfa-dom/test/node.spec.tsx
@@ -66,7 +66,7 @@ test(`#tabOrder() does not mix explicit taborder between trees`, (t) => {
     </div>
   );
 
-  // a and b, with >0 tabindex, come before the hosts and e.
+  // a and c, with >0 tabindex, come before the hosts and f.
   t.deepEqual([...div.tabOrder()], [a, c, e, d, b, f]);
 });
 

--- a/packages/alfa-dom/tsconfig.json
+++ b/packages/alfa-dom/tsconfig.json
@@ -94,6 +94,7 @@
   "references": [
     { "path": "../alfa-array" },
     { "path": "../alfa-cache" },
+    { "path": "../alfa-comparable" },
     { "path": "../alfa-css" },
     { "path": "../alfa-css-feature" },
     { "path": "../alfa-device" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1109,6 +1109,7 @@ __metadata:
   dependencies:
     "@siteimprove/alfa-array": "workspace:^0.78.2"
     "@siteimprove/alfa-cache": "workspace:^0.78.2"
+    "@siteimprove/alfa-comparable": "workspace:^0.78.2"
     "@siteimprove/alfa-css": "workspace:^0.78.2"
     "@siteimprove/alfa-css-feature": "workspace:^0.78.2"
     "@siteimprove/alfa-device": "workspace:^0.78.2"


### PR DESCRIPTION
The comparison of tab indexes was flawed due using `Option.compareWith` which puts `None` before any `Some`.
This placed non-tabbable shadow host **before** the rest of the content, thus any tabbable inside a shadow tree were put before the rest.

This corrects the comparison.
