### PR TITLE
Improve disabled text detection

### DIFF
--- a/.changeset/perfect-rivers-watch.md
+++ b/.changeset/perfect-rivers-watch.md
@@ -1,0 +1,7 @@
+---
+"@siteimprove/alfa-rules": patch
+---
+
+**Fixed:** SIA-R66 and SIA-R69 ar now inapplicable to text in `aria-disabled` `<a>` elements without `href`.
+
+See https://github.com/act-rules/act-rules.github.io/issues/2215

--- a/packages/alfa-rules/src/common/applicability/non-disabled-texts.ts
+++ b/packages/alfa-rules/src/common/applicability/non-disabled-texts.ts
@@ -1,14 +1,8 @@
 import { Cache } from "@siteimprove/alfa-cache";
 import { DOM, Node as ariaNode } from "@siteimprove/alfa-aria";
 import type { Device } from "@siteimprove/alfa-device";
-import type {
-  Document} from "@siteimprove/alfa-dom";
-import {
-  Element,
-  Namespace,
-  Node,
-  Text,
-} from "@siteimprove/alfa-dom";
+import type { Document } from "@siteimprove/alfa-dom";
+import { Element, Namespace, Node, Text } from "@siteimprove/alfa-dom";
 import type { Iterable } from "@siteimprove/alfa-iterable";
 import { Predicate } from "@siteimprove/alfa-predicate";
 import { Refinement } from "@siteimprove/alfa-refinement";
@@ -17,7 +11,7 @@ import { Set } from "@siteimprove/alfa-set";
 import { Style } from "@siteimprove/alfa-style";
 
 const { hasRole, isSemanticallyDisabled } = DOM;
-const { hasNamespace, isElement } = Element;
+const { hasAttribute, hasName, hasNamespace, isElement } = Element;
 const { or, not } = Predicate;
 const { and, test } = Refinement;
 const { isVisible } = Style;
@@ -92,8 +86,16 @@ function* visit(
 }
 
 function isDisabledGroupOrWidget(device: Device): Predicate<Element> {
-  return and(
-    hasRole(device, (role) => role.isWidget() || role.is("group")),
-    isSemanticallyDisabled,
+  return or(
+    and(
+      hasRole(device, (role) => role.isWidget() || role.is("group")),
+      isSemanticallyDisabled,
+    ),
+    // see https://github.com/act-rules/act-rules.github.io/issues/2215
+    and(
+      hasName("a", "area"),
+      not(hasAttribute("href")),
+      hasAttribute("aria-disabled", (value) => value === "true"),
+    ),
   );
 }

--- a/packages/alfa-rules/test/sia-r69/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r69/rule.spec.tsx
@@ -932,3 +932,26 @@ test("evaluate() can tell when interposed descendant overlaps offset parent, but
     }),
   ]);
 });
+
+test("evaluate() is inapplicable to `aria-disabled` `<a>` elements without `href`", async (t) => {
+  const document = h.document([<a aria-disabled="true">X</a>]);
+
+  t.deepEqual(await evaluate(R69, { document }), [inapplicable(R69)]);
+});
+
+test("evaluate() is applicable to  `<a>` elements without `href`", async (t) => {
+  const target = h.text("X");
+  const document = h.document([<a>{target}</a>]);
+
+  t.deepEqual(await evaluate(R69, { document }), [
+    passed(R69, target, {
+      1: Outcomes.HasSufficientContrast(21, 4.5, [
+        Diagnostic.Pairing.of(
+          ["foreground", rgb(0, 0, 0)],
+          ["background", rgb(1, 1, 1)],
+          21,
+        ),
+      ]),
+    }),
+  ]);
+});


### PR DESCRIPTION
Make text in `<a aria-disabled="true">foo</a>` inapplicable to color contrast rules.
It previously was because the `<a>` element without `href` is **not** a `link`, hence not a `widget`, making it fall through the exception in Applicability.

See https://github.com/act-rules/act-rules.github.io/issues/2215