### PR TITLE
Support used values

### DIFF
--- a/.changeset/ninety-ligers-fetch.md
+++ b/.changeset/ninety-ligers-fetch.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-style": patch
+---
+
+**Fixed:** `overflow` and `text-overflow` now have no used value on elements where they don't apply.

--- a/.changeset/twenty-snails-tap.md
+++ b/.changeset/twenty-snails-tap.md
@@ -1,0 +1,7 @@
+---
+"@siteimprove/alfa-style": minor
+---
+
+**Added:** Basic support for used values is now available.
+
+This mostly supports no values for elements where the property does not apply.

--- a/docs/review/api/alfa-style.api.md
+++ b/docs/review/api/alfa-style.api.md
@@ -80,30 +80,37 @@ export class Longhand<SPECIFIED = unknown, COMPUTED = SPECIFIED> {
         initial?: COMPUTED;
         parse?: parser.Parser<Slice<Token>, SPECIFIED, string>;
         compute?: Mapper<Value<SPECIFIED>, Value<COMPUTED>, [style: Style]>;
-        options?: Longhand.Options;
+        inherits?: boolean;
+        use?: Mapper<Value<COMPUTED>, Option<Value<COMPUTED>>, [style: Style]>;
     }): Longhand<SPECIFIED, COMPUTED>;
+    // (undocumented)
+    get inherits(): boolean;
     // (undocumented)
     get initial(): COMPUTED;
     // (undocumented)
-    static of<SPECIFIED, COMPUTED>(initial: COMPUTED, parse: parser.Parser<Slice<Token>, SPECIFIED, string>, compute: Mapper<Value<SPECIFIED>, Value<COMPUTED>, [style: Style]>, options?: Longhand.Options): Longhand<SPECIFIED, COMPUTED>;
-    // (undocumented)
-    get options(): Longhand.Options;
+    static of<SPECIFIED, COMPUTED>(initial: COMPUTED, parse: parser.Parser<Slice<Token>, SPECIFIED, string>, compute: Mapper<Value<SPECIFIED>, Value<COMPUTED>, [style: Style]>, options?: Partial<Longhand.Options<COMPUTED>>): Longhand<SPECIFIED, COMPUTED>;
     // (undocumented)
     get parse(): Longhand.Parser<SPECIFIED>;
     get parseBase(): parser.Parser<Slice<Token>, SPECIFIED, string>;
