### PR TITLE
Use `npm` for publishing

### DIFF
--- a/.github/workflows/alfa-release.yml
+++ b/.github/workflows/alfa-release.yml
@@ -140,13 +140,12 @@ jobs:
           # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
           VERSION: v${{ steps.new.outputs.version }}
 
-      - name: Make npm release
+      - name: Make npm release (Github Package Registry)
         run: >
-          yarn workspaces foreach
-          --all
-          --no-private
-          --topological-dev
-          npm publish --tolerate-republish
+          npm publish 
+          --tolerate-republish 
+          --provenance
+          --ws          
 
       - name: Make Github release
         run: >

--- a/config/validate-structure.json
+++ b/config/validate-structure.json
@@ -5,7 +5,7 @@
   "validate-package-json": {
     "organisation": "@siteimprove",
     "homepage": "https://alfa.siteimprove.com",
-    "repo": "https://github.com/siteimprove/alfa.git",
+    "repo": "git+https://github.com/siteimprove/alfa.git",
     "bugs": "https://github.com/siteimprove/alfa/issues",
     "noExternalDeps": true,
     "allowedExternalDeps": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "description": "Suite of open and standards-based tools for performing reliable accessibility conformance testing at scale",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git"
+    "url": "git+https://github.com/siteimprove/alfa.git"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",
   "scripts": {

--- a/packages/alfa-act/package.json
+++ b/packages/alfa-act/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for implementing rules specified in the ACT Rules Format",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-act"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-affine/package.json
+++ b/packages/alfa-affine/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with affine transformations",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-affine"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-applicative/package.json
+++ b/packages/alfa-applicative/package.json
@@ -7,7 +7,7 @@
   "description": "Types for modelling applicative functors",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-applicative"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-aria/package.json
+++ b/packages/alfa-aria/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with ARIA and the accessibility tree",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-aria"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-array/package.json
+++ b/packages/alfa-array/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with arrays",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-array"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-bits/package.json
+++ b/packages/alfa-bits/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for doing bit manipulation of 32-bit numbers",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-bits"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-branched/package.json
+++ b/packages/alfa-branched/package.json
@@ -7,7 +7,7 @@
   "description": "An implementation of branched values, which are abstract values that can take on multiple concrete values",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-branched"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-cache/package.json
+++ b/packages/alfa-cache/package.json
@@ -7,7 +7,7 @@
   "description": "A simple in-memory cache that can be used for various purposes, such as function memoization",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-cache"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-callback/package.json
+++ b/packages/alfa-callback/package.json
@@ -7,7 +7,7 @@
   "description": "Types for modelling functions that can be passed around and called back with a value once available",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-callback"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-cascade/package.json
+++ b/packages/alfa-cascade/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with the CSS cascade and scalable selector matching",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-cascade"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-clone/package.json
+++ b/packages/alfa-clone/package.json
@@ -7,7 +7,7 @@
   "description": "Types for modelling clonable structures",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-clone"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-collection/package.json
+++ b/packages/alfa-collection/package.json
@@ -7,7 +7,7 @@
   "description": "Types for modelling uniform collection structures",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-collection"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-comparable/package.json
+++ b/packages/alfa-comparable/package.json
@@ -7,7 +7,7 @@
   "description": "Types for modelling comparable, totally ordered structures",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-comparable"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-compatibility/package.json
+++ b/packages/alfa-compatibility/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for answering user agent compatibility questions based on MDN compatibility data",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-compatibility"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-continuation/package.json
+++ b/packages/alfa-continuation/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with continuations, which are abstract representations of control flow",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-continuation"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-css-feature/package.json
+++ b/packages/alfa-css-feature/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with CSS feature queries (media, user-preference, and supports).",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-css-feature"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-css/package.json
+++ b/packages/alfa-css/package.json
@@ -7,7 +7,7 @@
   "description": "Implementations of the core CSS syntax and value types",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-css"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-device/package.json
+++ b/packages/alfa-device/package.json
@@ -7,7 +7,7 @@
   "description": "Types for modelling device parameters, such as viewport dimensions and pixel density",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-device"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-dom/package.json
+++ b/packages/alfa-dom/package.json
@@ -7,7 +7,7 @@
   "description": "Implementations of the core DOM and CSSOM node types",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-dom"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-earl/package.json
+++ b/packages/alfa-earl/package.json
@@ -7,7 +7,7 @@
   "description": "Types for modelling EARL serializable structures",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-earl"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-either/package.json
+++ b/packages/alfa-either/package.json
@@ -7,7 +7,7 @@
   "description": "Types for modelling tagged unions for cases where the member types cannot otherwise be distinguished",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-either"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-emitter/package.json
+++ b/packages/alfa-emitter/package.json
@@ -7,7 +7,7 @@
   "description": "An implementation of a strongly typed and asynchronously iterable event emitter",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-emitter"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-encoding/package.json
+++ b/packages/alfa-encoding/package.json
@@ -7,7 +7,7 @@
   "description": "Implementations of performant UTF-8 string encoders and decoders",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-encoding"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-equatable/package.json
+++ b/packages/alfa-equatable/package.json
@@ -7,7 +7,7 @@
   "description": "Types for modelling structures with equivalence relations",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-equatable"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-flags/package.json
+++ b/packages/alfa-flags/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for manipulating set of boolean flags",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-flags"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-fnv/package.json
+++ b/packages/alfa-fnv/package.json
@@ -7,7 +7,7 @@
   "description": "An implementation of the Fowler–Noll–Vo non-cryptographic hash function",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-fnv"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-foldable/package.json
+++ b/packages/alfa-foldable/package.json
@@ -7,7 +7,7 @@
   "description": "Types for modelling structures that can be folded over",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-foldable"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-functor/package.json
+++ b/packages/alfa-functor/package.json
@@ -7,7 +7,7 @@
   "description": "Types for modelling functors, which are structures that can be mapped over",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-functor"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-future/package.json
+++ b/packages/alfa-future/package.json
@@ -7,7 +7,7 @@
   "description": "An implementation of futures, which are a lazy version of promises for dealing with possibly asynchronous control flow",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-future"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-generator/package.json
+++ b/packages/alfa-generator/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with generator functions",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-generator"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-graph/package.json
+++ b/packages/alfa-graph/package.json
@@ -7,7 +7,7 @@
   "description": "An implementation of an immutable, directed graph",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-graph"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-hash/package.json
+++ b/packages/alfa-hash/package.json
@@ -7,7 +7,7 @@
   "description": "Types for modelling structures that support hashing",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-hash"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-http/package.json
+++ b/packages/alfa-http/package.json
@@ -7,7 +7,7 @@
   "description": "Types for modelling HTTP primitives",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-http"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-iana/package.json
+++ b/packages/alfa-iana/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with the different IANA registries, such as the language subtag registry",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-iana"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-iterable/package.json
+++ b/packages/alfa-iterable/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with structures that support iteration",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-iterable"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-json-ld/package.json
+++ b/packages/alfa-json-ld/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with JSON-LD documents",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-json-ld"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-json/package.json
+++ b/packages/alfa-json/package.json
@@ -7,7 +7,7 @@
   "description": "Types for modelling JSON serializable structures",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-json"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-lazy/package.json
+++ b/packages/alfa-lazy/package.json
@@ -7,7 +7,7 @@
   "description": "An implementation of lazy values, which are values whose initialization can be delayed until needed",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-lazy"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-list/package.json
+++ b/packages/alfa-list/package.json
@@ -7,7 +7,7 @@
   "description": "An implementation of an immutable list structure, based on a bit-partitioned vector trie",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-list"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-map/package.json
+++ b/packages/alfa-map/package.json
@@ -7,7 +7,7 @@
   "description": "An implementation of an immutable map structure, based on a hash array mapped trie",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-map"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-mapper/package.json
+++ b/packages/alfa-mapper/package.json
@@ -7,7 +7,7 @@
   "description": "Types for modelling mapper functions, which are functions that map values from one domain into another domain",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-mapper"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-math/package.json
+++ b/packages/alfa-math/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with numbers and mathematical structures, such as vectors and matrices",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-math"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-monad/package.json
+++ b/packages/alfa-monad/package.json
@@ -7,7 +7,7 @@
   "description": "Types for modelling monads, which are functors that can be mapped to themselves",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-monad"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-network/package.json
+++ b/packages/alfa-network/package.json
@@ -7,7 +7,7 @@
   "description": "An implementation of an immutable, directed graph that allows for multiple, unique edges",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-network"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-option/package.json
+++ b/packages/alfa-option/package.json
@@ -7,7 +7,7 @@
   "description": "An implementation of optional values, which are values that may or may not be present",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-option"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-parser/package.json
+++ b/packages/alfa-parser/package.json
@@ -7,7 +7,7 @@
   "description": "Types for modelling parsers and implementations of various parser combinators, which can be used for constructing modular parsers",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-parser"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-performance/package.json
+++ b/packages/alfa-performance/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with performance measurements, inspired by the User Timing specification",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-performance"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-predicate/package.json
+++ b/packages/alfa-predicate/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with first-order predicate logic",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-predicate"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-promise/package.json
+++ b/packages/alfa-promise/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with promises",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-promise"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-record/package.json
+++ b/packages/alfa-record/package.json
@@ -7,7 +7,7 @@
   "description": "An implementation of an immutable record structure with fixed keys",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-record"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-rectangle/package.json
+++ b/packages/alfa-rectangle/package.json
@@ -7,7 +7,7 @@
   "description": "Package for working with rectangles",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-rectangle"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-reducer/package.json
+++ b/packages/alfa-reducer/package.json
@@ -7,7 +7,7 @@
   "description": "Types for modelling reducer functions, which are functions that combine an accumulator with a value to form the next accumulator",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-reducer"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-refinement/package.json
+++ b/packages/alfa-refinement/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with first-order type predicates",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-refinement"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-result/package.json
+++ b/packages/alfa-result/package.json
@@ -7,7 +7,7 @@
   "description": "An implementation of result values, which are values that may either be a successful value or an error",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-result"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-rules/package.json
+++ b/packages/alfa-rules/package.json
@@ -7,7 +7,7 @@
   "description": "Implementations of ACT rules from the Sanshikan repository",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-rules"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-sarif/package.json
+++ b/packages/alfa-sarif/package.json
@@ -7,7 +7,7 @@
   "description": "Types for modelling SARIF serializable structures",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-sarif"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-selective/package.json
+++ b/packages/alfa-selective/package.json
@@ -7,7 +7,7 @@
   "description": "An implementation of a selective functor for modelling conditional function application",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-selective"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-selector/package.json
+++ b/packages/alfa-selector/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with CSS selectors and individual selector matching",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-selector"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-sequence/package.json
+++ b/packages/alfa-sequence/package.json
@@ -7,7 +7,7 @@
   "description": "An implementation of a lazy, immutable sequence structure, which is similar to a list but lazily evaluated",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-sequence"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-set/package.json
+++ b/packages/alfa-set/package.json
@@ -7,7 +7,7 @@
   "description": "An implementation of an immutable set structure, based on a hash array mapped trie",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-set"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-slice/package.json
+++ b/packages/alfa-slice/package.json
@@ -7,7 +7,7 @@
   "description": "An implementation of an immutable slice structure, which provides an efficient view over an array",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-slice"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-string/package.json
+++ b/packages/alfa-string/package.json
@@ -7,7 +7,7 @@
   "description": "Utilities for manipulating strings",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-string"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-style/package.json
+++ b/packages/alfa-style/package.json
@@ -7,7 +7,7 @@
   "description": "An implementation of the CSS style system capable of resolving and computing style information for DOM nodes",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-style"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-table/package.json
+++ b/packages/alfa-table/package.json
@@ -7,7 +7,7 @@
   "description": "An implementation of the HTML table model for forming and laying out tables",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-table"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-test/package.json
+++ b/packages/alfa-test/package.json
@@ -7,7 +7,7 @@
   "description": "A simple test library sitting on top of the built-in Node.js assert module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-test"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-thenable/package.json
+++ b/packages/alfa-thenable/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with thenables, which are promise-like structures that can be awaited",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-thenable"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-thunk/package.json
+++ b/packages/alfa-thunk/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with thunks, which are computations that are delayed until needed",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-thunk"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-time/package.json
+++ b/packages/alfa-time/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with time",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-time"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-toolchain/package.json
+++ b/packages/alfa-toolchain/package.json
@@ -7,7 +7,7 @@
   "description": "Toolchain for developing Alfa and related projects",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-toolchain"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-trampoline/package.json
+++ b/packages/alfa-trampoline/package.json
@@ -7,7 +7,7 @@
   "description": "An implementation of a trampoline structure, which is used for achieving tail-recursive function calls without relying on built-in language support",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-trampoline"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-tree/package.json
+++ b/packages/alfa-tree/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for modelling n-ary trees",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-tree"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-trilean/package.json
+++ b/packages/alfa-trilean/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with trilean logic, which is logic involving three possible truth values",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-trilean"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-tuple/package.json
+++ b/packages/alfa-tuple/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with heterogeneous arrays, also called tuples",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-tuple"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-url/package.json
+++ b/packages/alfa-url/package.json
@@ -7,7 +7,7 @@
   "description": "Functionality for working with immutable URLs",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-url"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-wcag/package.json
+++ b/packages/alfa-wcag/package.json
@@ -7,7 +7,7 @@
   "description": "Types for working with WCAG-related information in a structured manner",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-wcag"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-web/package.json
+++ b/packages/alfa-web/package.json
@@ -7,7 +7,7 @@
   "description": "Types for modelling web resources, such as individual web pages and entire web sites",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-web"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",

--- a/packages/alfa-xpath/package.json
+++ b/packages/alfa-xpath/package.json
@@ -7,7 +7,7 @@
   "description": "An implementation of a subset of the XPath query language",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siteimprove/alfa.git",
+    "url": "git+https://github.com/siteimprove/alfa.git",
     "directory": "packages/alfa-xpath"
   },
   "bugs": "https://github.com/siteimprove/alfa/issues",


### PR DESCRIPTION
Use `npm publish` directly for publishing, rather than `yarn npm publish`.

This has much more options, including the possibility to override the registry, hence to also publish to https://registry.npmjs.org/

We'll see with next release if that works…