### PR TITLE
Move changeset generator to CJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@ node_modules
 **/*.log
 **/*.tsbuildinfo
 
+**/*.cjs
 **/*.js
+**/*.d.cts
 **/*.d.ts
 **/*.map
 

--- a/docs/review/api/alfa-toolchain.api.md
+++ b/docs/review/api/alfa-toolchain.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { Array as Array_2 } from '@siteimprove/alfa-array';
-import type { ChangelogFunctions as ChangelogFunctions_2 } from '@changesets/types';
 import type { Config } from '@changesets/types';
 import type { NewChangesetWithCommit } from '@changesets/types';
 import type { PackageJSON } from '@changesets/types';
@@ -15,9 +14,6 @@ import type { Packages } from '@manypkg/get-packages';
 //
 // @public (undocumented)
 export const changelogFunctions: ChangelogFunctions;
-
-// @public (undocumented)
-const changelogFunctions_2: ChangelogFunctions_2;
 
 // @public (undocumented)
 export function generateGraphs(cwd: string): Promise<void>;
@@ -34,7 +30,7 @@ function hasExtractorConfig(name: string, dir: string): Array<string>;
 
 declare namespace individualChangelog {
     export {
-        changelogFunctions_2 as default
+
     }
 }
 export { individualChangelog }

--- a/packages/alfa-toolchain/package.json
+++ b/packages/alfa-toolchain/package.json
@@ -18,8 +18,9 @@
   "main": "dist/index.js",
   "exports": {
     ".": "./dist/index.js",
-    "./changelog": "./dist/changeset/changelog-individual.js",
-    "./changelog.js": "./dist/changeset/changelog-individual.js",
+    "./changelog": "./dist/changeset/changelog-individual.cjs",
+    "./changelog.cjs": "./dist/changeset/changelog-individual.cjs",
+    "./changelog.js": "./dist/changeset/changelog-individual.cjs",
     "./global-changelog": "./dist/changeset/build-changelog.js",
     "./global-changelog.js": "./dist/changeset/build-changelog.js"
   },

--- a/packages/alfa-toolchain/src/changeset/changelog-individual.cts
+++ b/packages/alfa-toolchain/src/changeset/changelog-individual.cts
@@ -13,8 +13,8 @@ const changelog = require("@svitejs/changesets-changelog-github-compact");
  * @public
  */
 const changelogFunctions: ChangelogFunctions = {
+  ...changelog.default,
   getDependencyReleaseLine: async () => "",
-  getReleaseLine: changelog.getReleaseLine,
 };
 
 /**

--- a/packages/alfa-toolchain/src/changeset/changelog-individual.cts
+++ b/packages/alfa-toolchain/src/changeset/changelog-individual.cts
@@ -7,7 +7,7 @@
  * there is no need to add changelog entries for (internal) dependency bumps.
  */
 import type { ChangelogFunctions } from "@changesets/types";
-import changelog from "@svitejs/changesets-changelog-github-compact";
+const changelog = require("@svitejs/changesets-changelog-github-compact");
 
 /**
  * @public
@@ -20,4 +20,4 @@ const changelogFunctions: ChangelogFunctions = {
 /**
  * @public
  */
-export default changelogFunctions;
+module.exports = changelogFunctions;

--- a/packages/alfa-toolchain/src/index.ts
+++ b/packages/alfa-toolchain/src/index.ts
@@ -1,7 +1,7 @@
 import { generateGraphs } from "./dependency-graph/generate-graphs.js";
 import changelogFunctions from "./changeset/build-changelog.js";
 import * as globalChangelog from "./changeset/changelog-global.js";
-import * as individualChangelog from "./changeset/changelog-individual.js";
+import * as individualChangelog from "./changeset/changelog-individual.cjs";
 import * as Validation from "./validation/index.js";
 
 export {

--- a/packages/alfa-toolchain/src/tsconfig.json
+++ b/packages/alfa-toolchain/src/tsconfig.json
@@ -5,7 +5,7 @@
   "files": [
     "./changeset/build-changelog.ts",
     "./changeset/changelog-global.ts",
-    "./changeset/changelog-individual.ts",
+    "./changeset/changelog-individual.cts",
     "./dependency-graph/dependency-graph.ts",
     "./dependency-graph/generate-graphs.ts",
     "./dependency-graph/rainbow.ts",


### PR DESCRIPTION
It seems that changeset config doesn't manage to load its own ESM version and thus needs to load more CJS code.
Fortunately, it also seems that only one file is really impacted 🤞 