### PR TITLE
Accept and pass down options in serialization of collection-like types (and `Page`  and releated)

### DIFF
--- a/.changeset/eight-hats-lie.md
+++ b/.changeset/eight-hats-lie.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-web": minor
+---
+
+**Added:** Serialization options are now accepted by `Page.toJSON()`

--- a/.changeset/eight-hats-lie.md
+++ b/.changeset/eight-hats-lie.md
@@ -1,5 +1,0 @@
----
-"@siteimprove/alfa-web": minor
----
-
-**Added:** Serialization options are now accepted by `Page.toJSON()`

--- a/.changeset/lazy-phones-search.md
+++ b/.changeset/lazy-phones-search.md
@@ -1,0 +1,21 @@
+---
+"@siteimprove/alfa-collection": minor
+"@siteimprove/alfa-iterable": minor
+"@siteimprove/alfa-sequence": minor
+"@siteimprove/alfa-device": minor
+"@siteimprove/alfa-option": minor
+"@siteimprove/alfa-record": minor
+"@siteimprove/alfa-result": minor
+"@siteimprove/alfa-array": minor
+"@siteimprove/alfa-graph": minor
+"@siteimprove/alfa-rules": minor
+"@siteimprove/alfa-slice": minor
+"@siteimprove/alfa-http": minor
+"@siteimprove/alfa-lazy": minor
+"@siteimprove/alfa-list": minor
+"@siteimprove/alfa-map": minor
+"@siteimprove/alfa-set": minor
+"@siteimprove/alfa-web": minor
+---
+
+**Added:** Serialization options are now accepted and propageted through `toJSON()`.

--- a/.changeset/lazy-phones-search.md
+++ b/.changeset/lazy-phones-search.md
@@ -18,4 +18,4 @@
 "@siteimprove/alfa-web": minor
 ---
 
-**Added:** Serialization options are now accepted and propageted through `toJSON()`.
+**Added:** Serialization options are now accepted, and passed on, by `toJSON()` on these types.

--- a/docs/review/api/alfa-array.api.md
+++ b/docs/review/api/alfa-array.api.md
@@ -134,7 +134,7 @@ namespace Array_2 {
     // (undocumented)
     function subtract<T>(array: ReadonlyArray<T>, ...iterables: Array_2<Iterable_2<T>>): Array_2<T>;
     // (undocumented)
-    function toJSON<T>(array: ReadonlyArray<T>): Array_2<Serializable.ToJSON<T>>;
+    function toJSON<T, O extends Serializable.Options = Serializable.Options>(array: ReadonlyArray<T>, options?: O): Array_2<Serializable.ToJSON<T>>;
     // (undocumented)
     function zip<T, U = T>(array: ReadonlyArray<T>, iterable: Iterable_2<U>): Array_2<[T, U]>;
 }

