### PR TITLE
Improve handling of default options in `Page#toJSON`

### DIFF
--- a/.changeset/dirty-horses-exist.md
+++ b/.changeset/dirty-horses-exist.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-web": patch
+---
+
+**Changed:** Improved handling of default options in `Page#.toJSON()`.

--- a/packages/alfa-web/src/page.ts
+++ b/packages/alfa-web/src/page.ts
@@ -69,7 +69,10 @@ export class Page
     return {
       request: this._request.toJSON(options),
       response: this._response.toJSON(options),
-      document: this._document.toJSON(options ?? { device: this._device }),
+      document: this._document.toJSON({
+        device: this._device,
+        ...(options ?? {}),
+      }),
       device: this._device.toJSON(options),
     };
   }


### PR DESCRIPTION
With the previous situation, provided options completely overwrite default ones, i.e. when providing a verbosity the device needed to be provided again.