### PR TITLE
Do not scan generated files

### DIFF
--- a/.github/codeql/config.yml
+++ b/.github/codeql/config.yml
@@ -9,3 +9,4 @@ paths:
 paths-ignore:
   - "**/node_modules"
   - "**/*.spec.js"
+  - "**/dist/**"


### PR DESCRIPTION
Most CodeQL alerts are on the generated `.js` files on which we have little control, resulting in needless noise.