### PR TITLE
Include descendants in clickable area computation

### DIFF
--- a/.changeset/happy-lions-tie.md
+++ b/.changeset/happy-lions-tie.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-dom": minor
+---
+
+**Added:** A new function `getInclusiveElementDescendants` was added to the `Query` namespace.

--- a/.changeset/sixty-trainers-sleep.md
+++ b/.changeset/sixty-trainers-sleep.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-rules": patch
+---
+
+**Fixed:** R111 and R113 no longer fails targets with sufficiently sized descendant elements.

--- a/.changeset/sixty-trainers-sleep.md
+++ b/.changeset/sixty-trainers-sleep.md
@@ -2,4 +2,4 @@
 "@siteimprove/alfa-rules": patch
 ---
 
-**Fixed:** R111 and R113 no longer fails targets with sufficiently sized descendant elements.
+**Fixed:** R111 and R113 now computes the clickable area of a target more accurately which should reduce both number of false positives and false negatives.

--- a/docs/review/api/alfa-dom.api.md
+++ b/docs/review/api/alfa-dom.api.md
@@ -987,6 +987,10 @@ export namespace Query {
     //
     // (undocumented)
     getElementIdMap: typeof elementIdMap.getElementIdMap;
+    const // Warning: (ae-forgotten-export) The symbol "inclusiveElementDescendants" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    getInclusiveElementDescendants: typeof inclusiveElementDescendants.getInclusiveElementDescendants;
 }
 
 // @public (undocumented)

--- a/packages/alfa-dom/src/node/query/inclusive-element-descendants.ts
+++ b/packages/alfa-dom/src/node/query/inclusive-element-descendants.ts
@@ -1,0 +1,23 @@
+import { Cache } from "@siteimprove/alfa-cache";
+import type { Sequence } from "@siteimprove/alfa-sequence";
+import { Node } from "../../node.js";
+import { Element } from "../element.js";
+
+const cache = Cache.empty<Element, Array<Sequence<Element>>>();
+
+/**
+ * @public
+ */
+export function getInclusiveElementDescendants(
+  node: Element,
+  options: Node.Traversal = Node.Traversal.empty,
+): Sequence<Element> {
+  const optionsMap = cache.get(node, () => []);
+  if (optionsMap[options.value] === undefined) {
+    optionsMap[options.value] = node
+      .inclusiveDescendants(options)
+      .filter(Element.isElement);
+  }
+
+  return optionsMap[options.value];
+}

--- a/packages/alfa-dom/src/node/query/inclusive-element-descendants.ts
+++ b/packages/alfa-dom/src/node/query/inclusive-element-descendants.ts
@@ -12,12 +12,5 @@ export function getInclusiveElementDescendants(
   node: Element,
   options: Node.Traversal = Node.Traversal.empty,
 ): Sequence<Element> {
-  const optionsMap = cache.get(node, () => []);
-  if (optionsMap[options.value] === undefined) {
-    optionsMap[options.value] = node
-      .inclusiveDescendants(options)
-      .filter(Element.isElement);
-  }
-
-  return optionsMap[options.value];
+return getElementDescendants(node, options).prepend(node)
 }

--- a/packages/alfa-dom/src/node/query/inclusive-element-descendants.ts
+++ b/packages/alfa-dom/src/node/query/inclusive-element-descendants.ts
@@ -1,9 +1,8 @@
-import { Cache } from "@siteimprove/alfa-cache";
 import type { Sequence } from "@siteimprove/alfa-sequence";
 import { Node } from "../../node.js";
 import { Element } from "../element.js";
 
