### PR TITLE
Fix serialization of boxes

### DIFF
--- a/.changeset/six-numbers-raise.md
+++ b/.changeset/six-numbers-raise.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-dom": patch
+---
+
+**Fixed:** Bug where boxes where not being serialized due to device not being passed down when recursing has been fixed.

--- a/docs/review/api/alfa-dom.api.md
+++ b/docs/review/api/alfa-dom.api.md
@@ -1050,7 +1050,7 @@ export class Shadow extends Node<"shadow"> {
     // (undocumented)
     get style(): Iterable_2<Sheet>;
     // (undocumented)
-    toJSON(): Shadow.JSON;
+    toJSON(options?: Node.SerializationOptions): Shadow.JSON;
     // (undocumented)
     toString(): string;
 }
@@ -1258,7 +1258,7 @@ export class Type<N extends string = string> extends Node<"type"> {
     // (undocumented)
     get systemId(): Option<string>;
     // (undocumented)
-    toJSON(): Type.JSON<N>;
+    toJSON(options?: Node.SerializationOptions): Type.JSON<N>;
     // (undocumented)
     toString(): string;
 }

--- a/packages/alfa-dom/src/node/element.ts
+++ b/packages/alfa-dom/src/node/element.ts
@@ -299,7 +299,7 @@ export class Element<N extends string = string>
 
   public toJSON(options?: Node.SerializationOptions): Element.JSON<N> {
     return {
-      ...super.toJSON(),
+      ...super.toJSON(options),
       namespace: this._namespace.getOr(null),
       prefix: this._prefix.getOr(null),
       name: this._name,
@@ -307,8 +307,10 @@ export class Element<N extends string = string>
         attribute.toJSON(),
       ),
       style: this._style.map((style) => style.toJSON()).getOr(null),
-      shadow: this._shadow.map((shadow) => shadow.toJSON()).getOr(null),
-      content: this._content.map((content) => content.toJSON()).getOr(null),
+      shadow: this._shadow.map((shadow) => shadow.toJSON(options)).getOr(null),
+      content: this._content
+        .map((content) => content.toJSON(options))
+        .getOr(null),
       box:
         options?.device === undefined
           ? null

--- a/packages/alfa-dom/src/node/shadow.ts
+++ b/packages/alfa-dom/src/node/shadow.ts
@@ -91,9 +91,9 @@ export class Shadow extends Node<"shadow"> {
     return "/";
   }
 
-  public toJSON(): Shadow.JSON {
+  public toJSON(options?: Node.SerializationOptions): Shadow.JSON {
     return {
-      ...super.toJSON(),
+      ...super.toJSON(options),
       mode: this._mode,
       style: this._style.map((sheet) => sheet.toJSON()),
     };

--- a/packages/alfa-dom/src/node/type.ts
+++ b/packages/alfa-dom/src/node/type.ts
@@ -51,9 +51,9 @@ export class Type<N extends string = string> extends Node<"type"> {
     return this._systemId;
   }
 
-  public toJSON(): Type.JSON<N> {
+  public toJSON(options?: Node.SerializationOptions): Type.JSON<N> {
     const result = {
-      ...super.toJSON(),
+      ...super.toJSON(options),
       name: this._name,
       publicId: this._publicId.getOr(null),
       systemId: this._systemId.getOr(null),

--- a/packages/alfa-dom/test/node.spec.tsx
+++ b/packages/alfa-dom/test/node.spec.tsx
@@ -175,13 +175,10 @@ test(`Node.clone() correctly replaces elements based on predicate`, (t) => {
 test(`#toJSON() serializes boxes of all descendants when device is passed in`, (t) => {
   const device = Device.standard();
 
-  const box1 = { device, x: 8, y: 8, width: 100, height: 100 };
-  const box2 = { device, x: 16, y: 16, width: 50, height: 50 };
-
   const doc = h.document([
-    <div box={box1}>
+    <div box={{ device, x: 8, y: 8, width: 100, height: 100 }}>
       Hello
-      <div box={box2}>World</div>
+      <div box={{ device, x: 16, y: 16, width: 50, height: 50 }}>World</div>
     </div>,
   ]);
 
@@ -216,6 +213,7 @@ test(`#toJSON() serializes box of descendant inside shadow DOM`, (t) => {
     <div box={{ device, x: 8, y: 8, width: 100, height: 100 }}>
       Hello
       {h.shadow([
+        <slot box={{ device, x: 12, y: 12, width: 50, height: 50 }} />,
         <span box={{ device, x: 16, y: 16, width: 50, height: 50 }}>
           World
         </span>,
@@ -253,6 +251,7 @@ test(`#toJSON() serializes box of descendant inside shadow DOM`, (t) => {
 
   t.deepEqual(boxes, [
     Rectangle.of(8, 8, 100, 100).toJSON(),
+    Rectangle.of(12, 12, 50, 50).toJSON(),
     Rectangle.of(16, 16, 50, 50).toJSON(),
   ]);
 });

--- a/packages/alfa-dom/test/node.spec.tsx
+++ b/packages/alfa-dom/test/node.spec.tsx
@@ -1,6 +1,7 @@
 import { test } from "@siteimprove/alfa-test";
 
 import { Device } from "@siteimprove/alfa-device";
+
 import { h } from "../h";
 import { Node } from "../src";
 
@@ -166,4 +167,36 @@ test(`Node.clone() correctly replaces elements based on predicate`, (t) => {
     type: "document",
     children: [...newElements.map((e) => e.toJSON()), bar.toJSON()],
   });
+});
+
+test(`#toJSON() serializes boxes of all descendants when device is passed in`, (t) => {
+  const device = Device.standard();
+
+  const doc = h.document(
+    [
+      <div box={{ device, x: 8, y: 8, width: 100, height: 100 }}>
+        Hello
+        <div box={{ device, x: 16, y: 16, width: 50, height: 50 }}>
+          World
+        </div>
+      </div>,
+    ]
+  );
+
+  function visit(node: Node.JSON) {
+    if (node.type === "element") {
+      t.notEqual(node.box, null);
+      t.notEqual(node.box, undefined);
+    }
+
+    if (node.children === undefined) {
+      return;
+    }
+
+    for (let child of node.children) {
+      visit(child);
+    }
+  }
+
+  visit(doc.toJSON({ device }));
 });


### PR DESCRIPTION
I discovered that the options containing the device used to serialize the boxes of elements where not passed down in all cases when recursively serializing descendants, causing the box to only be serialized on the top elements. This PR fixes that.