--- a/docs/review/api/alfa-collection.api.md
+++ b/docs/review/api/alfa-collection.api.md
@@ -76,7 +76,7 @@ export interface Collection<T> extends Functor<T>, Applicative<T>, Monad<T>, Fol
 // @public (undocumented)
 export namespace Collection {
     // (undocumented)
-    export interface Indexed<T> extends Collection<T>, Iterable_2<T>, Comparable<Iterable_2<T>>, Serializable<Indexed.JSON<T>> {
+    export interface Indexed<T, O extends Serializable.Options = Serializable.Options> extends Collection<T>, Iterable_2<T>, Comparable<Iterable_2<T>>, Serializable<Indexed.JSON<T>, O> {
         // (undocumented)
         append(value: T): Indexed<T>;
         // (undocumented)
@@ -206,7 +206,7 @@ export namespace Collection {
         export type JSON<T> = Array_2<Serializable.ToJSON<T>>;
     }
     // (undocumented)
-    export interface Keyed<K, V> extends Collection<V>, Iterable_2<[K, V]>, Serializable<Keyed.JSON<K, V>> {
+    export interface Keyed<K, V, O extends Serializable.Options = Serializable.Options> extends Collection<V>, Iterable_2<[K, V]>, Serializable<Keyed.JSON<K, V>, O> {
         // (undocumented)
         apply<U>(mapper: Keyed<K, Mapper<V, U>>): Keyed<K, U>;
         // (undocumented)
@@ -275,7 +275,7 @@ export namespace Collection {
         ]>;
     }
     // (undocumented)
-    export interface Unkeyed<T> extends Collection<T>, Iterable_2<T>, Serializable<Unkeyed.JSON<T>> {
+    export interface Unkeyed<T, O extends Serializable.Options = Serializable.Options> extends Collection<T>, Iterable_2<T>, Serializable<Unkeyed.JSON<T>, O> {
         // (undocumented)
         add(value: T): Unkeyed<T>;
         // (undocumented)

--- a/docs/review/api/alfa-css-feature.api.md
+++ b/docs/review/api/alfa-css-feature.api.md
@@ -61,9 +61,9 @@ export namespace Feature {
     const // Warning: (ae-forgotten-export) The symbol "Media" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    parseMediaQuery: Parser<Slice<Token>, Media.List, string, []>;
+    parseMediaQuery: Parser<Slice<Token, Serializable.Options>, Media.List, string, []>;
     const // (undocumented)
-    parseSupportsQuery: Parser<Slice<Token>, Supports.Query, string, []>;
+    parseSupportsQuery: Parser<Slice<Token, Serializable.Options>, Supports.Query, string, []>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/docs/review/api/alfa-css.api.md
+++ b/docs/review/api/alfa-css.api.md
@@ -285,7 +285,7 @@ export namespace Color {
     // (undocumented)
     export function rgb<C extends Number_2.Canonical | Percentage.Canonical, A extends Number_2.Canonical | Percentage.Canonical>(red: C, green: C, blue: C, alpha: A): RGB<C, A>;
     const // (undocumented)
-    parse: Parser_2<Slice<Token>, Color, string, []>;
+    parse: Parser_2<Slice<Token, Serializable>, Color, string, []>;
     // (undocumented)
     export function system(keyword: System.Keyword): System;
 }
@@ -293,7 +293,7 @@ export namespace Color {
 // @public (undocumented)
 export namespace Comma {
     const // (undocumented)
-    parse: Parser_2<Slice<Token>, Token.Comma, string, []>;
+    parse: Parser_2<Slice<Token, Serializable>, Token.Comma, string, []>;
 }
 
 // @public (undocumented)
@@ -319,7 +319,7 @@ export namespace Component {
     const // (undocumented)
     consume: Parser<Component>;
     const // (undocumented)
-    parse: Parser_2<Slice<Token>, Component, string, []>;
+    parse: Parser_2<Slice<Token, Serializable.Options>, Component, string, []>;
 }
 
 // @public
@@ -549,7 +549,7 @@ namespace Function_2 {
     const // (undocumented)
     consume: Parser<Function_2>;
     const // (undocumented)
-    parse: <T>(query?: string | Predicate<Token.Function>, body?: Parser<T> | Thunk<Parser<T>>) => Parser_2<Slice<Token>, readonly [Function_2, T], string, []>;
+    parse: <T>(query?: string | Predicate<Token.Function>, body?: Parser<T> | Thunk<Parser<T>>) => Parser_2<Slice<Token, Serializable.Options>, readonly [Function_2, T], string, []>;
 }
 export { Function_2 as Function }
 
@@ -1156,19 +1156,19 @@ namespace Math_2 {
     const // Warning: (ae-incompatible-release-tags) The symbol "parse" is marked as @public, but its signature references "Math_2" which is marked as @internal
     //
     // (undocumented)
-    parse: Parser_2<Slice<Token>, Math_2<Dimension>, string, []>;
+    parse: Parser_2<Slice<Token, json.Serializable.Options>, Math_2<Dimension>, string, []>;
     const // (undocumented)
-    parseAngle: Parser_2<Slice<Token>, Math_2<"angle">, string, []>;
+    parseAngle: Parser_2<Slice<Token, json.Serializable.Options>, Math_2<"angle">, string, []>;
     const // (undocumented)
-    parseAnglePercentage: Parser_2<Slice<Token>, Math_2<"angle-percentage">, string, []>;
+    parseAnglePercentage: Parser_2<Slice<Token, json.Serializable.Options>, Math_2<"angle-percentage">, string, []>;
     const // (undocumented)
-    parseLength: Parser_2<Slice<Token>, Math_2<"length">, string, []>;
+    parseLength: Parser_2<Slice<Token, json.Serializable.Options>, Math_2<"length">, string, []>;
     const // (undocumented)
-    parseLengthPercentage: Parser_2<Slice<Token>, Math_2<"length-percentage">, string, []>;
+    parseLengthPercentage: Parser_2<Slice<Token, json.Serializable.Options>, Math_2<"length-percentage">, string, []>;
     const // (undocumented)
-    parseNumber: Parser_2<Slice<Token>, Math_2<"number">, string, []>;
+    parseNumber: Parser_2<Slice<Token, json.Serializable.Options>, Math_2<"number">, string, []>;
     const // (undocumented)
-    parsePercentage: Parser_2<Slice<Token>, Math_2<"percentage">, string, []>;
+    parsePercentage: Parser_2<Slice<Token, json.Serializable.Options>, Math_2<"percentage">, string, []>;
 }
 export { Math_2 as Math }
 
@@ -1232,7 +1232,7 @@ export namespace Matrix {
     ]
     ];
     const // (undocumented)
-    parse: Parser_2<Slice<Token>, Matrix, string, []>;
+    parse: Parser_2<Slice<Token, Serializable>, Matrix, string, []>;
 }
 
 // @public (undocumented)
@@ -1552,7 +1552,7 @@ export namespace Percentage {
     // (undocumented)
     export function of<H extends Numeric_2.Type = Numeric_2.Type>(value: Math_2<"percentage">): Calculated<H>;
     // (undocumented)
-    export function parse<H extends Numeric_2.Type = Numeric_2.Type>(input: Slice<Token>): Result<[Slice<Token>, Fixed<H> | Calculated<H>], string>;
+    export function parse<H extends Numeric_2.Type = Numeric_2.Type>(input: Slice<Token>): Result<[Slice<Token, Serializable>, Fixed<H> | Calculated<H>], string, Serializable>;
     // (undocumented)
     export type PartiallyResolved<H extends Numeric_2.Type> = Fixed<H>;
     // (undocumented)
@@ -1597,7 +1597,7 @@ export namespace Perspective {
     // (undocumented)
     export type Resolver = Length.Resolver;
     const // (undocumented)
-    parse: Parser_2<Slice<Token>, Perspective<Length<import("../..").Unit.Length>>, string, []>;
+    parse: Parser_2<Slice<Token, Serializable>, Perspective<Length<import("../..").Unit.Length>>, string, []>;
 }
 
 // Warning: (ae-incompatible-release-tags) The symbol "Polygon" is marked as @public, but its signature references "Resolvable" which is marked as @internal
@@ -1940,7 +1940,7 @@ export namespace Rotate {
         z: Number_2.Fixed.JSON;
     }
     const // (undocumented)
-    parse: Parser_2<Slice<Token>, Rotate, string, []>;
+    parse: Parser_2<Slice<Token, Serializable>, Rotate, string, []>;
 }
 
 // Warning: (ae-incompatible-release-tags) The symbol "Scale" is marked as @public, but its signature references "Resolvable" which is marked as @internal
@@ -1981,7 +1981,7 @@ export namespace Scale {
         y: Number_2.Fixed.JSON;
     }
     const // (undocumented)
-    parse: Parser_2<Slice<Token>, Scale, string, []>;
+    parse: Parser_2<Slice<Token, Serializable>, Scale, string, []>;
 }
 
 // Warning: (ae-incompatible-release-tags) The symbol "Shadow" is marked as @public, but its signature references "Resolvable" which is marked as @internal
@@ -2097,7 +2097,7 @@ export namespace Shape {
         // Warning: (ae-forgotten-export) The symbol "Keywords" needs to be exported by the entry point index.d.ts
         //
         // @internal (undocumented)
-        parse: Parser_2<Slice<Token>, Circle<Radius<LengthPercentage | import("./radius").Radius.Side>, Position<import("../position/keywords").Keywords.Horizontal, import("../position/keywords").Keywords.Vertical, Component_2<import("../position/keywords").Keywords.Horizontal>, Component_2<import("../position/keywords").Keywords.Vertical>>> | Ellipse<Radius<LengthPercentage | import("./radius").Radius.Side>, Position<import("../position/keywords").Keywords.Horizontal, import("../position/keywords").Keywords.Vertical, Component_2<import("../position/keywords").Keywords.Horizontal>, Component_2<import("../position/keywords").Keywords.Vertical>>> | Inset<Inset.Offset, Corner_2> | Polygon<Polygon.Fill, LengthPercentage>, string, []>;
+        parse: Parser_2<Slice<Token, Serializable>, Circle<Radius<LengthPercentage | import("./radius").Radius.Side>, Position<import("../position/keywords").Keywords.Horizontal, import("../position/keywords").Keywords.Vertical, Component_2<import("../position/keywords").Keywords.Horizontal>, Component_2<import("../position/keywords").Keywords.Vertical>>> | Ellipse<Radius<LengthPercentage | import("./radius").Radius.Side>, Position<import("../position/keywords").Keywords.Horizontal, import("../position/keywords").Keywords.Vertical, Component_2<import("../position/keywords").Keywords.Horizontal>, Component_2<import("../position/keywords").Keywords.Vertical>>> | Inset<Inset.Offset, Corner_2> | Polygon<Polygon.Fill, LengthPercentage>, string, []>;
     }
     // (undocumented)
     export type Canonical = Shape<Basic.Canonical, Box.Geometry>;
@@ -2154,7 +2154,7 @@ export namespace Skew {
         y: Angle.Fixed.JSON;
     }
     const // (undocumented)
-    parse: Parser_2<Slice<Token>, Skew, string, []>;
+    parse: Parser_2<Slice<Token, Serializable>, Skew, string, []>;
 }
 
 // Warning: (ae-incompatible-release-tags) The symbol "String" is marked as @public, but its signature references "Resolvable" which is marked as @internal
@@ -2717,7 +2717,7 @@ export namespace Token {
     whitespace: typeof Whitespace.of, // (undocumented)
     isWhitespace: typeof Whitespace.isWhitespace;
     const // (undocumented)
-    parseWhitespace: Parser_2<Slice<Token>, Whitespace, string, []>;
+    parseWhitespace: Parser_2<Slice<Token, Serializable.Options>, Whitespace, string, []>;
     // (undocumented)
     export namespace OpenParenthesis {
         // (undocumented)
@@ -2749,7 +2749,7 @@ export namespace Token {
     colon: typeof Colon.of, // (undocumented)
     isColon: typeof Colon.isColon;
     const // (undocumented)
-    parseColon: Parser_2<Slice<Token>, Colon, string, []>;
+    parseColon: Parser_2<Slice<Token, Serializable.Options>, Colon, string, []>;
     // (undocumented)
     export namespace OpenSquareBracket {
         // (undocumented)
@@ -2763,48 +2763,48 @@ export namespace Token {
         }
     }
     // (undocumented)
-    export function parseDelim(query?: string | number | Predicate<Delim>): Parser_2<Slice<Token>, Delim, string, []>;
+    export function parseDelim(query?: string | number | Predicate<Delim>): Parser_2<Slice<Token, Serializable.Options>, Delim, string, []>;
     const // (undocumented)
     semicolon: typeof Semicolon.of, // (undocumented)
     isSemicolon: typeof Semicolon.isSemicolon;
     const // (undocumented)
-    parseSemicolon: Parser_2<Slice<Token>, Semicolon, string, []>;
+    parseSemicolon: Parser_2<Slice<Token, Serializable.Options>, Semicolon, string, []>;
     // (undocumented)
-    export function parseDimension(predicate?: Predicate<Dimension>): Parser_2<Slice<Token>, Dimension, string, []>;
+    export function parseDimension(predicate?: Predicate<Dimension>): Parser_2<Slice<Token, Serializable.Options>, Dimension, string, []>;
     // (undocumented)
-    export function parseFunction(query?: string | Predicate<Function>): Parser_2<Slice<Token>, Function, string, []>;
+    export function parseFunction(query?: string | Predicate<Function>): Parser_2<Slice<Token, Serializable.Options>, Function, string, []>;
     const // (undocumented)
     comma: typeof Comma.of, // (undocumented)
     isComma: typeof Comma.isComma;
     const // (undocumented)
-    parseComma: Parser_2<Slice<Token>, Comma, string, []>;
+    parseComma: Parser_2<Slice<Token, Serializable.Options>, Comma, string, []>;
     // (undocumented)
-    export function parseHash(predicate?: Predicate<Hash>): Parser_2<Slice<Token>, Hash, string, []>;
+    export function parseHash(predicate?: Predicate<Hash>): Parser_2<Slice<Token, Serializable.Options>, Hash, string, []>;
     // (undocumented)
-    export function parseIdent(query?: string | Predicate<Ident>): Parser_2<Slice<Token>, Ident, string, []>;
+    export function parseIdent(query?: string | Predicate<Ident>): Parser_2<Slice<Token, Serializable.Options>, Ident, string, []>;
     const // (undocumented)
     openParenthesis: typeof OpenParenthesis.of, // (undocumented)
     isOpenParenthesis: typeof OpenParenthesis.isOpenParenthesis;
     const // (undocumented)
-    parseOpenParenthesis: Parser_2<Slice<Token>, OpenParenthesis, string, []>;
+    parseOpenParenthesis: Parser_2<Slice<Token, Serializable.Options>, OpenParenthesis, string, []>;
     // (undocumented)
-    export function parseNumber(predicate?: Predicate<Number>): Parser_2<Slice<Token>, Number, string, []>;
+    export function parseNumber(predicate?: Predicate<Number>): Parser_2<Slice<Token, Serializable.Options>, Number, string, []>;
     // (undocumented)
-    export function parsePercentage(predicate?: Predicate<Percentage>): Parser_2<Slice<Token>, Percentage, string, []>;
+    export function parsePercentage(predicate?: Predicate<Percentage>): Parser_2<Slice<Token, Serializable.Options>, Percentage, string, []>;
     const // (undocumented)
     closeParenthesis: typeof CloseParenthesis.of, // (undocumented)
     isCloseParenthesis: typeof CloseParenthesis.isCloseParenthesis;
     const // (undocumented)
-    parseCloseParenthesis: Parser_2<Slice<Token>, CloseParenthesis, string, []>;
+    parseCloseParenthesis: Parser_2<Slice<Token, Serializable.Options>, CloseParenthesis, string, []>;
     // (undocumented)
-    export function parseString(predicate?: Predicate<String>): Parser_2<Slice<Token>, String, string, []>;
+    export function parseString(predicate?: Predicate<String>): Parser_2<Slice<Token, Serializable.Options>, String, string, []>;
     // (undocumented)
-    export function parseURL(predicate?: Predicate<URL>): Parser_2<Slice<Token>, URL, string, []>;
+    export function parseURL(predicate?: Predicate<URL>): Parser_2<Slice<Token, Serializable.Options>, URL, string, []>;
     const // (undocumented)
     openSquareBracket: typeof OpenSquareBracket.of, // (undocumented)
     isOpenSquareBracket: typeof OpenSquareBracket.isOpenSquareBracket;
     const // (undocumented)
-    parseOpenSquareBracket: Parser_2<Slice<Token>, OpenSquareBracket, string, []>;
+    parseOpenSquareBracket: Parser_2<Slice<Token, Serializable.Options>, OpenSquareBracket, string, []>;
     // (undocumented)
     export class Percentage implements Equatable, Serializable<Percentage.JSON> {
         // (undocumented)
@@ -2842,7 +2842,7 @@ export namespace Token {
     closeSquareBracket: typeof CloseSquareBracket.of, // (undocumented)
     isCloseSquareBracket: typeof CloseSquareBracket.isCloseSquareBracket;
     const // (undocumented)
-    parseCloseSquareBracket: Parser_2<Slice<Token>, CloseSquareBracket, string, []>;
+    parseCloseSquareBracket: Parser_2<Slice<Token, Serializable.Options>, CloseSquareBracket, string, []>;
     // (undocumented)
     export class Semicolon implements Equatable, Serializable<Semicolon.JSON> {
         // (undocumented)
@@ -2872,7 +2872,7 @@ export namespace Token {
     openCurlyBracket: typeof OpenCurlyBracket.of, // (undocumented)
     isOpenCurlyBracket: typeof OpenCurlyBracket.isOpenCurlyBracket;
     const // (undocumented)
-    parseOpenCurlyBracket: Parser_2<Slice<Token>, OpenCurlyBracket, string, []>;
+    parseOpenCurlyBracket: Parser_2<Slice<Token, Serializable.Options>, OpenCurlyBracket, string, []>;
     // (undocumented)
     export class String implements Equatable, Serializable<String.JSON> {
         // (undocumented)
@@ -2906,7 +2906,7 @@ export namespace Token {
     closeCurlyBracket: typeof CloseCurlyBracket.of, // (undocumented)
     isCloseCurlyBracket: typeof CloseCurlyBracket.isCloseCurlyBracket;
     const // (undocumented)
-    parseCloseCurlyBracket: Parser_2<Slice<Token>, CloseCurlyBracket, string, []>;
+    parseCloseCurlyBracket: Parser_2<Slice<Token, Serializable.Options>, CloseCurlyBracket, string, []>;
     // (undocumented)
     export class URL implements Equatable, Serializable<URL.JSON> {
         // (undocumented)
@@ -2940,7 +2940,7 @@ export namespace Token {
     openComment: typeof OpenComment.of, // (undocumented)
     isOpenComment: typeof OpenComment.isOpenComment;
     const // (undocumented)
-    parseOpenComment: Parser_2<Slice<Token>, OpenComment, string, []>;
+    parseOpenComment: Parser_2<Slice<Token, Serializable.Options>, OpenComment, string, []>;
     // (undocumented)
     export class Whitespace implements Equatable, Serializable<Whitespace.JSON> {
         // (undocumented)
@@ -2970,7 +2970,7 @@ export namespace Token {
     closeComment: typeof CloseComment.of, // (undocumented)
     isCloseComment: typeof CloseComment.isCloseComment;
     const // (undocumented)
-    parseCloseComment: Parser_2<Slice<Token>, CloseComment, string, []>;
+    parseCloseComment: Parser_2<Slice<Token, Serializable.Options>, CloseComment, string, []>;
 }
 
 // @public (undocumented)
@@ -3003,7 +3003,7 @@ export namespace Transform {
     // (undocumented)
     export function translate<X extends LengthPercentage, Y extends LengthPercentage, Z extends Length>(x: X, y: Y, z: Z): Translate<X, Y, Z>;
     const // @internal (undocumented)
-    parse: Parser_2<Slice<Token>, Transform, string, []>;
+    parse: Parser_2<Slice<Token, Serializable>, Transform, string, []>;
     const // (undocumented)
     parseList: Parser<List<Transform>>;
 }

--- a/docs/review/api/alfa-device.api.md
+++ b/docs/review/api/alfa-device.api.md
@@ -28,7 +28,7 @@ export class Device implements Equatable, Hashable, Serializable {
     // (undocumented)
     get scripting(): Scripting;
     // (undocumented)
-    toJSON(): Device.JSON;
+    toJSON(options?: json.Serializable.Options): Device.JSON;
     // (undocumented)
     get type(): Device.Type;
     // (undocumented)
@@ -80,7 +80,7 @@ export class Display implements Equatable, Hashable, Serializable {
     // (undocumented)
     get scan(): Display.Scan;
     // (undocumented)
-    toJSON(): Display.JSON;
+    toJSON(options?: json.Serializable.Options): Display.JSON;
 }
 
 // @public (undocumented)
@@ -118,7 +118,7 @@ export class Preference<N extends Preference.Name = Preference.Name> implements 
     // (undocumented)
     static of<N extends Preference.Name>(name: N, value: Preference.Value<N>): Preference<N>;
     // (undocumented)
-    toJSON(): Preference.JSON<N>;
+    toJSON(options?: json.Serializable.Options): Preference.JSON<N>;
     // (undocumented)
     get value(): Preference.Value<N>;
 }
@@ -167,7 +167,7 @@ export class Scripting implements Equatable, Hashable, Serializable {
     // (undocumented)
     static of(enabled: boolean): Scripting;
     // (undocumented)
-    toJSON(): Scripting.JSON;
+    toJSON(options?: json.Serializable.Options): Scripting.JSON;
 }
 
 // @public (undocumented)
@@ -202,7 +202,7 @@ export class Viewport implements Equatable, Hashable, Serializable {
     // (undocumented)
     get orientation(): Viewport.Orientation;
     // (undocumented)
-    toJSON(): Viewport.JSON;
+    toJSON(options?: json.Serializable.Options): Viewport.JSON;
     // (undocumented)
     get width(): number;
 }

--- a/docs/review/api/alfa-graph.api.md
+++ b/docs/review/api/alfa-graph.api.md
@@ -14,7 +14,7 @@ import { Serializable } from '@siteimprove/alfa-json';
 import { Set as Set_2 } from '@siteimprove/alfa-set';
 
 // @public (undocumented)
-export class Graph<T> implements Iterable_2<[T, Iterable_2<T>]>, Equatable, Hashable, Serializable<Graph.JSON<T>> {
+export class Graph<T, O extends Serializable.Options = Serializable.Options> implements Iterable_2<[T, Iterable_2<T>]>, Equatable, Hashable, Serializable<Graph.JSON<T>, O> {
     // (undocumented)
     [Symbol.iterator](): Iterator<[T, Iterable_2<T>]>;
     // (undocumented)
@@ -58,7 +58,7 @@ export class Graph<T> implements Iterable_2<[T, Iterable_2<T>]>, Equatable, Hash
     // (undocumented)
     toArray(): Array<[T, Array<T>]>;
     // (undocumented)
-    toJSON(): Graph.JSON<T>;
+    toJSON(options?: O): Graph.JSON<T>;
     // (undocumented)
     toString(): string;
     // (undocumented)

--- a/docs/review/api/alfa-http.api.md
+++ b/docs/review/api/alfa-http.api.md
@@ -121,7 +121,7 @@ export class Header implements Equatable, json.Serializable<Header.JSON>, earl.S
     // (undocumented)
     toEARL(): Header.EARL;
     // (undocumented)
-    toJSON(): Header.JSON;
+    toJSON(options?: json.Serializable.Options): Header.JSON;
     // (undocumented)
     toString(): string;
     // (undocumented)
@@ -179,7 +179,7 @@ export class Headers implements Iterable_2<Header>, json.Serializable<Headers.JS
     // (undocumented)
     toEARL(): Headers.EARL;
     // (undocumented)
-    toJSON(): Headers.JSON;
+    toJSON(options?: json.Serializable.Options): Headers.JSON;
     // (undocumented)
     toString(): string;
 }
@@ -219,7 +219,7 @@ export class Request implements Body, json.Serializable<Request.JSON>, earl.Seri
     // (undocumented)
     toEARL(): Request.EARL;
     // (undocumented)
-    toJSON(): Request.JSON;
+    toJSON(options?: json.Serializable.Options): Request.JSON;
     // (undocumented)
     toString(): string;
     // (undocumented)
@@ -279,7 +279,7 @@ export class Response implements Body, json.Serializable<Response.JSON>, earl.Se
     // (undocumented)
     toEARL(): Response.EARL;
     // (undocumented)
-    toJSON(): Response.JSON;
+    toJSON(options?: json.Serializable.Options): Response.JSON;
     // (undocumented)
     toString(): string;
     // (undocumented)

--- a/docs/review/api/alfa-iterable.api.md
+++ b/docs/review/api/alfa-iterable.api.md
@@ -156,7 +156,7 @@ namespace Iterable_2 {
     // (undocumented)
     function takeWhile<T>(iterable: Iterable_2<T>, predicate: Predicate<T, [index: number]>): Iterable_2<T>;
     // (undocumented)
-    function toJSON<T>(iterable: Iterable_2<T>): Array<Serializable.ToJSON<T>>;
+    function toJSON<T, O extends Serializable.Options = Serializable.Options>(iterable: Iterable_2<T>, options?: O): Array<Serializable.ToJSON<T>>;
     // (undocumented)
     function trim<T>(iterable: Iterable_2<T>, predicate: Predicate<T, [index: number]>): Iterable_2<T>;
     // (undocumented)

--- a/docs/review/api/alfa-lazy.api.md
+++ b/docs/review/api/alfa-lazy.api.md
@@ -13,7 +13,7 @@ import { Serializable } from '@siteimprove/alfa-json';
 import { Thunk } from '@siteimprove/alfa-thunk';
 
 // @public (undocumented)
-export class Lazy<T> implements Functor<T>, Applicative<T>, Monad<T>, Iterable<T>, Equatable, Serializable<Lazy.JSON<T>> {
+export class Lazy<T, O extends Serializable.Options = Serializable.Options> implements Functor<T>, Applicative<T>, Monad<T>, Iterable<T>, Equatable, Serializable<Lazy.JSON<T>, O> {
     // (undocumented)
     [Symbol.iterator](): Iterator<T>;
     // (undocumented)
@@ -37,7 +37,7 @@ export class Lazy<T> implements Functor<T>, Applicative<T>, Monad<T>, Iterable<T
     // (undocumented)
     static of<T>(thunk: Thunk<T>): Lazy<T>;
     // (undocumented)
-    toJSON(): Lazy.JSON<T>;
+    toJSON(options?: O): Lazy.JSON<T>;
     // (undocumented)
     toString(): string;
     // (undocumented)

--- a/docs/review/api/alfa-list.api.md
+++ b/docs/review/api/alfa-list.api.md
@@ -20,6 +20,7 @@ import { Option } from '@siteimprove/alfa-option';
 import { Predicate } from '@siteimprove/alfa-predicate';
 import { Reducer } from '@siteimprove/alfa-reducer';
 import { Refinement } from '@siteimprove/alfa-refinement';
+import { Serializable } from '@siteimprove/alfa-json';
 
 // Warning: (ae-internal-missing-underscore) The name "Branch" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -85,7 +86,7 @@ export class Leaf<T> implements Node<T> {
 }
 
 // @public (undocumented)
-export class List<T> implements Collection.Indexed<T> {
+export class List<T, O extends Serializable.Options = Serializable.Options> implements Collection.Indexed<T, O> {
     // (undocumented)
     [Symbol.iterator](): Iterator<T>;
     // (undocumented)
@@ -221,7 +222,7 @@ export class List<T> implements Collection.Indexed<T> {
     // (undocumented)
     toArray(): Array_2<T>;
     // (undocumented)
-    toJSON(): List.JSON<T>;
+    toJSON(options?: O): List.JSON<T>;
     // (undocumented)
     toString(): string;
     // (undocumented)

--- a/docs/review/api/alfa-map.api.md
+++ b/docs/review/api/alfa-map.api.md
@@ -16,6 +16,7 @@ import { Option } from '@siteimprove/alfa-option';
 import { Predicate } from '@siteimprove/alfa-predicate';
 import { Reducer } from '@siteimprove/alfa-reducer';
 import { Refinement } from '@siteimprove/alfa-refinement';
+import { Serializable } from '@siteimprove/alfa-json';
 
 // Warning: (ae-internal-missing-underscore) The name "Collision" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -81,7 +82,7 @@ export class Leaf<K, V> implements Node<K, V> {
 }
 
 // @public (undocumented)
-class Map_2<K, V> implements Collection.Keyed<K, V> {
+class Map_2<K, V, O extends Serializable.Options = Serializable.Options> implements Collection.Keyed<K, V> {
     // (undocumented)
     [Symbol.iterator](): Iterator<[K, V]>;
     apply<U>(mapper: Map_2<K, Mapper<V, U>>): Map_2<K, U>;
@@ -160,7 +161,7 @@ class Map_2<K, V> implements Collection.Keyed<K, V> {
     // (undocumented)
     toArray(): Array_2<[K, V]>;
     // (undocumented)
-    toJSON(): Map_2.JSON<K, V>;
+    toJSON(options?: O): Map_2.JSON<K, V>;
     // (undocumented)
     toString(): string;
     // (undocumented)

--- a/docs/review/api/alfa-media.api.md
+++ b/docs/review/api/alfa-media.api.md
@@ -74,7 +74,7 @@ export namespace Media {
     list: typeof List.of, // (undocumented)
     isList: typeof List.isList;
     const // (undocumented)
-    parse: Parser<Slice<Token>, List, string, []>;
+    parse: Parser<Slice<Token, Serializable.Options>, List, string, []>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/docs/review/api/alfa-option.api.md
+++ b/docs/review/api/alfa-option.api.md
@@ -53,7 +53,7 @@ export namespace None {
 }
 
 // @public (undocumented)
-export interface Option<T> extends Functor<T>, Applicative<T>, Monad<T>, Foldable<T>, Iterable<T>, Equatable, Hashable, Serializable<Option.JSON<T>> {
+export interface Option<T, O extends Serializable.Options = Serializable.Options> extends Functor<T>, Applicative<T>, Monad<T>, Foldable<T>, Iterable<T>, Equatable, Hashable, Serializable<Option.JSON<T>, O> {
     // (undocumented)
     and<U>(option: Option<U>): Option<U>;
     // (undocumented)
@@ -115,7 +115,7 @@ export interface Option<T> extends Functor<T>, Applicative<T>, Monad<T>, Foldabl
     // (undocumented)
     toArray(): Array<T>;
     // (undocumented)
-    toJSON(): Option.JSON<T>;
+    toJSON(options?: O): Option.JSON<T>;
 }
 
 // @public (undocumented)
@@ -143,7 +143,7 @@ export namespace Option {
 }
 
 // @public (undocumented)
-export class Some<T> implements Option<T> {
+export class Some<T, O extends Serializable.Options = Serializable.Options> implements Option<T, O> {
     // (undocumented)
     [Symbol.iterator](): Iterator<T>;
     // (undocumented)
@@ -209,7 +209,7 @@ export class Some<T> implements Option<T> {
     // (undocumented)
     toArray(): [T];
     // (undocumented)
-    toJSON(): Some.JSON<T>;
+    toJSON(options?: O): Some.JSON<T>;
     // (undocumented)
     toString(): string;
 }

--- a/docs/review/api/alfa-record.api.md
+++ b/docs/review/api/alfa-record.api.md
@@ -13,7 +13,7 @@ import { Reducer } from '@siteimprove/alfa-reducer';
 import { Serializable } from '@siteimprove/alfa-json';
 
 // @public (undocumented)
-class Record_2<T> implements Foldable<Record_2.Value<T>>, Iterable_2<Record_2.Entry<T>>, Equatable, Serializable<Record_2.JSON<T>> {
+class Record_2<T, O extends Serializable.Options = Serializable.Options> implements Foldable<Record_2.Value<T>>, Iterable_2<Record_2.Entry<T>>, Equatable, Serializable<Record_2.JSON<T>, O> {
     // (undocumented)
     [Symbol.iterator](): Iterator<Record_2.Entry<T>>;
     // (undocumented)
@@ -41,7 +41,7 @@ class Record_2<T> implements Foldable<Record_2.Value<T>>, Iterable_2<Record_2.En
     // (undocumented)
     toArray(): Array<Record_2.Entry<T>>;
     // (undocumented)
-    toJSON(): Record_2.JSON<T>;
+    toJSON(options?: O): Record_2.JSON<T>;
     // (undocumented)
     toString(): string;
     // (undocumented)

--- a/docs/review/api/alfa-result.api.md
+++ b/docs/review/api/alfa-result.api.md
@@ -23,7 +23,7 @@ import { Serializable } from '@siteimprove/alfa-json';
 import { Thunk } from '@siteimprove/alfa-thunk';
 
 // @public (undocumented)
-export class Err<E> implements Result<never, E> {
+export class Err<E, O extends Serializable.Options = Serializable.Options> implements Result<never, E, O> {
     // (undocumented)
     [Symbol.iterator](): Generator<never, void, unknown>;
     // (undocumented)
@@ -97,7 +97,7 @@ export class Err<E> implements Result<never, E> {
     // (undocumented)
     teeErr(callback: Callback<E>): Err<E>;
     // (undocumented)
-    toJSON(): Err.JSON<E>;
+    toJSON(options?: O): Err.JSON<E>;
     // (undocumented)
     toString(): string;
 }
@@ -120,7 +120,7 @@ export namespace Err {
 }
 
 // @public (undocumented)
-export class Ok<T> implements Result<T, never> {
+export class Ok<T, O extends Serializable.Options = Serializable.Options> implements Result<T, never, O> {
     // (undocumented)
     [Symbol.iterator](): Generator<T, void, unknown>;
     // (undocumented)
@@ -194,7 +194,7 @@ export class Ok<T> implements Result<T, never> {
     // (undocumented)
     teeErr(): Ok<T>;
     // (undocumented)
-    toJSON(): Ok.JSON<T>;
+    toJSON(options?: O): Ok.JSON<T>;
     // (undocumented)
     toString(): string;
 }
@@ -217,7 +217,7 @@ export namespace Ok {
 }
 
 // @public (undocumented)
-export interface Result<T, E = T> extends Functor<T>, Applicative<T>, Monad<T>, Foldable<T>, Iterable<T>, Equatable, Hashable, Serializable<Result.JSON<T, E>> {
+export interface Result<T, E = T, O extends Serializable.Options = Serializable.Options> extends Functor<T>, Applicative<T>, Monad<T>, Foldable<T>, Iterable<T>, Equatable, Hashable, Serializable<Result.JSON<T, E>, O> {
     // (undocumented)
     and<U, F>(result: Result<U, F>): Result<U, E | F>;
     // (undocumented)
@@ -293,7 +293,7 @@ export interface Result<T, E = T> extends Functor<T>, Applicative<T>, Monad<T>, 
     // (undocumented)
     teeErr(callback: Callback<E>): Result<T, E>;
     // (undocumented)
-    toJSON(): Result.JSON<T, E>;
+    toJSON(options?: O): Result.JSON<T, E>;
 }
 
 // @public (undocumented)

--- a/docs/review/api/alfa-rules.api.md
+++ b/docs/review/api/alfa-rules.api.md
@@ -22,6 +22,7 @@ import { RGB } from '@siteimprove/alfa-css';
 import { Rule } from '@siteimprove/alfa-act';
 import * as sarif from '@siteimprove/alfa-sarif';
 import { Sequence } from '@siteimprove/alfa-sequence';
+import { Serializable } from '@siteimprove/alfa-json';
 import { Tag } from '@siteimprove/alfa-act';
 import { Text as Text_2 } from '@siteimprove/alfa-dom';
 
@@ -117,7 +118,7 @@ export namespace Flattened {
 }
 
 // @public
-const FlattenedRules: Sequence<Flattened.Rule>;
+const FlattenedRules: Sequence<Flattened.Rule, Serializable.Options>;
 export default FlattenedRules;
 
 // @public (undocumented)
@@ -339,7 +340,7 @@ export namespace Question {
 export type Rules = typeof Rules;
 
 // @public
-export const Rules: Record_2<typeof rules>;
+export const Rules: Record_2<typeof rules, Serializable.Options>;
 
 // @public (undocumented)
 export class Scope<S extends string = string> extends Tag<"scope"> {

--- a/docs/review/api/alfa-selector.api.md
+++ b/docs/review/api/alfa-selector.api.md
@@ -100,7 +100,7 @@ export namespace Attribute {
         CaseSensitive = "s"
     }
     const // @internal (undocumented)
-    parse: Parser<Slice<Token>, Attribute, string, []>;
+    parse: Parser<Slice<Token, Serializable.Options>, Attribute, string, []>;
 }
 
 // @public (undocumented)
@@ -131,7 +131,7 @@ export namespace Class {
     export interface JSON extends WithName.JSON<"class"> {
     }
     const // @internal (undocumented)
-    parse: Parser<Slice<Token>, Class, string, []>;
+    parse: Parser<Slice<Token, Serializable.Options>, Class, string, []>;
 }
 
 // @public (undocumented)
@@ -193,7 +193,7 @@ export namespace Complex {
         right: Simple.JSON | Compound.JSON;
     }
     const // @internal (undocumented)
-    parseComplex: (parseSelector: Thunk<Parser_2<Absolute>>) => Parser<Slice<Token>, Simple | Compound | Complex, string, []>;
+    parseComplex: (parseSelector: Thunk<Parser_2<Absolute>>) => Parser<Slice<Token, Serializable.Options>, Simple | Compound | Complex, string, []>;
 }
 
 // @public (undocumented)
@@ -230,7 +230,7 @@ export namespace Compound {
         selectors: Array_2<Simple.JSON>;
     }
     const // @internal (undocumented)
-    parseCompound: (parseSelector: () => Parser<Slice<Token>, Absolute, string>) => Parser<Slice<Token>, Simple | Compound, string, []>;
+    parseCompound: (parseSelector: () => Parser<Slice<Token>, Absolute, string>) => Parser<Slice<Token, Serializable.Options>, Simple | Compound, string, []>;
 }
 
 // @public (undocumented)
@@ -322,7 +322,7 @@ export namespace Id {
     export interface JSON extends WithName.JSON<"id"> {
     }
     const // @internal (undocumented)
-    parse: Parser<Slice<Token>, Id, string, []>;
+    parse: Parser<Slice<Token, Serializable.Options>, Id, string, []>;
 }
 
 // Warning: (ae-forgotten-export) The symbol "Item" needs to be exported by the entry point index.d.ts
@@ -357,7 +357,7 @@ export namespace List {
         selectors: Array_2<Serializable.ToJSON<T>>;
     }
     const // @internal (undocumented)
-    parseList: (parseSelector: Thunk<Parser_2<Absolute>>) => Parser<Slice<Token>, List<Simple | Compound | Complex>, string, []>;
+    parseList: (parseSelector: Thunk<Parser_2<Absolute>>) => Parser<Slice<Token, Serializable.Options>, List<Simple | Compound | Complex>, string, []>;
 }
 
 // Warning: (ae-forgotten-export) The symbol "Active" needs to be exported by the entry point index.d.ts
@@ -499,7 +499,7 @@ export namespace Simple {
     // (undocumented)
     export type JSON = Type.JSON | Universal.JSON | Attribute.JSON | Class.JSON | Id.JSON | PseudoClass.JSON | PseudoElement.JSON;
     const // @internal (undocumented)
-    parse: (parseSelector: Thunk<Parser_2<Absolute>>) => Parser<Slice<Token>, Simple, string, []>;
+    parse: (parseSelector: Thunk<Parser_2<Absolute>>) => Parser<Slice<Token, Serializable.Options>, Simple, string, []>;
 }
 
 // @public (undocumented)
@@ -583,7 +583,7 @@ export namespace Type {
         namespace: string | null;
     }
     const // @internal (undocumented)
-    parse: Parser<Slice<Token>, Type, string, []>;
+    parse: Parser<Slice<Token, Serializable.Options>, Type, string, []>;
 }
 
 // @public (undocumented)
@@ -618,7 +618,7 @@ export namespace Universal {
         namespace: string | null;
     }
     const // (undocumented)
-    parse: Parser<Slice<Token>, Universal, string, []>;
+    parse: Parser<Slice<Token, Serializable.Options>, Universal, string, []>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/docs/review/api/alfa-sequence.api.md
+++ b/docs/review/api/alfa-sequence.api.md
@@ -19,10 +19,11 @@ import { Option } from '@siteimprove/alfa-option';
 import { Predicate } from '@siteimprove/alfa-predicate';
 import { Reducer } from '@siteimprove/alfa-reducer';
 import { Refinement } from '@siteimprove/alfa-refinement';
+import { Serializable } from '@siteimprove/alfa-json';
 import { Set as Set_2 } from '@siteimprove/alfa-set';
 
 // @public (undocumented)
-export class Cons<T> implements Sequence<T> {
+export class Cons<T, O extends Serializable.Options = Serializable.Options> implements Sequence<T, O> {
     // (undocumented)
     [Symbol.iterator](): Iterator<T>;
     // (undocumented)
@@ -168,7 +169,7 @@ export class Cons<T> implements Sequence<T> {
     // (undocumented)
     toArray(): Array_2<T>;
     // (undocumented)
-    toJSON(): Cons.JSON<T>;
+    toJSON(options?: O): Cons.JSON<T>;
     // (undocumented)
     toString(): string;
     // (undocumented)
@@ -205,7 +206,7 @@ export namespace Nil {
 }
 
 // @public (undocumented)
-export interface Sequence<T> extends Collection.Indexed<T> {
+export interface Sequence<T, O extends Serializable.Options = Serializable.Options> extends Collection.Indexed<T, O> {
     // (undocumented)
     append(value: T): Sequence<T>;
     // (undocumented)
@@ -327,7 +328,7 @@ export interface Sequence<T> extends Collection.Indexed<T> {
     // (undocumented)
     toArray(): Array_2<T>;
     // (undocumented)
-    toJSON(): Sequence.JSON<T>;
+    toJSON(options?: O): Sequence.JSON<T>;
     // (undocumented)
     trim(predicate: Predicate<T, [index: number]>): Sequence<T>;
     // (undocumented)

--- a/docs/review/api/alfa-set.api.md
+++ b/docs/review/api/alfa-set.api.md
@@ -14,9 +14,10 @@ import { Option } from '@siteimprove/alfa-option';
 import { Predicate } from '@siteimprove/alfa-predicate';
 import { Reducer } from '@siteimprove/alfa-reducer';
 import { Refinement } from '@siteimprove/alfa-refinement';
+import { Serializable } from '@siteimprove/alfa-json';
 
 // @public (undocumented)
-class Set_2<T> implements Collection.Unkeyed<T> {
+class Set_2<T, O extends Serializable.Options = Serializable.Options> implements Collection.Unkeyed<T, O> {
     // (undocumented)
     [Symbol.iterator](): Iterator<T>;
     // (undocumented)
@@ -94,7 +95,7 @@ class Set_2<T> implements Collection.Unkeyed<T> {
     // (undocumented)
     toArray(): Array_2<T>;
     // (undocumented)
-    toJSON(): Set_2.JSON<T>;
+    toJSON(options?: O): Set_2.JSON<T>;
     // (undocumented)
     toString(): string;
 }

--- a/docs/review/api/alfa-slice.api.md
+++ b/docs/review/api/alfa-slice.api.md
@@ -20,7 +20,7 @@ import { Refinement } from '@siteimprove/alfa-refinement';
 import { Serializable } from '@siteimprove/alfa-json';
 
 // @public (undocumented)
-export class Slice<T> implements Collection.Indexed<T> {
+export class Slice<T, O extends Serializable.Options = Serializable.Options> implements Collection.Indexed<T, O> {
     // (undocumented)
     [Symbol.iterator](): Iterator<T>;
     // (undocumented)
@@ -158,7 +158,7 @@ export class Slice<T> implements Collection.Indexed<T> {
     // (undocumented)
     toArray(): Array_2<T>;
     // (undocumented)
-    toJSON(): Slice.JSON<T>;
+    toJSON(options?: O): Slice.JSON<T>;
     // (undocumented)
     toString(): string;
     // (undocumented)

--- a/docs/review/api/alfa-web.api.md
+++ b/docs/review/api/alfa-web.api.md
@@ -9,6 +9,7 @@ import { Document as Document_2 } from '@siteimprove/alfa-dom';
 import * as earl from '@siteimprove/alfa-earl';
 import { Graph } from '@siteimprove/alfa-graph';
 import * as json from '@siteimprove/alfa-json';
+import { Node as Node_2 } from '@siteimprove/alfa-dom';
 import { Request as Request_2 } from '@siteimprove/alfa-http';
 import { Response as Response_2 } from '@siteimprove/alfa-http';
 import { Result } from '@siteimprove/alfa-result';
@@ -29,7 +30,7 @@ export class Page implements Resource, json.Serializable<Page.JSON>, earl.Serial
     // (undocumented)
     toEARL(): Page.EARL;
     // (undocumented)
-    toJSON(): Page.JSON;
+    toJSON(options?: Node_2.SerializationOptions): Page.JSON;
     // (undocumented)
     toSARIF(): sarif.Artifact;
 }

--- a/docs/review/api/alfa-xpath.api.md
+++ b/docs/review/api/alfa-xpath.api.md
@@ -952,7 +952,7 @@ export namespace Token {
         }
     }
     const // (undocumented)
-    parseInteger: Parser_2<Slice<Token>, Integer, string, []>;
+    parseInteger: Parser_2<Slice<Token, Serializable.Options>, Integer, string, []>;
     // (undocumented)
     export class Decimal implements Equatable, Serializable<Decimal.JSON> {
         // (undocumented)
@@ -996,7 +996,7 @@ export namespace Token {
         get value(): number;
     }
     const // (undocumented)
-    parseDecimal: Parser_2<Slice<Token>, Decimal, string, []>;
+    parseDecimal: Parser_2<Slice<Token, Serializable.Options>, Decimal, string, []>;
     // (undocumented)
     export namespace Double {
         // (undocumented)
@@ -1037,7 +1037,7 @@ export namespace Token {
         }
     }
     const // (undocumented)
-    parseDouble: Parser_2<Slice<Token>, Double, string, []>;
+    parseDouble: Parser_2<Slice<Token, Serializable.Options>, Double, string, []>;
     // (undocumented)
     export function isCharacter(value: unknown): value is Character;
     // (undocumented)
@@ -1045,7 +1045,7 @@ export namespace Token {
     // (undocumented)
     export function isDecimal(value: unknown): value is Decimal;
     const // (undocumented)
-    parseString: Parser_2<Slice<Token>, String, string, []>;
+    parseString: Parser_2<Slice<Token, Serializable.Options>, String, string, []>;
     // (undocumented)
     export function isDouble(value: unknown): value is Double;
     // (undocumented)
@@ -1053,7 +1053,7 @@ export namespace Token {
     // (undocumented)
     export function isName(value: unknown): value is Name;
     const // (undocumented)
-    parseComment: Parser_2<Slice<Token>, Comment, string, []>;
+    parseComment: Parser_2<Slice<Token, Serializable.Options>, Comment, string, []>;
     // (undocumented)
     export function isString(value: unknown): value is String;
     // (undocumented)
@@ -1076,7 +1076,7 @@ export namespace Token {
         get value(): string;
     }
     const // (undocumented)
-    parseName: (query?: string | Predicate<Name>) => Parser_2<Slice<Token>, Name, string, []>;
+    parseName: (query?: string | Predicate<Name>) => Parser_2<Slice<Token, Serializable.Options>, Name, string, []>;
     // (undocumented)
     export namespace Name {
         // (undocumented)
@@ -1119,7 +1119,7 @@ export namespace Token {
         }
     }
     const // (undocumented)
-    parseCharacter: (query?: string | Predicate<Character>) => Parser_2<Slice<Token>, Character, string, []>;
+    parseCharacter: (query?: string | Predicate<Character>) => Parser_2<Slice<Token, Serializable.Options>, Character, string, []>;
 }
 
 // @public (undocumented)

--- a/packages/alfa-array/src/array.ts
+++ b/packages/alfa-array/src/array.ts
@@ -534,9 +534,10 @@ export namespace Array {
     return array[Symbol.iterator]();
   }
 
-  export function toJSON<T>(
-    array: ReadonlyArray<T>,
-  ): Array<Serializable.ToJSON<T>> {
-    return array.map((value) => Serializable.toJSON(value));
+  export function toJSON<
+    T,
+    O extends Serializable.Options = Serializable.Options,
+  >(array: ReadonlyArray<T>, options?: O): Array<Serializable.ToJSON<T>> {
+    return array.map((value) => Serializable.toJSON(value, options));
   }
 }

--- a/packages/alfa-collection/src/collection.ts
+++ b/packages/alfa-collection/src/collection.ts
@@ -57,10 +57,13 @@ export interface Collection<T>
  * @public
  */
 export namespace Collection {
-  export interface Keyed<K, V>
-    extends Collection<V>,
+  export interface Keyed<
+    K,
+    V,
+    O extends Serializable.Options = Serializable.Options,
+  > extends Collection<V>,
       Iterable<[K, V]>,
-      Serializable<Keyed.JSON<K, V>> {
+      Serializable<Keyed.JSON<K, V>, O> {
     isEmpty(): this is Keyed<K, never>;
     forEach(callback: Callback<V, void, [key: K]>): void;
     map<U>(mapper: Mapper<V, U, [key: K]>): Keyed<K, U>;
@@ -103,10 +106,12 @@ export namespace Collection {
     >;
   }
 
-  export interface Unkeyed<T>
-    extends Collection<T>,
+  export interface Unkeyed<
+    T,
+    O extends Serializable.Options = Serializable.Options,
+  > extends Collection<T>,
       Iterable<T>,
-      Serializable<Unkeyed.JSON<T>> {
+      Serializable<Unkeyed.JSON<T>, O> {
     isEmpty(): this is Unkeyed<never>;
     forEach(callback: Callback<T>): void;
     map<U>(mapper: Mapper<T, U>): Unkeyed<U>;
@@ -145,11 +150,13 @@ export namespace Collection {
     export type JSON<T> = Array<Serializable.ToJSON<T>>;
   }
 
-  export interface Indexed<T>
-    extends Collection<T>,
+  export interface Indexed<
+    T,
+    O extends Serializable.Options = Serializable.Options,
+  > extends Collection<T>,
       Iterable<T>,
       Comparable<Iterable<T>>,
-      Serializable<Indexed.JSON<T>> {
+      Serializable<Indexed.JSON<T>, O> {
     isEmpty(): this is Indexed<never>;
     forEach(callback: Callback<T, void, [index: number]>): void;
     map<U>(mapper: Mapper<T, U, [index: number]>): Indexed<U>;

--- a/packages/alfa-device/src/device.ts
+++ b/packages/alfa-device/src/device.ts
@@ -117,14 +117,14 @@ export class Device implements Equatable, Hashable, Serializable {
       .writeHashable(this._preferences);
   }
 
-  public toJSON(): Device.JSON {
+  public toJSON(options?: json.Serializable.Options): Device.JSON {
     return {
       type: this._type,
-      viewport: this._viewport.toJSON(),
-      display: this._display.toJSON(),
-      scripting: this._scripting.toJSON(),
+      viewport: this._viewport.toJSON(options),
+      display: this._display.toJSON(options),
+      scripting: this._scripting.toJSON(options),
       preferences: [...this._preferences.values()].map((preferece) =>
-        preferece.toJSON(),
+        preferece.toJSON(options),
       ),
     };
   }

--- a/packages/alfa-device/src/display.ts
+++ b/packages/alfa-device/src/display.ts
@@ -57,7 +57,7 @@ export class Display implements Equatable, Hashable, Serializable {
     }
   }
 
-  public toJSON(): Display.JSON {
+  public toJSON(options?: json.Serializable.Options): Display.JSON {
     return {
       resolution: this._resolution,
       scan: this._scan,

--- a/packages/alfa-device/src/preference.ts
+++ b/packages/alfa-device/src/preference.ts
@@ -47,7 +47,7 @@ export class Preference<N extends Preference.Name = Preference.Name>
     hash.writeString(this._name).writeString(this._value);
   }
 
-  public toJSON(): Preference.JSON<N> {
+  public toJSON(options?: json.Serializable.Options): Preference.JSON<N> {
     return {
       name: this._name,
       value: this._value,

--- a/packages/alfa-device/src/scripting.ts
+++ b/packages/alfa-device/src/scripting.ts
@@ -38,7 +38,7 @@ export class Scripting implements Equatable, Hashable, Serializable {
     hash.writeBoolean(this._enabled);
   }
 
-  public toJSON(): Scripting.JSON {
+  public toJSON(options?: json.Serializable.Options): Scripting.JSON {
     return {
       enabled: this._enabled,
     };

--- a/packages/alfa-device/src/viewport.ts
+++ b/packages/alfa-device/src/viewport.ts
@@ -81,7 +81,7 @@ export class Viewport implements Equatable, Hashable, Serializable {
     }
   }
 
-  public toJSON(): Viewport.JSON {
+  public toJSON(options?: json.Serializable.Options): Viewport.JSON {
     return {
       width: this._width,
       height: this._height,

--- a/packages/alfa-graph/src/graph.ts
+++ b/packages/alfa-graph/src/graph.ts
@@ -9,12 +9,12 @@ import { Set } from "@siteimprove/alfa-set";
 /**
  * @public
  */
-export class Graph<T>
+export class Graph<T, O extends Serializable.Options = Serializable.Options>
   implements
     Iterable<[T, Iterable<T>]>,
     Equatable,
     Hashable,
-    Serializable<Graph.JSON<T>>
+    Serializable<Graph.JSON<T>, O>
 {
   public static of<T>(nodes: Map<T, Set<T>>): Graph<T> {
     return new Graph(nodes);
@@ -214,10 +214,10 @@ export class Graph<T>
     return [...this].map(([node, neighbors]) => [node, [...neighbors]]);
   }
 
-  public toJSON(): Graph.JSON<T> {
+  public toJSON(options?: O): Graph.JSON<T> {
     return this.toArray().map(([node, neighbors]) => [
-      Serializable.toJSON(node),
-      neighbors.map((node) => Serializable.toJSON(node)),
+      Serializable.toJSON(node, options),
+      neighbors.map((node) => Serializable.toJSON(node, options)),
     ]);
   }
 

--- a/packages/alfa-http/src/header.ts
+++ b/packages/alfa-http/src/header.ts
@@ -44,7 +44,7 @@ export class Header
     );
   }
 
-  public toJSON(): Header.JSON {
+  public toJSON(options?: json.Serializable.Options): Header.JSON {
     return {
       name: this._name,
       value: this._value,

--- a/packages/alfa-http/src/headers.ts
+++ b/packages/alfa-http/src/headers.ts
@@ -63,8 +63,8 @@ export class Headers
     return [...this];
   }
 
-  public toJSON(): Headers.JSON {
-    return this.toArray().map((header) => header.toJSON());
+  public toJSON(options?: json.Serializable.Options): Headers.JSON {
+    return this.toArray().map((header) => header.toJSON(options));
   }
 
   public toEARL(): Headers.EARL {

--- a/packages/alfa-http/src/request.ts
+++ b/packages/alfa-http/src/request.ts
@@ -79,11 +79,11 @@ export class Request
     return this._body;
   }
 
-  public toJSON(): Request.JSON {
+  public toJSON(options?: json.Serializable.Options): Request.JSON {
     return {
       method: this._method,
       url: this._url.toString(),
-      headers: this._headers.toJSON(),
+      headers: this._headers.toJSON(options),
       body: Decoder.decode(new Uint8Array(this._body)),
     };
   }

--- a/packages/alfa-http/src/response.ts
+++ b/packages/alfa-http/src/response.ts
@@ -79,11 +79,11 @@ export class Response
     return this._body;
   }
 
-  public toJSON(): Response.JSON {
+  public toJSON(options?: json.Serializable.Options): Response.JSON {
     return {
       url: this._url.toString(),
       status: this._status,
-      headers: this._headers.toJSON(),
+      headers: this._headers.toJSON(options),
       body: Decoder.decode(new Uint8Array(this._body)),
     };
   }

--- a/packages/alfa-iterable/src/iterable.ts
+++ b/packages/alfa-iterable/src/iterable.ts
@@ -852,9 +852,10 @@ export namespace Iterable {
     return groups;
   }
 
-  export function toJSON<T>(
-    iterable: Iterable<T>,
-  ): Array<Serializable.ToJSON<T>> {
-    return [...map(iterable, (value) => Serializable.toJSON(value))];
+  export function toJSON<
+    T,
+    O extends Serializable.Options = Serializable.Options,
+  >(iterable: Iterable<T>, options?: O): Array<Serializable.ToJSON<T>> {
+    return [...map(iterable, (value) => Serializable.toJSON(value, options))];
   }
 }

--- a/packages/alfa-lazy/src/lazy.ts
+++ b/packages/alfa-lazy/src/lazy.ts
@@ -10,14 +10,14 @@ import { Trampoline } from "@siteimprove/alfa-trampoline";
 /**
  * @public
  */
-export class Lazy<T>
+export class Lazy<T, O extends Serializable.Options = Serializable.Options>
   implements
     Functor<T>,
     Applicative<T>,
     Monad<T>,
     Iterable<T>,
     Equatable,
-    Serializable<Lazy.JSON<T>>
+    Serializable<Lazy.JSON<T>, O>
 {
   public static of<T>(thunk: Thunk<T>): Lazy<T> {
     return new Lazy(Trampoline.delay(thunk));
@@ -95,8 +95,8 @@ export class Lazy<T>
     return () => this.force();
   }
 
-  public toJSON(): Lazy.JSON<T> {
-    return Serializable.toJSON(this.force());
+  public toJSON(options?: O): Lazy.JSON<T> {
+    return Serializable.toJSON(this.force(), options);
   }
 
   public toString(): string {

--- a/packages/alfa-list/src/list.ts
+++ b/packages/alfa-list/src/list.ts
@@ -21,7 +21,9 @@ const { compareComparable } = Comparable;
 /**
  * @public
  */
-export class List<T> implements Collection.Indexed<T> {
+export class List<T, O extends Serializable.Options = Serializable.Options>
+  implements Collection.Indexed<T, O>
+{
   public static of<T>(...values: Array<T>): List<T> {
     const size = values.length;
 
@@ -480,8 +482,8 @@ export class List<T> implements Collection.Indexed<T> {
     return [...this];
   }
 
-  public toJSON(): List.JSON<T> {
-    return this.toArray().map((value) => Serializable.toJSON(value));
+  public toJSON(options?: O): List.JSON<T> {
+    return this.toArray().map((value) => Serializable.toJSON(value, options));
   }
 
   public toString(): string {

--- a/packages/alfa-map/src/map.ts
+++ b/packages/alfa-map/src/map.ts
@@ -18,7 +18,9 @@ const { not } = Predicate;
 /**
  * @public
  */
-export class Map<K, V> implements Collection.Keyed<K, V> {
+export class Map<K, V, O extends Serializable.Options = Serializable.Options>
+  implements Collection.Keyed<K, V>
+{
   public static of<K, V>(...entries: Array<readonly [K, V]>): Map<K, V> {
     return entries.reduce(
       (map, [key, value]) => map.set(key, value),
@@ -291,10 +293,10 @@ export class Map<K, V> implements Collection.Keyed<K, V> {
     return [...this];
   }
 
-  public toJSON(): Map.JSON<K, V> {
+  public toJSON(options?: O): Map.JSON<K, V> {
     return this.toArray().map(([key, value]) => [
-      Serializable.toJSON(key),
-      Serializable.toJSON(value),
+      Serializable.toJSON(key, options),
+      Serializable.toJSON(value, options),
     ]);
   }
 

--- a/packages/alfa-option/src/option.ts
+++ b/packages/alfa-option/src/option.ts
@@ -19,15 +19,17 @@ import { Some } from "./some";
 /**
  * @public
  */
-export interface Option<T>
-  extends Functor<T>,
+export interface Option<
+  T,
+  O extends Serializable.Options = Serializable.Options,
+> extends Functor<T>,
     Applicative<T>,
     Monad<T>,
     Foldable<T>,
     Iterable<T>,
     Equatable,
     Hashable,
-    Serializable<Option.JSON<T>> {
+    Serializable<Option.JSON<T>, O> {
   isSome(): this is Some<T>;
   isNone(): this is None;
   map<U>(mapper: Mapper<T, U>): Option<U>;
@@ -67,7 +69,7 @@ export interface Option<T>
   compare<T>(this: Option<Comparable<T>>, option: Option<T>): Comparison;
   compareWith<U = T>(option: Option<U>, comparer: Comparer<T, U>): Comparison;
   toArray(): Array<T>;
-  toJSON(): Option.JSON<T>;
+  toJSON(options?: O): Option.JSON<T>;
 }
 
 /**

--- a/packages/alfa-option/src/some.ts
+++ b/packages/alfa-option/src/some.ts
@@ -19,7 +19,9 @@ const { compareComparable } = Comparable;
 /**
  * @public
  */
-export class Some<T> implements Option<T> {
+export class Some<T, O extends Serializable.Options = Serializable.Options>
+  implements Option<T, O>
+{
   public static of<T>(value: T): Some<T> {
     return new Some(value);
   }
@@ -168,10 +170,10 @@ export class Some<T> implements Option<T> {
     return [this._value];
   }
 
-  public toJSON(): Some.JSON<T> {
+  public toJSON(options?: O): Some.JSON<T> {
     return {
       type: "some",
-      value: Serializable.toJSON(this._value),
+      value: Serializable.toJSON(this._value, options),
     };
   }
 

--- a/packages/alfa-record/src/record.ts
+++ b/packages/alfa-record/src/record.ts
@@ -12,12 +12,12 @@ import * as json from "@siteimprove/alfa-json";
 /**
  * @public
  */
-export class Record<T>
+export class Record<T, O extends Serializable.Options = Serializable.Options>
   implements
     Foldable<Record.Value<T>>,
     Iterable<Record.Entry<T>>,
     Equatable,
-    Serializable<Record.JSON<T>>
+    Serializable<Record.JSON<T>, O>
 {
   public static of<T>(properties: T): Record<T> {
     const keys = Object.keys(properties ?? {}).sort() as Array<Record.Key<T>>;
@@ -125,11 +125,11 @@ export class Record<T>
     return [...this];
   }
 
-  public toJSON(): Record.JSON<T> {
+  public toJSON(options?: O): Record.JSON<T> {
     const json: { [key: string]: json.JSON } = {};
 
     for (const [key, value] of this) {
-      json[key] = Serializable.toJSON(value);
+      json[key] = Serializable.toJSON(value, options);
     }
 
     return json as Record.JSON<T>;

--- a/packages/alfa-result/src/err.ts
+++ b/packages/alfa-result/src/err.ts
@@ -17,7 +17,9 @@ const { not, test } = Predicate;
 /**
  * @public
  */
-export class Err<E> implements Result<never, E> {
+export class Err<E, O extends Serializable.Options = Serializable.Options>
+  implements Result<never, E, O>
+{
   public static of<E>(error: E): Err<E> {
     return new Err(error);
   }
@@ -173,10 +175,10 @@ export class Err<E> implements Result<never, E> {
 
   public *[Symbol.iterator]() {}
 
-  public toJSON(): Err.JSON<E> {
+  public toJSON(options?: O): Err.JSON<E> {
     return {
       type: "err",
-      error: Serializable.toJSON(this._error),
+      error: Serializable.toJSON(this._error, options),
     };
   }
 

--- a/packages/alfa-result/src/ok.ts
+++ b/packages/alfa-result/src/ok.ts
@@ -18,7 +18,9 @@ const { not, test } = Predicate;
 /**
  * @public
  */
-export class Ok<T> implements Result<T, never> {
+export class Ok<T, O extends Serializable.Options = Serializable.Options>
+  implements Result<T, never, O>
+{
   public static of<T>(value: T): Ok<T> {
     return new Ok(value);
   }
@@ -176,10 +178,10 @@ export class Ok<T> implements Result<T, never> {
     yield this._value;
   }
 
-  public toJSON(): Ok.JSON<T> {
+  public toJSON(options?: O): Ok.JSON<T> {
     return {
       type: "ok",
-      value: Serializable.toJSON(this._value),
+      value: Serializable.toJSON(this._value, options),
     };
   }
 

--- a/packages/alfa-result/src/result.ts
+++ b/packages/alfa-result/src/result.ts
@@ -19,15 +19,18 @@ import { Ok } from "./ok";
 /**
  * @public
  */
-export interface Result<T, E = T>
-  extends Functor<T>,
+export interface Result<
+  T,
+  E = T,
+  O extends Serializable.Options = Serializable.Options,
+> extends Functor<T>,
     Applicative<T>,
     Monad<T>,
     Foldable<T>,
     Iterable<T>,
     Equatable,
     Hashable,
-    Serializable<Result.JSON<T, E>> {
+    Serializable<Result.JSON<T, E>, O> {
   isOk(): this is Ok<T>;
   isErr(): this is Err<E>;
   map<U>(mapper: Mapper<T, U>): Result<U, E>;
@@ -83,7 +86,7 @@ export interface Result<T, E = T>
   err(): Option<E>;
   tee(callback: Callback<T>): Result<T, E>;
   teeErr(callback: Callback<E>): Result<T, E>;
-  toJSON(): Result.JSON<T, E>;
+  toJSON(options?: O): Result.JSON<T, E>;
 }
 
 /**

--- a/packages/alfa-rules/test/common/evaluate.ts
+++ b/packages/alfa-rules/test/common/evaluate.ts
@@ -1,14 +1,14 @@
 import type { Rule, Outcome, Oracle, Question } from "@siteimprove/alfa-act";
+import { Array } from "@siteimprove/alfa-array";
 import { Device } from "@siteimprove/alfa-device";
 import { Document } from "@siteimprove/alfa-dom";
 import { Future } from "@siteimprove/alfa-future";
 import type { Hashable } from "@siteimprove/alfa-hash";
 import { Request, Response } from "@siteimprove/alfa-http";
+import { Serializable } from "@siteimprove/alfa-json";
 import { None } from "@siteimprove/alfa-option";
 import { URL } from "@siteimprove/alfa-url";
 import { Page } from "@siteimprove/alfa-web";
-
-import * as json from "@siteimprove/alfa-json";
 
 // Creating these once allow to actually trigger caches in rules that rely on them.
 const defaultRequest = Request.of("GET", URL.example());
@@ -16,11 +16,16 @@ const defaultResponse = Response.of(URL.example(), 200);
 const defaultDocument = Document.empty();
 const defaultDevice = Device.standard();
 
-export function evaluate<T extends Hashable, Q extends Question.Metadata, S>(
+export function evaluate<
+  T extends Hashable,
+  Q extends Question.Metadata,
+  S,
+  O extends Serializable.Options = Serializable.Options,
+>(
   rule: Rule<Page, T, Q, S>,
   page: Partial<Page>,
   oracle: Oracle<Page, T, Q, S> = () => Future.now(None),
-  options?: json.Serializable.Options,
+  options?: O,
 ): Future<Array<Outcome.JSON>> {
   const {
     request = defaultRequest,
@@ -31,5 +36,5 @@ export function evaluate<T extends Hashable, Q extends Question.Metadata, S>(
 
   return rule
     .evaluate(Page.of(request, response, document, device), oracle)
-    .map((outcomes) => [...outcomes].map((outcome) => outcome.toJSON(options)));
+    .map((outcomes) => Array.toJSON(Array.from(outcomes), options));
 }

--- a/packages/alfa-rules/test/sia-r41/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r41/rule.spec.tsx
@@ -1,4 +1,3 @@
-import { Outcome } from "@siteimprove/alfa-act";
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
@@ -6,8 +5,11 @@ import R41, { Outcomes } from "../../src/sia-r41/rule";
 
 import { Group } from "../../src/common/act/group";
 
+import { Outcome } from "@siteimprove/alfa-act";
 import { Response } from "@siteimprove/alfa-http";
+import { Serializable } from "@siteimprove/alfa-json";
 import { URL } from "@siteimprove/alfa-url";
+
 import { WithName } from "../../src/common/diagnostic";
 import { evaluate } from "../common/evaluate";
 import { oracle } from "../common/oracle";
@@ -170,4 +172,45 @@ test(`evaluate() can't tell if two links that have the same name references
       ),
     ),
   ]);
+});
+
+test(`toJSON() with minimal verbosity produces target with correct serialization ids`, async (t) => {
+  const accessibleName = "Foo";
+
+  const elmId1 = crypto.randomUUID();
+  const elmId2 = crypto.randomUUID();
+
+  const target = [
+    <a href="foo.html" serializationId={elmId1}>
+      {accessibleName}
+    </a>,
+    <a href="foo.html" serializationId={elmId2}>
+      {accessibleName}
+    </a>,
+  ];
+
+  const document = h.document(target);
+
+  t.deepEqual(
+    (
+      await evaluate(
+        R41,
+        { document },
+        oracle({
+          "reference-equivalent-resources": false,
+        }),
+        { verbosity: Serializable.Verbosity.Minimal },
+      )
+    ).flatMap((foo) => foo.target),
+    [
+      {
+        type: "element",
+        serializationId: elmId1,
+      },
+      {
+        type: "element",
+        serializationId: elmId2,
+      },
+    ],
+  );
 });

--- a/packages/alfa-sequence/src/cons.ts
+++ b/packages/alfa-sequence/src/cons.ts
@@ -24,7 +24,9 @@ const { compareComparable } = Comparable;
 /**
  * @public
  */
-export class Cons<T> implements Sequence<T> {
+export class Cons<T, O extends Serializable.Options = Serializable.Options>
+  implements Sequence<T, O>
+{
   public static of<T>(
     head: T,
     tail: Lazy<Sequence<T>> = Lazy.force(Nil),
@@ -790,13 +792,13 @@ export class Cons<T> implements Sequence<T> {
     }
   }
 
-  public toJSON(): Cons.JSON<T> {
+  public toJSON(options?: O): Cons.JSON<T> {
     const json: Cons.JSON<T> = [];
 
     let next: Cons<T> = this;
 
     while (true) {
-      json.push(Serializable.toJSON(next._head));
+      json.push(Serializable.toJSON(next._head, options));
 
       const tail = next._tail.force();
 

--- a/packages/alfa-sequence/src/sequence.ts
+++ b/packages/alfa-sequence/src/sequence.ts
@@ -2,6 +2,7 @@ import { Array } from "@siteimprove/alfa-array";
 import { Callback } from "@siteimprove/alfa-callback";
 import { Collection } from "@siteimprove/alfa-collection";
 import { Comparable, Comparer, Comparison } from "@siteimprove/alfa-comparable";
+import { Serializable } from "@siteimprove/alfa-json";
 import { Lazy } from "@siteimprove/alfa-lazy";
 import { Map } from "@siteimprove/alfa-map";
 import { Mapper } from "@siteimprove/alfa-mapper";
@@ -16,7 +17,10 @@ import { Nil } from "./nil";
 /**
  * @public
  */
-export interface Sequence<T> extends Collection.Indexed<T> {
+export interface Sequence<
+  T,
+  O extends Serializable.Options = Serializable.Options,
+> extends Collection.Indexed<T, O> {
   isEmpty(): this is Sequence<never>;
   forEach(callback: Callback<T, void, [index: number]>): void;
   map<U>(mapper: Mapper<T, U, [index: number]>): Sequence<U>;
@@ -106,7 +110,7 @@ export interface Sequence<T> extends Collection.Indexed<T> {
   ): Comparison;
   groupBy<K>(grouper: Mapper<T, K, [index: number]>): Map<K, Sequence<T>>;
   toArray(): Array<T>;
-  toJSON(): Sequence.JSON<T>;
+  toJSON(options?: O): Sequence.JSON<T>;
 }
 
 /**

--- a/packages/alfa-set/src/set.ts
+++ b/packages/alfa-set/src/set.ts
@@ -16,7 +16,9 @@ const { not } = Predicate;
 /**
  * @public
  */
-export class Set<T> implements Collection.Unkeyed<T> {
+export class Set<T, O extends Serializable.Options = Serializable.Options>
+  implements Collection.Unkeyed<T, O>
+{
   public static of<T>(...values: Array<T>): Set<T> {
     return values.reduce((set, value) => set.add(value), Set.empty<T>());
   }
@@ -223,8 +225,8 @@ export class Set<T> implements Collection.Unkeyed<T> {
     return [...this];
   }
 
-  public toJSON(): Set.JSON<T> {
-    return this.toArray().map((value) => Serializable.toJSON(value));
+  public toJSON(options?: O): Set.JSON<T> {
+    return this.toArray().map((value) => Serializable.toJSON(value, options));
   }
 
   public toString(): string {

--- a/packages/alfa-slice/src/slice.ts
+++ b/packages/alfa-slice/src/slice.ts
@@ -18,7 +18,9 @@ const { compareComparable } = Comparable;
 /**
  * @public
  */
-export class Slice<T> implements Collection.Indexed<T> {
+export class Slice<T, O extends Serializable.Options = Serializable.Options>
+  implements Collection.Indexed<T, O>
+{
   public static of<T>(
     array: ReadonlyArray<T>,
     start: number = 0,
@@ -473,8 +475,8 @@ export class Slice<T> implements Collection.Indexed<T> {
     return this._array.slice(this._offset, this._offset + this._length);
   }
 
-  public toJSON(): Slice.JSON<T> {
-    return this.toArray().map((value) => Serializable.toJSON(value));
+  public toJSON(options?: O): Slice.JSON<T> {
+    return this.toArray().map((value) => Serializable.toJSON(value, options));
   }
 
   public toString(): string {

--- a/packages/alfa-web/src/page.ts
+++ b/packages/alfa-web/src/page.ts
@@ -1,5 +1,5 @@
 import { Device } from "@siteimprove/alfa-device";
-import { Document } from "@siteimprove/alfa-dom";
+import { Document, Node } from "@siteimprove/alfa-dom";
 import { Decoder } from "@siteimprove/alfa-encoding";
 import { Request, Response } from "@siteimprove/alfa-http";
 
@@ -64,11 +64,11 @@ export class Page
     return this._device;
   }
 
-  public toJSON(): Page.JSON {
+  public toJSON(options?: Node.SerializationOptions): Page.JSON {
     return {
       request: this._request.toJSON(),
       response: this._response.toJSON(),
-      document: this._document.toJSON({ device: this._device }),
+      document: this._document.toJSON(options ?? { device: this._device }),
       device: this._device.toJSON(),
     };
   }

--- a/packages/alfa-web/src/page.ts
+++ b/packages/alfa-web/src/page.ts
@@ -66,10 +66,10 @@ export class Page
 
   public toJSON(options?: Node.SerializationOptions): Page.JSON {
     return {
-      request: this._request.toJSON(),
-      response: this._response.toJSON(),
+      request: this._request.toJSON(options),
+      response: this._response.toJSON(options),
       document: this._document.toJSON(options ?? { device: this._device }),
-      device: this._device.toJSON(),
+      device: this._device.toJSON(options),
     };
   }
 


### PR DESCRIPTION
This is a follow up on #1618 where verbosity option was added for serialization of DOM nodes.

The serialization options are now propagated through `Page` and the collection-like types like `Array`, `Sequence` etc.

A test has been added to R41. It doesn't test the rule, but uses it to show case that the options are passed down through `Array` and `Group`.