-const cache = Cache.empty<Element, Array<Sequence<Element>>>();
+import { getElementDescendants } from "./element-descendants.js";
 
 /**
  * @public
@@ -12,5 +11,5 @@ export function getInclusiveElementDescendants(
   node: Element,
   options: Node.Traversal = Node.Traversal.empty,
 ): Sequence<Element> {
-return getElementDescendants(node, options).prepend(node)
+  return getElementDescendants(node, options).prepend(node);
 }

--- a/packages/alfa-dom/src/node/query/index.ts
+++ b/packages/alfa-dom/src/node/query/index.ts
@@ -1,5 +1,6 @@
 import * as elementDescendants from "./element-descendants.js";
 import * as elementIdMap from "./element-id-map.js";
+import * as inclusiveElementDescendants from "./inclusive-element-descendants.js";
 
 /**
  * @public
@@ -7,4 +8,6 @@ import * as elementIdMap from "./element-id-map.js";
 export namespace Query {
   export const getElementDescendants = elementDescendants.getElementDescendants;
   export const getElementIdMap = elementIdMap.getElementIdMap;
+  export const getInclusiveElementDescendants =
+    inclusiveElementDescendants.getInclusiveElementDescendants;
 }

--- a/packages/alfa-dom/src/tsconfig.json
+++ b/packages/alfa-dom/src/tsconfig.json
@@ -54,6 +54,7 @@
     "./node/type.ts",
     "./node/query/element-descendants.ts",
     "./node/query/element-id-map.ts",
+    "./node/query/inclusive-element-descendants.ts",
     "./node/query/index.ts",
     "./style/block.ts",
     "./style/declaration.ts",

--- a/packages/alfa-rules/src/common/applicability/targets-of-pointer-events.ts
+++ b/packages/alfa-rules/src/common/applicability/targets-of-pointer-events.ts
@@ -1,12 +1,14 @@
 import { DOM } from "@siteimprove/alfa-aria";
 import { Cache } from "@siteimprove/alfa-cache";
 import type { Device } from "@siteimprove/alfa-device";
-import type { Document} from "@siteimprove/alfa-dom";
+import type { Document } from "@siteimprove/alfa-dom";
 import { Element, Node, Text, Query } from "@siteimprove/alfa-dom";
 import { None, Option } from "@siteimprove/alfa-option";
 import { Predicate } from "@siteimprove/alfa-predicate";
 import { Sequence } from "@siteimprove/alfa-sequence";
 import { Style } from "@siteimprove/alfa-style";
+
+import { getClickableBox } from "../dom/get-clickable-box.js";
 
 const { hasRole } = DOM;
 const { hasComputedStyle, isFocusable, isVisible, isScrolledBehind } = Style;
@@ -112,12 +114,12 @@ function isTarget(device: Device): Predicate<Element> {
     isVisible(device),
     not(isScrolledBehind(device)),
     hasRole(device, (role) => role.isWidget()),
-    hasBoundingBox(device),
+    hasClickableBox(device),
   );
 }
 
-function hasBoundingBox(device: Device): Predicate<Element> {
-  return (element) => element.getBoundingBox(device).isSome();
+function hasClickableBox(device: Device): Predicate<Element> {
+  return (element) => getClickableBox(device, element).isSome();
 }
 
 const nonTargetTextCache = Cache.empty<Device, Cache<Element, boolean>>();

--- a/packages/alfa-rules/src/common/dom/get-clickable-box.ts
+++ b/packages/alfa-rules/src/common/dom/get-clickable-box.ts
@@ -1,0 +1,41 @@
+import { Cache } from "@siteimprove/alfa-cache";
+import type { Device } from "@siteimprove/alfa-device";
+import { Element, Node } from "@siteimprove/alfa-dom";
+import { Rectangle } from "@siteimprove/alfa-rectangle";
+import { None, Option } from "@siteimprove/alfa-option";
+
+const { isElement } = Element;
+
+const cache = Cache.empty<Device, Cache<Element, Option<Rectangle>>>();
+
+/**
+ * Gets the bounding box of the clickable area of an element
+ * or None if the element or one of its descendants doesn't have a bounding box.
+ *
+ * @remarks
+ * This function assumes that the element can receive pointer events, i.e. is clickable.
+ * If called on an element that is not clickable, the function will still return the
+ * bounding rectangle the area that would be clickable if the element was clickable.
+ *
+ * @internal
+ */
+export function getClickableBox(
+  device: Device,
+  element: Element,
+): Option<Rectangle> {
+  return cache.get(device, Cache.empty).get(element, () => {
+    let boxes: Array<Rectangle> = [];
+    for (let box of element
+      .inclusiveDescendants(Node.flatTree)
+      .filter(isElement)
+      .map((element) => element.getBoundingBox(device))) {
+      if (!box.isSome()) {
+        return None;
+      }
+
+      boxes.push(box.get());
+    }
+
+    return Option.of(Rectangle.union(...boxes));
+  });
+}

