### PR TITLE
Serialize elements in `WithBadElements`

### DIFF
--- a/.changeset/hungry-eyes-care.md
+++ b/.changeset/hungry-eyes-care.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-rules": minor
+---
+
+**Breaking:** The serialization of diagnostic `WithBadElements` has been changed to include the serialized elements and not just the xpath.

--- a/packages/alfa-rules/src/common/diagnostic/with-bad-elements.ts
+++ b/packages/alfa-rules/src/common/diagnostic/with-bad-elements.ts
@@ -50,7 +50,7 @@ export class WithBadElements extends Diagnostic implements Iterable<Element> {
   public toJSON(options?: Node.SerializationOptions): WithBadElements.JSON {
     return {
       ...super.toJSON(options),
-      errors: this._errors.map((element) => element.path()),
+      errors: Array.toJSON(this._errors, options),
     };
   }
 }
@@ -60,7 +60,7 @@ export class WithBadElements extends Diagnostic implements Iterable<Element> {
  */
 export namespace WithBadElements {
   export interface JSON extends Diagnostic.JSON {
-    errors: Array<string>;
+    errors: Array<Element.JSON>;
   }
 
   export function isWithBadElements(

--- a/packages/alfa-rules/test/common/diagnostic/with-bad-elements.spec.tsx
+++ b/packages/alfa-rules/test/common/diagnostic/with-bad-elements.spec.tsx
@@ -1,0 +1,50 @@
+import { test } from "@siteimprove/alfa-test";
+import { h } from "@siteimprove/alfa-dom";
+
+import * as json from "@siteimprove/alfa-json";
+
+import { WithBadElements } from "../../../dist/common/diagnostic/with-bad-elements.js";
+import { Device } from "@siteimprove/alfa-device";
+
+test("toJSON() calls toJSON() on error elements", (t) => {
+  const element = <div>Foo</div>;
+  const diagnostic = WithBadElements.of("Foo", [element]);
+
+  t.deepEqual(diagnostic.toJSON(), {
+    message: "Foo",
+    errors: [element.toJSON()],
+  });
+});
+
+test("toJSON() calls toJSON() on error elements and respects serialization options", (t) => {
+  const serializationId = crypto.randomUUID();
+  const element = h.element(
+    "div",
+    undefined,
+    [h.text("Foo")],
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    serializationId,
+  );
+  const diagnostic = WithBadElements.of("Foo", [element]);
+
+  t.deepEqual(
+    diagnostic.toJSON({
+      device: Device.standard(),
+      verbosity: json.Serializable.Verbosity.Minimal,
+    }),
+    {
+      message: "Foo",
+      errors: [
+        // @ts-ignore the type checker is not able to infer that the type should be Element.MinimalJSON when the serialization options are passed through WithBadElements.toJSON
+        {
+          type: "element",
+          serializationId,
+        },
+      ],
+    },
+  );
+});

--- a/packages/alfa-rules/test/common/diagnostic/with-bad-elements.spec.tsx
+++ b/packages/alfa-rules/test/common/diagnostic/with-bad-elements.spec.tsx
@@ -1,10 +1,11 @@
 import { test } from "@siteimprove/alfa-test";
 import { h } from "@siteimprove/alfa-dom";
 
+import { Device } from "@siteimprove/alfa-device";
+
 import * as json from "@siteimprove/alfa-json";
 
 import { WithBadElements } from "../../../dist/common/diagnostic/with-bad-elements.js";
-import { Device } from "@siteimprove/alfa-device";
 
 test("toJSON() calls toJSON() on error elements", (t) => {
   const element = <div>Foo</div>;

--- a/packages/alfa-rules/test/tsconfig.json
+++ b/packages/alfa-rules/test/tsconfig.json
@@ -12,6 +12,7 @@
     "./common/outcome.ts",
     "./common/dom/get-colors.spec.tsx",
     "./common/predicate/is-at-the-start.spec.tsx",
+    "./common/diagnostic/with-bad-elements.spec.tsx",
     "./sia-dr6/rule.spec.tsx",
     "./sia-dr18/rule.spec.tsx",
     "./sia-dr34/rule.spec.tsx",


### PR DESCRIPTION
When `WithBadElements` diagnostic is serialized, we now serialize the erroneous elements the same way we do most other places in stead of returning their xpaths. This give the clients control over how the elements should be serialized (full object or only serializationId).