+    // (undocumented)
+    get use(): Mapper<Value<COMPUTED>, Option<Value<COMPUTED>>, [style: Style]>;
 }
 
 // @internal (undocumented)
 export namespace Longhand {
-    export type Computed<T> = T extends Longhand<infer S, infer C> ? C : never;
+    export type Computed<T> = T extends Longhand<infer _, infer C> ? C : never;
     export type Default = Keyword<"initial"> | Keyword<"inherit"> | Keyword<"revert"> | Keyword<"unset">;
-    export function fromKeywords<K extends string>(options: Options, initial: K, ...other: Array<K>): Longhand<Keyword.ToKeywords<K>>;
+    export function fromKeywords<K extends string>(options: Partial<Options<Keyword.ToKeywords<K>>>, initial: K, ...other: Array<K>): Longhand<Keyword.ToKeywords<K>>;
     // (undocumented)
-    export interface Options {
+    export interface Options<COMPUTED> {
         // (undocumented)
         readonly inherits: boolean;
+        // (undocumented)
+        readonly use: Mapper<Value<COMPUTED>, Option<Value<COMPUTED>>, [
+        style: Style
+        ]>;
     }
-    export type Parsed<T> = T extends Longhand<infer S, unknown> ? S : never;
+    export type Parsed<T> = T extends Longhand<infer S, infer _> ? S : never;
     const // (undocumented)
     parseDefaults: Parser<Keyword.ToKeywords<"initial" | "inherit" | "revert" | "unset">>;
     // (undocumented)
@@ -361,6 +368,8 @@ export class Style implements Serializable<Style.JSON> {
     specified<N extends Name>(name: N): Value<Style.Specified<N>>;
     // (undocumented)
     toJSON(): Style.JSON;
+    // (undocumented)
+    used<N extends Name>(name: N): Option<Value<Style.Computed<N>>>;
     // (undocumented)
     get variables(): Map_2<string, Value<Slice<Token>>>;
 }

--- a/packages/alfa-style/src/longhand.ts
+++ b/packages/alfa-style/src/longhand.ts
@@ -178,7 +178,7 @@ export namespace Longhand {
     T extends Longhand<
       // Specified is used both in a covariant (output of the parser) and
       // contravariant (input of compute) position in Longhand. Therefore,
-      //       // it needs to be exactly inferred for the subtyping to exist.
+      // it needs to be exactly inferred for the subtyping to exist.
       infer _,
       infer C
     >

--- a/packages/alfa-style/src/longhand.ts
+++ b/packages/alfa-style/src/longhand.ts
@@ -37,23 +37,19 @@ export class Longhand<SPECIFIED = unknown, COMPUTED = SPECIFIED> {
       initial?: COMPUTED;
       parse?: parser.Parser<Slice<Token>, SPECIFIED, string>;
       compute?: Mapper<Value<SPECIFIED>, Value<COMPUTED>, [style: Style]>;
-      options?: Partial<Longhand.Options<COMPUTED>>;
+      inherits?: boolean;
+      use?: Mapper<Value<COMPUTED>, Option<Value<COMPUTED>>, [style: Style]>;
     } = {},
   ): Longhand<SPECIFIED, COMPUTED> {
     const {
       initial = property._initial,
       parse = property._parseBase,
       compute = property._compute,
-      options = {},
+      inherits = property._inherits,
+      use = property._use,
     } = overrides;
 
-    return new Longhand(
-      initial,
-      parse,
-      compute,
-      options?.inherits ?? property._inherits,
-      options?.use ?? property._use,
-    );
+    return new Longhand(initial, parse, compute, inherits, use);
   }
 
   private readonly _initial: COMPUTED;

--- a/packages/alfa-style/src/predicate/is-block-container.ts
+++ b/packages/alfa-style/src/predicate/is-block-container.ts
@@ -1,6 +1,8 @@
 import type { Style } from "../style.js";
 
 /**
+ * {@link https://drafts.csswg.org/css2/#block-boxes}
+ *
  * @internal
  */
 export function isBlockContainer(style: Style): boolean {

--- a/packages/alfa-style/src/predicate/is-block-container.ts
+++ b/packages/alfa-style/src/predicate/is-block-container.ts
@@ -1,0 +1,11 @@
+import type { Style } from "../style.js";
+
+/**
+ * @internal
+ */
+export function isBlockContainer(style: Style): boolean {
+  const [outside] = style.computed("display").value.values;
+
+  // `table` and `list-item` both set the outside value as `block`.
+  return outside.value === "block";
+}

--- a/packages/alfa-style/src/predicate/is-flex-container.ts
+++ b/packages/alfa-style/src/predicate/is-flex-container.ts
@@ -1,0 +1,12 @@
+import type { Style } from "../style.js";
+
+/**
+ * {@link https://drafts.csswg.org/css-flexbox-1/#flex-container}
+ *
+ * @internal
+ */
+export function isFlexContainer(style: Style): boolean {
+  const [_, inside] = style.computed("display").value.values;
+
+  return inside?.value === "flex";
+}

--- a/packages/alfa-style/src/predicate/is-grid-container.ts
+++ b/packages/alfa-style/src/predicate/is-grid-container.ts
@@ -1,0 +1,12 @@
+import type { Style } from "../style.js";
+
+/**
+ * {@link https://www.w3.org/TR/css-grid-2/#grid-container}
+ *
+ * @internal
+ */
+export function isGridContainer(style: Style): boolean {
+  const [_, inside] = style.computed("display").value.values;
+
+  return inside?.value === "grid";
+}

--- a/packages/alfa-style/src/property/overflow-x.ts
+++ b/packages/alfa-style/src/property/overflow-x.ts
@@ -1,6 +1,13 @@
 import { Keyword } from "@siteimprove/alfa-css";
+import { None, Option } from "@siteimprove/alfa-option";
+import { Predicate } from "@siteimprove/alfa-predicate";
 
 import { Longhand } from "../longhand.js";
+import { isBlockContainer } from "../predicate/is-block-container.js";
+import { isFlexContainer } from "../predicate/is-flex-container.js";
+import { isGridContainer } from "../predicate/is-grid-container.js";
+
+const { or } = Predicate;
 
 const base = Longhand.fromKeywords(
   { inherits: false },
@@ -11,8 +18,11 @@ const base = Longhand.fromKeywords(
   "auto",
 );
 
+const isContainer = or(isBlockContainer, isFlexContainer, isGridContainer);
+
 /**
  * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-x}
+ *
  * @internal
  */
 export default Longhand.extend(base, {
@@ -30,4 +40,5 @@ export default Longhand.extend(base, {
 
       return x.value === "visible" ? Keyword.of("auto") : Keyword.of("hidden");
     }),
+  use: (value, style) => (isContainer(style) ? Option.of(value) : None),
 });

--- a/packages/alfa-style/src/property/overflow-y.ts
+++ b/packages/alfa-style/src/property/overflow-y.ts
@@ -1,8 +1,17 @@
 import { Keyword } from "@siteimprove/alfa-css";
+import { None, Option } from "@siteimprove/alfa-option";
+import { Predicate } from "@siteimprove/alfa-predicate";
 
 import { Longhand } from "../longhand.js";
 
+import { isBlockContainer } from "../predicate/is-block-container.js";
+import { isFlexContainer } from "../predicate/is-flex-container.js";
+import { isGridContainer } from "../predicate/is-grid-container.js";
+
 import Base from "./overflow-x.js";
+
+const { or } = Predicate;
+const isContainer = or(isBlockContainer, isFlexContainer, isGridContainer);
 
 /**
  * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-y}
@@ -23,4 +32,5 @@ export default Longhand.extend(Base, {
 
       return y.value === "visible" ? Keyword.of("auto") : Keyword.of("hidden");
     }),
+  use: (value, style) => (isContainer(style) ? Option.of(value) : None),
 });

--- a/packages/alfa-style/src/property/text-overflow.ts
+++ b/packages/alfa-style/src/property/text-overflow.ts
@@ -1,7 +1,17 @@
+import { None, Option } from "@siteimprove/alfa-option";
+
 import { Longhand } from "../longhand.js";
+import { isBlockContainer } from "../predicate/is-block-container.js";
 
 /**
  * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow}
  * @internal
  */
-export default Longhand.fromKeywords({ inherits: false }, "clip", "ellipsis");
+export default Longhand.fromKeywords(
+  {
+    inherits: false,
+    use: (value, style) => (isBlockContainer(style) ? Option.of(value) : None),
+  },
+  "clip",
+  "ellipsis",
+);

--- a/packages/alfa-style/src/style.ts
+++ b/packages/alfa-style/src/style.ts
@@ -314,11 +314,15 @@ export class Style implements Serializable<Style.JSON> {
    * In our case, we do not resolve further (e.g., `width: auto`).
    * However, we filter out properties that do not apply to certain elements.
    */
-  // public used<N extends Name>(name: N): Option<Value<Style.Computed<N>>> {
-  //   const use = Longhands.get(name).use;
-  //
-  //   return use(this.computed(name), this);
-  // }
+  public used<N extends Name>(name: N): Option<Value<Style.Computed<N>>> {
+    const use = Longhands.get(name).use;
+
+    // Here also, TS is struggling with links between properties of the same
+    // Longhand, and need a bit of help.
+    return use(this.computed(name) as any, this) as Option<
+      Value<Style.Computed<N>>
+    >;
+  }
 
   public initial<N extends Name>(
     name: N,

--- a/packages/alfa-style/src/style.ts
+++ b/packages/alfa-style/src/style.ts
@@ -228,10 +228,16 @@ export class Style implements Serializable<Style.JSON> {
     return this._parent.map((parent) => parent.root()).getOr(this);
   }
 
+  /**
+   * {@link https://www.w3.org/TR/css-cascade/#cascaded}
+   */
   public cascaded<N extends Name>(name: N): Option<Value<Style.Cascaded<N>>> {
     return this._properties.get(name) as Option<Value<Style.Cascaded<N>>>;
   }
 
+  /**
+   * {@link https://www.w3.org/TR/css-cascade/#specified}
+   */
   public specified<N extends Name>(name: N): Value<Style.Specified<N>> {
     const { inherits } = Longhands.get(name);
 
@@ -268,6 +274,9 @@ export class Style implements Serializable<Style.JSON> {
       );
   }
 
+  /**
+   * {@link https://www.w3.org/TR/css-cascade/#computed}
+   */
   public computed<N extends Name>(name: N): Value<Style.Computed<N>> {
     if (this === Style._empty) {
       return this.initial(name);

--- a/packages/alfa-style/src/style.ts
+++ b/packages/alfa-style/src/style.ts
@@ -3,14 +3,8 @@ import { Cache } from "@siteimprove/alfa-cache";
 import { Cascade, Origin } from "@siteimprove/alfa-cascade";
 import { Keyword, Lexer, Token } from "@siteimprove/alfa-css";
 import { Device } from "@siteimprove/alfa-device";
-import type {
-  Declaration} from "@siteimprove/alfa-dom";
-import {
-  Document,
-  Element,
-  Node,
-  Shadow,
-} from "@siteimprove/alfa-dom";
+import type { Declaration } from "@siteimprove/alfa-dom";
+import { Document, Element, Node, Shadow } from "@siteimprove/alfa-dom";
 import { Iterable } from "@siteimprove/alfa-iterable";
 import type * as json from "@siteimprove/alfa-json";
 import type { Serializable } from "@siteimprove/alfa-json";
@@ -196,8 +190,10 @@ export class Style implements Serializable<Style.JSON> {
   private readonly _variables: Map<string, Value<Slice<Token>>>;
   private readonly _properties: Map<Name, Value>;
 
-  // We cache computed properties but not specified properties as these are
-  // inexpensive to resolve from cascaded and computed properties.
+  // We cache computed values but not specified values, as these are
+  // inexpensive to resolve from cascaded and computed values;
+  // nor used values, as in our case they are inexpensive to resolve
+  // from computed values.
   private _computed = Map.empty<Name, Value>();
 
   private constructor(
@@ -237,9 +233,7 @@ export class Style implements Serializable<Style.JSON> {
   }
 
   public specified<N extends Name>(name: N): Value<Style.Specified<N>> {
-    const {
-      options: { inherits },
-    } = Longhands.get(name);
+    const { inherits } = Longhands.get(name);
 
     return this.cascaded(name)
       .map((cascaded) => {
@@ -312,6 +306,19 @@ export class Style implements Serializable<Style.JSON> {
       >
     );
   }
+
+  /**
+   * {@link https://www.w3.org/TR/css-cascade/#used}
+   *
+   * @remarks
+   * In our case, we do not resolve further (e.g., `width: auto`).
+   * However, we filter out properties that do not apply to certain elements.
+   */
+  // public used<N extends Name>(name: N): Option<Value<Style.Computed<N>>> {
+  //   const use = Longhands.get(name).use;
+  //
+  //   return use(this.computed(name), this);
+  // }
 
   public initial<N extends Name>(
     name: N,

--- a/packages/alfa-style/src/tsconfig.json
+++ b/packages/alfa-style/src/tsconfig.json
@@ -34,6 +34,8 @@
     "./node/predicate/is-transparent.ts",
     "./node/predicate/is-visible.ts",
     "./predicate/is-block-container.ts",
+    "./predicate/is-flex-container.ts",
+    "./predicate/is-grid-container.ts",
     "./property/background.ts",
     "./property/background-attachment.ts",
     "./property/background-clip.ts",

--- a/packages/alfa-style/src/tsconfig.json
+++ b/packages/alfa-style/src/tsconfig.json
@@ -33,6 +33,7 @@
     "./node/predicate/is-rendered.ts",
     "./node/predicate/is-transparent.ts",
     "./node/predicate/is-visible.ts",
+    "./predicate/is-block-container.ts",
     "./property/background.ts",
     "./property/background-attachment.ts",
     "./property/background-clip.ts",

--- a/packages/alfa-style/test/common.ts
+++ b/packages/alfa-style/test/common.ts
@@ -1,6 +1,6 @@
 import { Device } from "@siteimprove/alfa-device";
 import type { Element } from "@siteimprove/alfa-dom";
-import { Option } from "@siteimprove/alfa-option";
+import type { Option } from "@siteimprove/alfa-option";
 import { Context } from "@siteimprove/alfa-selector";
 
 import { type Longhands, Style, type Value } from "../dist/index.js";

--- a/packages/alfa-style/test/common.ts
+++ b/packages/alfa-style/test/common.ts
@@ -1,5 +1,6 @@
 import { Device } from "@siteimprove/alfa-device";
 import type { Element } from "@siteimprove/alfa-dom";
+import { Option } from "@siteimprove/alfa-option";
 import { Context } from "@siteimprove/alfa-selector";
 
 import { type Longhands, Style, type Value } from "../dist/index.js";
@@ -29,4 +30,15 @@ export function specified<N extends Longhands.Name>(
   context: Context = Context.empty(),
 ): Value.JSON<Style.Specified<N>> {
   return Style.from(element, device, context).specified(name).toJSON();
+}
+
+/**
+ * @internal
+ */
+export function used<N extends Longhands.Name>(
+  element: Element,
+  name: N,
+  context: Context = Context.empty(),
+): Option.JSON<Value<Style.Computed<N>>> {
+  return Style.from(element, device, context).used(name).toJSON();
 }

--- a/packages/alfa-style/test/property/overflow.spec.tsx
+++ b/packages/alfa-style/test/property/overflow.spec.tsx
@@ -1,0 +1,93 @@
+import { h } from "@siteimprove/alfa-dom";
+import { test } from "@siteimprove/alfa-test";
+
+import { used } from "../common.js";
+
+test(".used() returns the computed value for a block container", (t) => {
+  for (const value of [
+    "auto",
+    "clip",
+    "hidden",
+    "scroll",
+    "visible",
+  ] as const) {
+    const target = <div style={{ overflow: value }}></div>;
+    h.document([target]);
+
+    for (const direction of ["x", "y"] as const) {
+      t.deepEqual(used(target, `overflow-${direction}`), {
+        type: "some",
+        value: {
+          value: { type: "keyword", value },
+          source: { name: `overflow`, value, important: false },
+        },
+      });
+    }
+  }
+});
+
+test(".used() returns the computed value for a flex container", (t) => {
+  for (const value of [
+    "auto",
+    "clip",
+    "hidden",
+    "scroll",
+    "visible",
+  ] as const) {
+    for (const display of ["flex", "inline-flex", "block flex"]) {
+      const target = <div style={{ overflow: value, display }}></div>;
+      h.document([target]);
+
+      for (const direction of ["x", "y"] as const) {
+        t.deepEqual(used(target, `overflow-${direction}`), {
+          type: "some",
+          value: {
+            value: { type: "keyword", value },
+            source: { name: `overflow`, value, important: false },
+          },
+        });
+      }
+    }
+  }
+});
+
+test(".used() returns the computed value for a grid container", (t) => {
+  for (const value of [
+    "auto",
+    "clip",
+    "hidden",
+    "scroll",
+    "visible",
+  ] as const) {
+    for (const display of ["grid", "inline-grid", "block grid"]) {
+      const target = <div style={{ overflow: value, display }}></div>;
+      h.document([target]);
+
+      for (const direction of ["x", "y"] as const) {
+        t.deepEqual(used(target, `overflow-${direction}`), {
+          type: "some",
+          value: {
+            value: { type: "keyword", value },
+            source: { name: `overflow`, value, important: false },
+          },
+        });
+      }
+    }
+  }
+});
+
+test(".used() returns None for others element", (t) => {
+  for (const value of [
+    "auto",
+    "clip",
+    "hidden",
+    "scroll",
+    "visible",
+  ] as const) {
+    const target = <span style={{ overflow: value }}></span>;
+    h.document([target]);
+
+    t.deepEqual(used(target, "overflow-x"), { type: "none" });
+    t.deepEqual(used(target, "overflow-y"), { type: "none" });
+  }
+});

--- a/packages/alfa-style/test/property/text-overflow.spec.tsx
+++ b/packages/alfa-style/test/property/text-overflow.spec.tsx
@@ -1,0 +1,29 @@
+import { h } from "@siteimprove/alfa-dom";
+import { test } from "@siteimprove/alfa-test";
+import { used } from "../common.js";
+
+test(".used() returns the computed value for a block element", (t) => {
+  for (const value of ["clip", "ellipsis"] as const) {
+    const target = <div style={{ textOverflow: value }}></div>;
+    h.document([target]);
+
+    const actual = used(target, "text-overflow");
+    t.deepEqual(actual, {
+      type: "some",
+      value: {
+        value: { type: "keyword", value },
+        source: { name: "text-overflow", value, important: false },
+      },
+    });
+  }
+});
+
+test(".used() returns None for a line element", (t) => {
+  for (const value of ["clip", "ellipsis"] as const) {
+    const target = <span style={{ textOverflow: value }}></span>;
+    h.document([target]);
+
+    const actual = used(target, "text-overflow");
+    t.deepEqual(actual, { type: "none" });
+  }
+});

--- a/packages/alfa-style/test/property/text-overflow.spec.tsx
+++ b/packages/alfa-style/test/property/text-overflow.spec.tsx
@@ -1,5 +1,6 @@
 import { h } from "@siteimprove/alfa-dom";
 import { test } from "@siteimprove/alfa-test";
+
 import { used } from "../common.js";
 
 test(".used() returns the computed value for a block element", (t) => {
@@ -7,8 +8,7 @@ test(".used() returns the computed value for a block element", (t) => {
     const target = <div style={{ textOverflow: value }}></div>;
     h.document([target]);
 
-    const actual = used(target, "text-overflow");
-    t.deepEqual(actual, {
+    t.deepEqual(used(target, "text-overflow"), {
       type: "some",
       value: {
         value: { type: "keyword", value },
@@ -23,7 +23,6 @@ test(".used() returns None for a line element", (t) => {
     const target = <span style={{ textOverflow: value }}></span>;
     h.document([target]);
 
-    const actual = used(target, "text-overflow");
-    t.deepEqual(actual, { type: "none" });
+    t.deepEqual(used(target, "text-overflow"), { type: "none" });
   }
 });

--- a/packages/alfa-style/test/tsconfig.json
+++ b/packages/alfa-style/test/tsconfig.json
@@ -55,6 +55,7 @@
     "./property/mix-blend-mode.spec.tsx",
     "./property/opacity.spec.tsx",
     "./property/outline.spec.tsx",
+    "./property/overflow.spec.tsx",
     "./property/rotate.spec.tsx",
     "./property/text-decoration.spec.tsx",
     "./property/text-indent.spec.tsx",

--- a/packages/alfa-style/test/tsconfig.json
+++ b/packages/alfa-style/test/tsconfig.json
@@ -58,6 +58,7 @@
     "./property/rotate.spec.tsx",
     "./property/text-decoration.spec.tsx",
     "./property/text-indent.spec.tsx",
+    "./property/text-overflow.spec.tsx",
     "./property/text-shadow.spec.tsx",
     "./property/top.spec.tsx",
     "./property/z-index.spec.tsx",


### PR DESCRIPTION
Part of #955 

While we cannot fully support used values for stuff that depends on layout (e.g., `width: auto`) (nor really need to yet), we can at least return no used value when the property does not apply to the element.

This adds the support for used value, as well as computes it correctly for `overflow` and `text-overflow`. We may have other properties in the same case, but we'll handle that when needed.