--- a/packages/alfa-rules/src/common/dom/get-clickable-box.ts
+++ b/packages/alfa-rules/src/common/dom/get-clickable-box.ts
@@ -1,10 +1,10 @@
 import { Cache } from "@siteimprove/alfa-cache";
 import type { Device } from "@siteimprove/alfa-device";
-import { Element, Node } from "@siteimprove/alfa-dom";
+import { type Element, Query } from "@siteimprove/alfa-dom";
 import { Rectangle } from "@siteimprove/alfa-rectangle";
 import { None, Option } from "@siteimprove/alfa-option";
 
-const { isElement } = Element;
+const { getInclusiveElementDescendants } = Query;
 
 const cache = Cache.empty<Device, Cache<Element, Option<Rectangle>>>();
 
@@ -25,10 +25,9 @@ export function getClickableBox(
 ): Option<Rectangle> {
   return cache.get(device, Cache.empty).get(element, () => {
     let boxes: Array<Rectangle> = [];
-    for (let box of element
-      .inclusiveDescendants(Node.flatTree)
-      .filter(isElement)
-      .map((element) => element.getBoundingBox(device))) {
+    for (let box of getInclusiveElementDescendants(element).map((element) =>
+      element.getBoundingBox(device),
+    )) {
       if (!box.isSome()) {
         return None;
       }

--- a/packages/alfa-rules/src/common/dom/get-clickable-box.ts
+++ b/packages/alfa-rules/src/common/dom/get-clickable-box.ts
@@ -15,7 +15,7 @@ const cache = Cache.empty<Device, Cache<Element, Option<Rectangle>>>();
  * @remarks
  * This function assumes that the element can receive pointer events, i.e. is clickable.
  * If called on an element that is not clickable, the function will still return the
- * the area that would be clickable if the element was could receive pointer events.
+ * the area that would be clickable if the element could receive pointer events.
  *
  * @internal
  */

--- a/packages/alfa-rules/src/common/dom/get-clickable-box.ts
+++ b/packages/alfa-rules/src/common/dom/get-clickable-box.ts
@@ -15,7 +15,7 @@ const cache = Cache.empty<Device, Cache<Element, Option<Rectangle>>>();
  * @remarks
  * This function assumes that the element can receive pointer events, i.e. is clickable.
  * If called on an element that is not clickable, the function will still return the
- * bounding rectangle the area that would be clickable if the element was clickable.
+ * the area that would be clickable if the element was could receive pointer events.
  *
  * @internal
  */

--- a/packages/alfa-rules/src/common/predicate/has-sufficient-size.ts
+++ b/packages/alfa-rules/src/common/predicate/has-sufficient-size.ts
@@ -1,28 +1,22 @@
 import type { Device } from "@siteimprove/alfa-device";
 import type { Predicate } from "@siteimprove/alfa-predicate";
-import { Element } from "@siteimprove/alfa-dom";
-import { Refinement } from "@siteimprove/alfa-refinement";
+import type { Element } from "@siteimprove/alfa-dom";
 
-const { and } = Refinement;
-const { hasInclusiveDescendant, isElement } = Element;
+import { getClickableBox } from "../dom/get-clickable-box.js";
 
 /**
  * @remarks
- * This predicate tests that the bounding box of an element or one of it's element descendants
+ * This predicate tests that the clickable box of an element or one of it's element descendants
  * has width and height larger than a given value.
  *
- * Defaults to true if called on an element without bounding box to avoid false positives.
+ * Defaults to true if called on an element without clickable box to avoid false positives.
  */
 export function hasSufficientSize(
   size: number,
   device: Device,
 ): Predicate<Element> {
-  return hasInclusiveDescendant((desc) =>
-    and(isElement, (element) =>
-      element
-        .getBoundingBox(device)
-        .map((box) => box.width >= size && box.height >= size)
-        .getOr(true),
-    )(desc),
-  );
+  return (element) =>
+    getClickableBox(device, element)
+      .map((box) => box.width >= size && box.height >= size)
+      .getOr(true);
 }

--- a/packages/alfa-rules/src/common/predicate/has-sufficient-size.ts
+++ b/packages/alfa-rules/src/common/predicate/has-sufficient-size.ts
@@ -1,19 +1,28 @@
 import type { Device } from "@siteimprove/alfa-device";
 import type { Predicate } from "@siteimprove/alfa-predicate";
-import type { Element } from "@siteimprove/alfa-dom";
+import { Element } from "@siteimprove/alfa-dom";
+import { Refinement } from "@siteimprove/alfa-refinement";
+
+const { and } = Refinement;
+const { hasInclusiveDescendant, isElement } = Element;
 
 /**
  * @remarks
- * This predicate tests that the bounding box of an element has width and height larger than a given value.
+ * This predicate tests that the bounding box of an element or one of it's element descendants
+ * has width and height larger than a given value.
+ *
  * Defaults to true if called on an element without bounding box to avoid false positives.
  */
 export function hasSufficientSize(
   size: number,
   device: Device,
 ): Predicate<Element> {
-  return (element) =>
-    element
-      .getBoundingBox(device)
-      .map((box) => box.width >= size && box.height >= size)
-      .getOr(true);
+  return hasInclusiveDescendant((desc) =>
+    and(isElement, (element) =>
+      element
+        .getBoundingBox(device)
+        .map((box) => box.width >= size && box.height >= size)
+        .getOr(true),
+    )(desc),
+  );
 }

--- a/packages/alfa-rules/src/common/predicate/has-sufficient-size.ts
+++ b/packages/alfa-rules/src/common/predicate/has-sufficient-size.ts
@@ -6,8 +6,7 @@ import { getClickableBox } from "../dom/get-clickable-box.js";
 
 /**
  * @remarks
- * This predicate tests that the clickable box of an element or one of it's element descendants
- * has width and height larger than a given value.
+ * This predicate tests that the clickable box of an element has width and height larger than a given value.
  *
  * Defaults to true if called on an element without clickable box to avoid false positives.
  */

--- a/packages/alfa-rules/src/common/predicate/has-sufficient-size.ts
+++ b/packages/alfa-rules/src/common/predicate/has-sufficient-size.ts
@@ -7,7 +7,6 @@ import { getClickableBox } from "../dom/get-clickable-box.js";
 /**
  * @remarks
  * This predicate tests that the clickable box of an element has width and height larger than a given value.
- *
  * Defaults to true if called on an element without clickable box to avoid false positives.
  */
 export function hasSufficientSize(

--- a/packages/alfa-rules/src/sia-r111/rule.ts
+++ b/packages/alfa-rules/src/sia-r111/rule.ts
@@ -4,8 +4,8 @@ import { Criterion } from "@siteimprove/alfa-wcag";
 import type { Page } from "@siteimprove/alfa-web";
 
 import { expectation } from "../common/act/expectation.js";
-
 import { applicableTargetsOfPointerEvents } from "../common/applicability/targets-of-pointer-events.js";
+import { getClickableBox } from "../common/dom/get-clickable-box.js";
 
 import { WithName } from "../common/diagnostic.js";
 
@@ -24,8 +24,8 @@ export default Rule.Atomic.of<Page, Element>({
       },
 
       expectations(target) {
-        // Existence of a bounding box is guaranteed by applicability
-        const box = target.getBoundingBox(device).getUnsafe();
+        // Existence of a clickable box is guaranteed by applicability
+        const box = getClickableBox(device, target).getUnsafe();
         const name = WithName.getName(target, device).getOr("");
         return {
           1: expectation(

--- a/packages/alfa-rules/src/sia-r113/rule.ts
+++ b/packages/alfa-rules/src/sia-r113/rule.ts
@@ -102,7 +102,7 @@ function* findElementsWithInsufficientSpacingToTarget(
       ),
     );
 
-  // TODO: This needs to be optimized, we should be able to use some spatial data structure like a quadtree to reduce the number of comparisons
+  // TODO: We could avoid unnecessary comparisons by using a quad tree or similar
   for (const candidate of allTargetsOfPointerEvents(document, device)) {
     if (target !== candidate) {
       // Existence of a clickable box should be guaranteed by implementation of allTargetsOfPointerEvents

--- a/packages/alfa-rules/src/sia-r113/rule.ts
+++ b/packages/alfa-rules/src/sia-r113/rule.ts
@@ -8,6 +8,7 @@ import { Criterion } from "@siteimprove/alfa-wcag";
 import type { Page } from "@siteimprove/alfa-web";
 
 import { expectation } from "../common/act/expectation.js";
+import { getClickableBox } from "../common/dom/get-clickable-box.js";
 
 import {
   allTargetsOfPointerEvents,
@@ -31,8 +32,8 @@ export default Rule.Atomic.of<Page, Element>({
       },
 
       expectations(target) {
-        // Existence of a bounding box is guaranteed by applicability
-        const box = target.getBoundingBox(device).getUnsafe();
+        // Existence of a clickable box is guaranteed by applicability
+        const box = getClickableBox(device, target).getUnsafe();
         const name = WithName.getName(target, device).getOr("");
 
         return {
@@ -79,19 +80,19 @@ const undersizedCache = Cache.empty<
  * Yields all elements that have insufficient spacing to the target.
  *
  * @remarks
- * The spacing is calculated by drawing a circle around the center of the bounding box of the target of radius 12.
+ * The spacing is calculated by drawing a circle around the center of the clickable box of the target of radius 12.
  * The target is underspaced, if
- * 1) the circle intersects with the bounding box of any other target, or
- * 2) the distance between the center of the bounding box of the target
- *    and the center of the bounding box of any other **undersized** target is less than 24.
+ * 1) the circle intersects with the clickable box of any other target, or
+ * 2) the distance between the center of the clickable box of the target
+ *    and the center of the clickable box of any other **undersized** target is less than 24.
  */
 function* findElementsWithInsufficientSpacingToTarget(
   document: Document,
   device: Device,
   target: Element,
 ): Iterable<Element> {
-  // Existence of a bounding box is guaranteed by applicability
-  const targetRect = target.getBoundingBox(device).getUnsafe();
+  // Existence of a clickable box is guaranteed by applicability
+  const targetRect = getClickableBox(device, target).getUnsafe();
 
   const undersizedTargets = undersizedCache
     .get(document, Cache.empty)
@@ -104,8 +105,8 @@ function* findElementsWithInsufficientSpacingToTarget(
   // TODO: This needs to be optimized, we should be able to use some spatial data structure like a quadtree to reduce the number of comparisons
   for (const candidate of allTargetsOfPointerEvents(document, device)) {
     if (target !== candidate) {
-      // Existence of a bounding box should be guaranteed by implementation of allTargetsOfPointerEvents
-      const candidateRect = candidate.getBoundingBox(device).getUnsafe();
+      // Existence of a clickable box should be guaranteed by implementation of allTargetsOfPointerEvents
+      const candidateRect = getClickableBox(device, candidate).getUnsafe();
 
       if (
         candidateRect.intersectsCircle(
@@ -116,7 +117,7 @@ function* findElementsWithInsufficientSpacingToTarget(
         (undersizedTargets.includes(candidate) &&
           targetRect.distanceSquared(candidateRect) < 24 ** 2)
       ) {
-        // The 24px diameter circle of the target must not intersect with the bounding box of any other target, or
+        // The 24px diameter circle of the target must not intersect with the clickable box of any other target, or
         // if the candidate is undersized, the 24px diameter circle of the target must not intersect with the 24px diameter circle of the candidate
         yield candidate;
       }

--- a/packages/alfa-rules/src/tsconfig.json
+++ b/packages/alfa-rules/src/tsconfig.json
@@ -23,6 +23,7 @@
     "./common/diagnostic/with-other-heading.ts",
     "./common/diagnostic/with-role.ts",
     "./common/diagnostic.ts",
+    "./common/dom/get-clickable-box.ts",
     "./common/dom/get-colors.ts",
     "./common/dom/get-colors/color.ts",
     "./common/dom/get-colors/color-error.ts",

--- a/packages/alfa-rules/test/sia-r111/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r111/rule.spec.tsx
@@ -57,6 +57,31 @@ test("evaluate() passes input element regardless of size", async (t) => {
   ]);
 });
 
+test("evaluate() passes undersized link with rightsized image descendant", async (t) => {
+  const device = Device.standard();
+
+  const target = (
+    <a href="/" box={{ device, x: 544, y: 8, width: 0, height: 0 }}>
+      <img
+        style={{ float: "left" }}
+        box={{ device, x: 8, y: 8, width: 536, height: 354 }}
+        src="foo"
+      />
+    </a>
+  );
+
+  const document = h.document([target]);
+
+  t.deepEqual(await evaluate(R111, { document, device }), [
+    passed(R111, target, {
+      1: TargetSize.HasSufficientSize(
+        "",
+        target.getBoundingBox(device).getUnsafe(),
+      ),
+    }),
+  ]);
+});
+
 test("evaluate() fails button with clickable area of less than 44x44 pixels", async (t) => {
   const device = Device.standard();
 

--- a/packages/alfa-rules/test/sia-r111/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r111/rule.spec.tsx
@@ -2,13 +2,11 @@ import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
 
 import { Device } from "@siteimprove/alfa-device";
+import { Rectangle } from "@siteimprove/alfa-rectangle";
 
 import R111 from "../../dist/sia-r111/rule.js";
-
 import { evaluate } from "../common/evaluate.js";
-
 import { failed, inapplicable, passed } from "../common/outcome.js";
-
 import { TargetSize } from "../../dist/common/outcome/target-size.js";
 
 test("evaluate() passes button with clickable area of exactly 44x44 pixels", async (t) => {
@@ -61,12 +59,8 @@ test("evaluate() passes undersized link with rightsized image descendant", async
   const device = Device.standard();
 
   const target = (
-    <a href="/" box={{ device, x: 544, y: 8, width: 0, height: 0 }}>
-      <img
-        style={{ float: "left" }}
-        box={{ device, x: 8, y: 8, width: 536, height: 354 }}
-        src="foo"
-      />
+    <a href="/" box={{ device, x: 8, y: 348, width: 536, height: 17 }}>
+      <img box={{ device, x: 8, y: 8, width: 536, height: 354 }} src="foo" />
     </a>
   );
 
@@ -74,10 +68,7 @@ test("evaluate() passes undersized link with rightsized image descendant", async
 
   t.deepEqual(await evaluate(R111, { document, device }), [
     passed(R111, target, {
-      1: TargetSize.HasSufficientSize(
-        "",
-        target.getBoundingBox(device).getUnsafe(),
-      ),
+      1: TargetSize.HasSufficientSize("", Rectangle.of(8, 8, 536, 357)),
     }),
   ]);
 });


### PR DESCRIPTION
A target might have an undersized bounding box while the clickable area is sufficiently sized if there is an element descendant (like an image) that is sufficiently sized.

In general we need the target size rules to rely on the clickable area and not the bounding box of a target. So we try to calculate the clickable area of an element which as the union the bounding boxes of an element and all its descendants., i.e. the smallest rectangle that contains all the bounding boxes. This can overshoot the actual clickable area if it's not rectangular.