### PR TITLE
Add `assignedSlot` to high verbosity serialization of elements

### DIFF
--- a/.changeset/shaggy-maps-give.md
+++ b/.changeset/shaggy-maps-give.md
@@ -1,0 +1,7 @@
+---
+"@siteimprove/alfa-dom": minor
+---
+
+**Added:** `Element` serialised with high verbosity now include the serialisation ID of their assigned slot, if any.
+
+This help de-serialise the shadow trees for tools that do not want to re-compute slot assignement.

--- a/docs/review/api/alfa-dom.api.md
+++ b/docs/review/api/alfa-dom.api.md
@@ -324,6 +324,12 @@ export class Element<N extends string = string> extends Node<"element"> implemen
         verbosity: json.Serializable.Verbosity.Minimal | json.Serializable.Verbosity.Low;
     }): Element.MinimalJSON;
     // (undocumented)
+    toJSON(options: Node.SerializationOptions & {
+        verbosity: json.Serializable.Verbosity.High;
+    }): Element.JSON & {
+        assignedSlot: Element.MinimalJSON | null;
+    };
+    // (undocumented)
     toJSON(options?: Node.SerializationOptions): Element.JSON<N>;
     // (undocumented)
     toString(): string;

--- a/packages/alfa-dom/test/node.spec.tsx
+++ b/packages/alfa-dom/test/node.spec.tsx
@@ -461,7 +461,7 @@ test("#toJSON() includes everything including serializationId and assigned slot 
   });
 });
 
-test("#toJSON()", (t) => {
+test("#toJSON() includes serializationId of assigned slots when verbosity is high", (t) => {
   const a = <span serializationId="a"></span>;
   const b = <span serializationId="b"></span>;
 

--- a/packages/alfa-dom/test/node.spec.tsx
+++ b/packages/alfa-dom/test/node.spec.tsx
@@ -417,7 +417,7 @@ test("#toJSON() includes everything except serializationId when options is undef
   }
 });
 
-test("#toJSON() includes everything including serializationId when verbosity is high", (t) => {
+test("#toJSON() includes everything including serializationId and assigned slot when verbosity is high", (t) => {
   const docId = crypto.randomUUID();
   const elmId = crypto.randomUUID();
   const attrId = crypto.randomUUID();
@@ -437,6 +437,7 @@ test("#toJSON() includes everything including serializationId when verbosity is 
       {
         type: "element",
         serializationId: elmId,
+        assignedSlot: null,
         attributes: [
           {
             type: "attribute",
@@ -457,5 +458,91 @@ test("#toJSON() includes everything including serializationId when verbosity is 
         style: null,
       },
     ],
+  });
+});
+
+test("#toJSON()", (t) => {
+  const a = <span serializationId="a"></span>;
+  const b = <span serializationId="b"></span>;
+
+  const div = (
+    <div serializationId="div">
+      {h.shadow(
+        [<slot serializationId="slot" />, b],
+        undefined,
+        undefined,
+        undefined,
+        "shadow",
+      )}
+      {a}
+    </div>
+  );
+
+  t.deepEqual(div.toJSON({ verbosity: json.Serializable.Verbosity.High }), {
+    type: "element",
+    children: [
+      {
+        type: "element",
+        children: [],
+        serializationId: "a",
+        assignedSlot: {
+          type: "element",
+          serializationId: "slot",
+        },
+        namespace: "http://www.w3.org/1999/xhtml",
+        prefix: null,
+        name: "span",
+        attributes: [],
+        style: null,
+        shadow: null,
+        content: null,
+        box: null,
+      },
+    ],
+    serializationId: "div",
+    assignedSlot: null,
+    namespace: "http://www.w3.org/1999/xhtml",
+    prefix: null,
+    name: "div",
+    attributes: [],
+    style: null,
+    shadow: {
+      type: "shadow",
+      children: [
+        {
+          type: "element",
+          children: [],
+          serializationId: "slot",
+          assignedSlot: null,
+          namespace: "http://www.w3.org/1999/xhtml",
+          prefix: null,
+          name: "slot",
+          attributes: [],
+          style: null,
+          shadow: null,
+          content: null,
+          box: null,
+        },
+        {
+          type: "element",
+          children: [],
+          serializationId: "b",
+          assignedSlot: null,
+          namespace: "http://www.w3.org/1999/xhtml",
+          prefix: null,
+          name: "span",
+          attributes: [],
+          style: null,
+          shadow: null,
+          content: null,
+          box: null,
+        },
+      ],
+      serializationId: "shadow",
+      mode: "open",
+      style: [],
+    },
+    content: null,
+    box: null,
   });
 });


### PR DESCRIPTION
Resolves II-8077.

Adds (the serialization `id` of) the assigned slot when serializing `Element` with high verbosity. 
