### PR TITLE
Fix usages of `__dirname`

### DIFF
--- a/.changeset/dull-beers-attend.md
+++ b/.changeset/dull-beers-attend.md
@@ -1,0 +1,8 @@
+---
+"@siteimprove/alfa-aria": patch
+"@siteimprove/alfa-compatibility": patch
+"@siteimprove/alfa-iana": patch
+"@siteimprove/alfa-wcag": patch
+---
+
+**Fixed:** Fix usages of `__dirname`

--- a/packages/alfa-aria/scripts/attributes.ts
+++ b/packages/alfa-aria/scripts/attributes.ts
@@ -81,7 +81,7 @@ export const Attributes = ${JSON.stringify(attributes, null, 2)} as const;
   });
 
   fs.writeFileSync(
-    path.join(__dirname, "..", "src", "attribute", "data.ts"),
+    path.join(import.meta.dirname, "..", "src", "attribute", "data.ts"),
     code,
   );
 });

--- a/packages/alfa-aria/scripts/name-testable-statements.ts
+++ b/packages/alfa-aria/scripts/name-testable-statements.ts
@@ -190,7 +190,12 @@ async function main() {
   });
 
   fs.writeFileSync(
-    path.join(__dirname, "..", "test", "name-testable-statements.spec.tsx"),
+    path.join(
+      import.meta.dirname,
+      "..",
+      "test",
+      "name-testable-statements.spec.tsx",
+    ),
     code,
   );
 }

--- a/packages/alfa-aria/scripts/roles.ts
+++ b/packages/alfa-aria/scripts/roles.ts
@@ -232,5 +232,8 @@ export const Roles = ${JSON.stringify(roles, null, 2)} as const;
     parser: "typescript",
   });
 
-  fs.writeFileSync(path.join(__dirname, "..", "src", "role", "data.ts"), code);
+  fs.writeFileSync(
+    path.join(import.meta.dirname, "..", "src", "role", "data.ts"),
+    code,
+  );
 });

--- a/packages/alfa-compatibility/scripts/browsers.ts
+++ b/packages/alfa-compatibility/scripts/browsers.ts
@@ -93,7 +93,7 @@ prettier
   .format(code, { parser: "typescript" })
   .then((code) =>
     fs.writeFileSync(
-      path.join(__dirname, "..", "src", "browser", "data.ts"),
+      path.join(import.meta.dirname, "..", "src", "browser", "data.ts"),
       code,
     ),
   );

--- a/packages/alfa-compatibility/scripts/features.ts
+++ b/packages/alfa-compatibility/scripts/features.ts
@@ -181,7 +181,7 @@ prettier
   .format(code, { parser: "typescript" })
   .then((code) =>
     fs.writeFileSync(
-      path.join(__dirname, "..", "src", "feature", "data.ts"),
+      path.join(import.meta.dirname, "..", "src", "feature", "data.ts"),
       code,
     ),
   );

--- a/packages/alfa-iana/scripts/languages.ts
+++ b/packages/alfa-iana/scripts/languages.ts
@@ -192,6 +192,9 @@ export const Languages = {
       parser: "typescript",
     })
     .then((code) =>
-      fs.writeFileSync(path.join(__dirname, "../src/language/data.ts"), code),
+      fs.writeFileSync(
+        path.join(import.meta.dirname, "../src/language/data.ts"),
+        code,
+      ),
     );
 });

--- a/packages/alfa-wcag/scripts/criteria.ts
+++ b/packages/alfa-wcag/scripts/criteria.ts
@@ -111,7 +111,7 @@ export const Criteria = ${JSON.stringify(criteria, null, 2)} as const;
   });
 
   fs.writeFileSync(
-    path.join(__dirname, "..", "src", "criterion", "data.ts"),
+    path.join(import.meta.dirname, "..", "src", "criterion", "data.ts"),
     code,
   );
 });

--- a/packages/alfa-wcag/scripts/techniques.ts
+++ b/packages/alfa-wcag/scripts/techniques.ts
@@ -60,7 +60,7 @@ export const Techniques = ${JSON.stringify(techniques, null, 2)} as const;
   });
 
   fs.writeFileSync(
-    path.join(__dirname, "..", "src", "technique", "data.ts"),
+    path.join(import.meta.dirname, "..", "src", "technique", "data.ts"),
     code,
   );
 });


### PR DESCRIPTION
In ESM, `__dirname` has been replaced by `import.meta.dirname`.
Somehow, TS doesn't complain on this 🙈 and since these are grabbing scripts, they are not actually run during tests.
