### PR TITLE
Rename `tree.Node#serializationId` to `tree.Node#internalId`.

### DIFF
--- a/.changeset/fuzzy-toys-turn.md
+++ b/.changeset/fuzzy-toys-turn.md
@@ -6,4 +6,4 @@
 
 **Breaking:** `#serializationId` has been replaced with `#internalId`.
 
-The old `#serializationId` is now deprecated and acts as an alias to `#internalId`.
+The old `#serializationId` is now deprecated and acts as an alias to `#internalId`. It will be removed in a future version.

--- a/.changeset/fuzzy-toys-turn.md
+++ b/.changeset/fuzzy-toys-turn.md
@@ -1,0 +1,9 @@
+---
+"@siteimprove/alfa-rules": minor
+"@siteimprove/alfa-tree": minor
+"@siteimprove/alfa-dom": minor
+---
+
+**Breaking:** `#serializationId` has been replaced with `#internalId`.
+
+The old `#serializationId` is now deprecated and acts as an alias to `#internalId`.

--- a/docs/review/api/alfa-dom.api.md
+++ b/docs/review/api/alfa-dom.api.md
@@ -42,7 +42,7 @@ export class Attribute<N extends string = string> extends Node<"attribute"> {
     // (undocumented)
     get namespace(): Option<Namespace>;
     // (undocumented)
-    static of<N extends string = string>(namespace: Option<Namespace>, prefix: Option<string>, name: N, value: string, externalId?: string, serializationId?: string, extraData?: any): Attribute<N>;
+    static of<N extends string = string>(namespace: Option<Namespace>, prefix: Option<string>, name: N, value: string, externalId?: string, internalId?: string, extraData?: any): Attribute<N>;
     // (undocumented)
     get owner(): Option<Element>;
     // (undocumented)
@@ -132,7 +132,7 @@ export class Comment extends Node<"comment"> {
     // @internal (undocumented)
     protected _internalPath(options?: Node.Traversal): string;
     // (undocumented)
-    static of(data: string, externalId?: string, serializationId?: string, extraData?: any): Comment;
+    static of(data: string, externalId?: string, internalId?: string, extraData?: any): Comment;
     // (undocumented)
     toJSON(options: Node.SerializationOptions & {
         verbosity: json.Serializable.Verbosity.Minimal | json.Serializable.Verbosity.Low;
@@ -240,7 +240,7 @@ export class Document extends Node<"document"> {
     // @internal (undocumented)
     protected _internalPath(options?: Node.Traversal): string;
     // (undocumented)
-    static of(children: Iterable_2<Node>, style?: Iterable_2<Sheet>, externalId?: string, serializationId?: string, extraData?: any): Document;
+    static of(children: Iterable_2<Node>, style?: Iterable_2<Sheet>, externalId?: string, internalId?: string, extraData?: any): Document;
     // (undocumented)
     parent(options?: Node.Traversal): Option<Node>;
     // (undocumented)
@@ -314,7 +314,7 @@ export class Element<N extends string = string> extends Node<"element"> implemen
     // (undocumented)
     get namespace(): Option<Namespace>;
     // (undocumented)
-    static of<N extends string = string>(namespace: Option<Namespace>, prefix: Option<string>, name: N, attributes?: Iterable_2<Attribute>, children?: Iterable_2<Node>, style?: Option<Block>, box?: Option<Rectangle>, device?: Option<Device>, externalId?: string, serializationId?: string, extraData?: any): Element<N>;
+    static of<N extends string = string>(namespace: Option<Namespace>, prefix: Option<string>, name: N, attributes?: Iterable_2<Attribute>, children?: Iterable_2<Node>, style?: Option<Block>, box?: Option<Rectangle>, device?: Option<Device>, externalId?: string, internalId?: string, extraData?: any): Element<N>;
     // (undocumented)
     protected _optionsList: Sequence<Element<"option">> | undefined;
     // (undocumented)
@@ -433,7 +433,7 @@ export class Fragment extends Node<"fragment"> {
     // @internal (undocumented)
     protected _internalPath(): string;
     // (undocumented)
-    static of(children: Iterable_2<Node>, externalId?: string, serializationId?: string, extraData?: any): Fragment;
+    static of(children: Iterable_2<Node>, externalId?: string, internalId?: string, extraData?: any): Fragment;
     // (undocumented)
     toString(): string;
 }
@@ -476,20 +476,20 @@ export namespace GroupingRule {
 }
 
 // @public (undocumented)
-export function h<N extends string = string>(name: N, attributes?: Array<Attribute> | Record<string, string | boolean>, children?: Array<Node | string>, style?: Array<Declaration> | Record<string, string>, box?: Rectangle, device?: Device, externalId?: string, serializationId?: string, extraData?: any): Element<N>;
+export function h<N extends string = string>(name: N, attributes?: Array<Attribute> | Record<string, string | boolean>, children?: Array<Node | string>, style?: Array<Declaration> | Record<string, string>, box?: Rectangle, device?: Device, externalId?: string, internalId?: string, extraData?: any): Element<N>;
 
 // @public (undocumented)
 export namespace h {
     // (undocumented)
-    export function attribute<N extends string = string>(name: N, value: string, externalId?: string, serializationId?: string, extraData?: any): Attribute<N>;
+    export function attribute<N extends string = string>(name: N, value: string, externalId?: string, internalId?: string, extraData?: any): Attribute<N>;
     // (undocumented)
     export function block(declarations: Array<Declaration> | Record<string, string>): Block;
     // (undocumented)
     export function declaration(name: string, value: string, important?: boolean): Declaration;
     // (undocumented)
-    export function document(children: Array<Node | string>, style?: Array<Sheet>, externalId?: string, serializationId?: string, extraData?: any): Document;
+    export function document(children: Array<Node | string>, style?: Array<Sheet>, externalId?: string, internalId?: string, extraData?: any): Document;
     // (undocumented)
-    export function element<N extends string = string>(name: N, attributes?: Array<Attribute> | Record<string, string | boolean>, children?: Array<Node | string>, style?: Array<Declaration> | Record<string, string>, namespace?: Namespace, box?: Rectangle, device?: Device, externalId?: string, serializationId?: string, extraData?: any): Element<N>;
+    export function element<N extends string = string>(name: N, attributes?: Array<Attribute> | Record<string, string | boolean>, children?: Array<Node | string>, style?: Array<Declaration> | Record<string, string>, namespace?: Namespace, box?: Rectangle, device?: Device, externalId?: string, internalId?: string, extraData?: any): Element<N>;
     // (undocumented)
     export function fragment(children: Array<Node | string>, externalId?: string, extraData?: any): Fragment;
     // (undocumented)
@@ -518,13 +518,13 @@ export namespace h {
         export function supports(condition: string, rules: Array<Rule>): SupportsRule;
     }
     // (undocumented)
-    export function shadow(children: Array<Node | string>, style?: Array<Sheet>, mode?: Shadow.Mode, externalId?: string, serializationId?: string, extraData?: any): Shadow;
+    export function shadow(children: Array<Node | string>, style?: Array<Sheet>, mode?: Shadow.Mode, externalId?: string, internalId?: string, extraData?: any): Shadow;
     // (undocumented)
     export function sheet(rules: Array<Rule>, disabled?: boolean, condition?: string): Sheet;
     // (undocumented)
-    export function text(data: string, externalId?: string, serializationId?: string, extraData?: any): Text;
+    export function text(data: string, externalId?: string, internalId?: string, extraData?: any): Text;
     // (undocumented)
-    export function type<N extends string = string>(name: N, publicId?: string, systemId?: string, externalId?: string, serializationId?: string, extraData?: any): Type<N>;
+    export function type<N extends string = string>(name: N, publicId?: string, systemId?: string, externalId?: string, internalId?: string, extraData?: any): Type<N>;
 }
 
 // @public (undocumented)
@@ -783,7 +783,7 @@ export namespace NamespaceRule {
 
 // @public (undocumented)
 export abstract class Node<T extends string = string> extends tree.Node<Node.Traversal.Flag, T> implements earl.Serializable<Node.EARL>, json.Serializable<tree.Node.JSON<T>>, sarif.Serializable<sarif.Location> {
-    protected constructor(children: Array<Node>, type: T, externalId?: string, serializationId?: string, extraData?: any);
+    protected constructor(children: Array<Node>, type: T, externalId?: string, internalId?: string, extraData?: any);
     // (undocumented)
     equals(value: Node): boolean;
     // (undocumented)
@@ -1088,7 +1088,7 @@ export class Shadow extends Node<"shadow"> {
     // (undocumented)
     get mode(): Shadow.Mode;
     // (undocumented)
-    static of(children: Iterable_2<Node>, style?: Iterable_2<Sheet>, mode?: Shadow.Mode, externalId?: string, serializationId?: string, extraData?: any): Shadow;
+    static of(children: Iterable_2<Node>, style?: Iterable_2<Sheet>, mode?: Shadow.Mode, externalId?: string, internalId?: string, extraData?: any): Shadow;
     // (undocumented)
     parent(options?: Node.Traversal): Option<Node>;
     // (undocumented)
@@ -1274,7 +1274,7 @@ export class Text extends Node<"text"> implements Slotable {
     // @internal (undocumented)
     protected _internalPath(options?: Node.Traversal): string;
     // (undocumented)
-    static of(data: string, externalId?: string, serializationId?: string, extraData?: any): Text;
+    static of(data: string, externalId?: string, internalId?: string, extraData?: any): Text;
     // (undocumented)
     toJSON(options: Node.SerializationOptions & {
         verbosity: json.Serializable.Verbosity.Minimal | json.Serializable.Verbosity.Low;
@@ -1310,7 +1310,7 @@ export class Type<N extends string = string> extends Node<"type"> {
     // (undocumented)
     get name(): N;
     // (undocumented)
-    static of<N extends string = string>(name: N, publicId?: Option<string>, systemId?: Option<string>, externalId?: string, serializationId?: string, extraData?: any): Type<N>;
+    static of<N extends string = string>(name: N, publicId?: Option<string>, systemId?: Option<string>, externalId?: string, internalId?: string, extraData?: any): Type<N>;
     // (undocumented)
     get publicId(): Option<string>;
     // (undocumented)

--- a/docs/review/api/alfa-tree.api.md
+++ b/docs/review/api/alfa-tree.api.md
@@ -94,7 +94,7 @@ export abstract class Node<F extends Flags.allFlags, T extends string = string> 
     // (undocumented)
     root(options?: Flags<F>): Node<F>;
     // @deprecated (undocumented)
-    get serializationIdId(): string | undefined;
+    get serializationId(): string | undefined;
     // (undocumented)
     siblings(options?: Flags<F>): Sequence<Node<F>>;
     // (undocumented)
@@ -117,6 +117,8 @@ export namespace Node {
         externalId?: string;
         // (undocumented)
         internalId?: string;
+        // (undocumented)
+        serializationId?: string;
         // (undocumented)
         type: T;
     }

--- a/docs/review/api/alfa-tree.api.md
+++ b/docs/review/api/alfa-tree.api.md
@@ -18,7 +18,7 @@ import { Sequence } from '@siteimprove/alfa-sequence';
 export abstract class Node<F extends Flags.allFlags, T extends string = string> implements Iterable<Node<F>>, Equatable, Hashable, json.Serializable<Node.JSON<T>> {
     // (undocumented)
     [Symbol.iterator](): Iterator<Node<F>>;
-    protected constructor(children: Array<Node<F>>, type: T, externalId?: string, serializationId?: string, extraData?: any);
+    protected constructor(children: Array<Node<F>>, type: T, externalId?: string, internalId?: string, extraData?: any);
     // (undocumented)
     ancestors(options?: Flags<F>): Sequence<Node<F>>;
     // @internal (undocumented)
@@ -60,6 +60,8 @@ export abstract class Node<F extends Flags.allFlags, T extends string = string> 
     // (undocumented)
     index(options?: Flags<F>): number;
     // (undocumented)
+    get internalId(): string;
+    // (undocumented)
     isAncestorOf(node: Node<F>, options?: Flags<F>): boolean;
     // (undocumented)
     isChildOf(node: Node<F>, options?: Flags<F>): boolean;
@@ -91,8 +93,8 @@ export abstract class Node<F extends Flags.allFlags, T extends string = string> 
     previous(options?: Flags<F>): Option<Node<F>>;
     // (undocumented)
     root(options?: Flags<F>): Node<F>;
-    // (undocumented)
-    get serializationId(): string;
+    // @deprecated (undocumented)
+    get serializationIdId(): string | undefined;
     // (undocumented)
     siblings(options?: Flags<F>): Sequence<Node<F>>;
     // (undocumented)
@@ -114,7 +116,7 @@ export namespace Node {
         // (undocumented)
         externalId?: string;
         // (undocumented)
-        serializationId?: string;
+        internalId?: string;
         // (undocumented)
         type: T;
     }

--- a/packages/alfa-dom/src/h.ts
+++ b/packages/alfa-dom/src/h.ts
@@ -3,9 +3,7 @@ import { Predicate } from "@siteimprove/alfa-predicate";
 
 import { Device } from "@siteimprove/alfa-device";
 import type { Rectangle } from "@siteimprove/alfa-rectangle";
-import type {
-  Node,
-  Rule} from "./index.js";
+import type { Node, Rule } from "./index.js";
 import {
   Attribute,
   Block,
@@ -44,7 +42,7 @@ export function h<N extends string = string>(
   box?: Rectangle,
   device: Device = Device.standard(),
   externalId?: string,
-  serializationId?: string,
+  internalId?: string,
   extraData?: any,
 ): Element<N> {
   return h.element(
@@ -56,7 +54,7 @@ export function h<N extends string = string>(
     box,
     device,
     externalId,
-    serializationId,
+    internalId,
     extraData,
   );
 }
@@ -74,7 +72,7 @@ export namespace h {
     box?: Rectangle,
     device?: Device,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ): Element<N> {
     attributes = Array.isArray(attributes)
@@ -124,7 +122,7 @@ export namespace h {
       Option.from(box),
       Option.from(device),
       externalId,
-      serializationId,
+      internalId,
       extraData,
     );
 
@@ -143,7 +141,7 @@ export namespace h {
     name: N,
     value: string,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ): Attribute<N> {
     return Attribute.of(
@@ -152,7 +150,7 @@ export namespace h {
       name,
       value,
       externalId,
-      serializationId,
+      internalId,
       extraData,
     );
   }
@@ -160,17 +158,17 @@ export namespace h {
   export function text(
     data: string,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ): Text {
-    return Text.of(data, externalId, serializationId, extraData);
+    return Text.of(data, externalId, internalId, extraData);
   }
 
   export function document(
     children: Array<Node | string>,
     style?: Array<Sheet>,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ): Document {
     return Document.of(
@@ -179,7 +177,7 @@ export namespace h {
       ),
       style,
       externalId,
-      serializationId,
+      internalId,
       extraData,
     );
   }
@@ -189,7 +187,7 @@ export namespace h {
     style?: Array<Sheet>,
     mode?: Shadow.Mode,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ): Shadow {
     return Shadow.of(
@@ -199,7 +197,7 @@ export namespace h {
       style,
       mode,
       externalId,
-      serializationId,
+      internalId,
       extraData,
     );
   }
@@ -209,7 +207,7 @@ export namespace h {
     publicId?: string,
     systemId?: string,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ): Type<N> {
     return Type.of(
@@ -217,7 +215,7 @@ export namespace h {
       Option.from(publicId),
       Option.from(systemId),
       externalId,
-      serializationId,
+      internalId,
       extraData,
     );
   }

--- a/packages/alfa-dom/src/jsx.ts
+++ b/packages/alfa-dom/src/jsx.ts
@@ -21,7 +21,7 @@ export function jsx<N extends string = string>(
   let box: Rectangle | undefined = undefined;
   let device: Device | undefined = undefined;
   let externalId: string | undefined = undefined;
-  let serializationId: string | undefined = undefined;
+  let internalId: string | undefined = undefined;
 
   for (const [name, value] of entries(properties ?? {})) {
     if (value === null || value === undefined) {
@@ -50,9 +50,9 @@ export function jsx<N extends string = string>(
         }
         continue;
 
-      case "serializationId":
+      case "internalId":
         if (typeof value === "string") {
-          serializationId = value;
+          internalId = value;
         }
         continue;
 
@@ -69,7 +69,7 @@ export function jsx<N extends string = string>(
     box,
     device,
     externalId,
-    serializationId,
+    internalId,
   );
 }
 

--- a/packages/alfa-dom/src/node.ts
+++ b/packages/alfa-dom/src/node.ts
@@ -50,10 +50,10 @@ export abstract class Node<T extends string = string>
     children: Array<Node>,
     type: T,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ) {
-    super(children, type, externalId, serializationId, extraData);
+    super(children, type, externalId, internalId, extraData);
   }
 
   /**

--- a/packages/alfa-dom/src/node/attribute.ts
+++ b/packages/alfa-dom/src/node/attribute.ts
@@ -25,7 +25,7 @@ export class Attribute<N extends string = string> extends Node<"attribute"> {
     name: N,
     value: string,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ): Attribute<N> {
     return new Attribute(
@@ -34,7 +34,7 @@ export class Attribute<N extends string = string> extends Node<"attribute"> {
       name,
       value,
       externalId,
-      serializationId,
+      internalId,
       extraData,
     );
   }
@@ -51,10 +51,10 @@ export class Attribute<N extends string = string> extends Node<"attribute"> {
     name: N,
     value: string,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ) {
-    super([], "attribute", externalId, serializationId, extraData);
+    super([], "attribute", externalId, internalId, extraData);
 
     this._namespace = namespace;
     this._prefix = prefix;
@@ -242,7 +242,7 @@ export namespace Attribute {
         attribute.name,
         attribute.value,
         attribute.externalId,
-        attribute.serializationId,
+        attribute.internalId,
       ),
     );
   }
@@ -260,7 +260,7 @@ export namespace Attribute {
         attribute.name,
         attribute.value,
         attribute.externalId,
-        attribute.serializationId,
+        attribute.internalId,
         attribute.extraData,
       ),
     );

--- a/packages/alfa-dom/src/node/comment.ts
+++ b/packages/alfa-dom/src/node/comment.ts
@@ -11,10 +11,10 @@ export class Comment extends Node<"comment"> {
   public static of(
     data: string,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ): Comment {
-    return new Comment(data, externalId, serializationId, extraData);
+    return new Comment(data, externalId, internalId, extraData);
   }
 
   public static empty(): Comment {
@@ -26,10 +26,10 @@ export class Comment extends Node<"comment"> {
   private constructor(
     data: string,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ) {
-    super([], "comment", externalId, serializationId, extraData);
+    super([], "comment", externalId, internalId, extraData);
 
     this._data = data;
   }
@@ -106,7 +106,7 @@ export namespace Comment {
    */
   export function fromComment(json: JSON): Trampoline<Comment> {
     return Trampoline.done(
-      Comment.of(json.data, json.externalId, json.serializationId),
+      Comment.of(json.data, json.externalId, json.internalId),
     );
   }
 
@@ -118,7 +118,7 @@ export namespace Comment {
       Comment.of(
         comment.data,
         comment.externalId,
-        comment.serializationId,
+        comment.internalId,
         comment.extraData,
       ),
     );

--- a/packages/alfa-dom/src/node/document.ts
+++ b/packages/alfa-dom/src/node/document.ts
@@ -19,14 +19,14 @@ export class Document extends Node<"document"> {
     children: Iterable<Node>,
     style: Iterable<Sheet> = [],
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ): Document {
     return new Document(
       Array.from(children),
       style,
       externalId,
-      serializationId,
+      internalId,
       extraData,
     );
   }
@@ -42,10 +42,10 @@ export class Document extends Node<"document"> {
     children: Array<Node>,
     style: Iterable<Sheet>,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ) {
-    super(children, "document", externalId, serializationId, extraData);
+    super(children, "document", externalId, internalId, extraData);
 
     this._style = Array.from(style);
   }
@@ -163,7 +163,7 @@ export namespace Document {
         children,
         json.style.map(Sheet.from),
         json.externalId,
-        json.serializationId,
+        json.internalId,
       ),
     );
   }
@@ -187,7 +187,7 @@ export namespace Document {
           Iterable.flatten(children),
           document.style,
           document.externalId,
-          document.serializationId,
+          document.internalId,
           document.extraData,
         );
       });

--- a/packages/alfa-dom/src/node/element.ts
+++ b/packages/alfa-dom/src/node/element.ts
@@ -45,7 +45,7 @@ export class Element<N extends string = string>
     box: Option<Rectangle> = None,
     device: Option<Device> = None,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ): Element<N> {
     return new Element(
@@ -58,7 +58,7 @@ export class Element<N extends string = string>
       box,
       device,
       externalId,
-      serializationId,
+      internalId,
       extraData,
     );
   }
@@ -84,10 +84,10 @@ export class Element<N extends string = string>
     box: Option<Rectangle>,
     device: Option<Device>,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ) {
-    super(children, "element", externalId, serializationId, extraData);
+    super(children, "element", externalId, internalId, extraData);
 
     this._namespace = namespace;
     this._prefix = prefix;
@@ -491,7 +491,7 @@ export namespace Element {
         Option.from(json.box).map(Rectangle.from),
         Option.from(device),
         json.externalId,
-        json.serializationId,
+        json.internalId,
       );
 
       if (json.shadow !== null) {
@@ -546,7 +546,7 @@ export namespace Element {
           deviceOption.flatMap((d) => element.getBoundingBox(d)),
           deviceOption,
           element.externalId,
-          element.serializationId,
+          element.internalId,
           element.extraData,
         );
 

--- a/packages/alfa-dom/src/node/fragment.ts
+++ b/packages/alfa-dom/src/node/fragment.ts
@@ -13,13 +13,13 @@ export class Fragment extends Node<"fragment"> {
   public static of(
     children: Iterable<Node>,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ): Fragment {
     return new Fragment(
       Array.from(children),
       externalId,
-      serializationId,
+      internalId,
       extraData,
     );
   }
@@ -31,10 +31,10 @@ export class Fragment extends Node<"fragment"> {
   private constructor(
     children: Array<Node>,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ) {
-    super(children, "fragment", externalId, serializationId, extraData);
+    super(children, "fragment", externalId, internalId, extraData);
   }
 
   /**

--- a/packages/alfa-dom/src/node/shadow.ts
+++ b/packages/alfa-dom/src/node/shadow.ts
@@ -19,7 +19,7 @@ export class Shadow extends Node<"shadow"> {
     style: Iterable<Sheet> = [],
     mode: Shadow.Mode = Shadow.Mode.Open,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ): Shadow {
     return new Shadow(
@@ -27,7 +27,7 @@ export class Shadow extends Node<"shadow"> {
       Array.from(style),
       mode,
       externalId,
-      serializationId,
+      internalId,
       extraData,
     );
   }
@@ -45,10 +45,10 @@ export class Shadow extends Node<"shadow"> {
     style: Array<Sheet>,
     mode: Shadow.Mode,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ) {
-    super(children, "shadow", externalId, serializationId, extraData);
+    super(children, "shadow", externalId, internalId, extraData);
 
     this._mode = mode;
     this._style = style;
@@ -188,7 +188,7 @@ export namespace Shadow {
         json.style.map(Sheet.from),
         json.mode as Mode,
         json.externalId,
-        json.serializationId,
+        json.internalId,
       ),
     );
   }
@@ -214,7 +214,7 @@ export namespace Shadow {
           shadow.mode,
           shadow.externalId,
           shadow.extraData,
-          shadow.serializationId,
+          shadow.internalId,
         );
       });
   }

--- a/packages/alfa-dom/src/node/text.ts
+++ b/packages/alfa-dom/src/node/text.ts
@@ -14,10 +14,10 @@ export class Text extends Node<"text"> implements Slotable {
   public static of(
     data: string,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ): Text {
-    return new Text(data, externalId, serializationId, extraData);
+    return new Text(data, externalId, internalId, extraData);
   }
 
   public static empty(): Text {
@@ -29,10 +29,10 @@ export class Text extends Node<"text"> implements Slotable {
   private constructor(
     data: string,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ) {
-    super([], "text", externalId, serializationId, extraData);
+    super([], "text", externalId, internalId, extraData);
 
     this._data = data;
   }
@@ -121,7 +121,7 @@ export namespace Text {
    */
   export function fromText(json: JSON): Trampoline<Text> {
     return Trampoline.done(
-      Text.of(json.data, json.externalId, undefined, json.serializationId),
+      Text.of(json.data, json.externalId, undefined, json.internalId),
     );
   }
 
@@ -130,7 +130,7 @@ export namespace Text {
    */
   export function cloneText(text: Text) {
     return Trampoline.done(
-      Text.of(text.data, text.externalId, text.extraData, text.serializationId),
+      Text.of(text.data, text.externalId, text.extraData, text.internalId),
     );
   }
 }

--- a/packages/alfa-dom/src/node/type.ts
+++ b/packages/alfa-dom/src/node/type.ts
@@ -14,7 +14,7 @@ export class Type<N extends string = string> extends Node<"type"> {
     publicId: Option<string> = None,
     systemId: Option<string> = None,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ): Type<N> {
     return new Type(
@@ -22,7 +22,7 @@ export class Type<N extends string = string> extends Node<"type"> {
       publicId,
       systemId,
       externalId,
-      serializationId,
+      internalId,
       extraData,
     );
   }
@@ -40,10 +40,10 @@ export class Type<N extends string = string> extends Node<"type"> {
     publicId: Option<string>,
     systemId: Option<string>,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ) {
-    super([], "type", externalId, serializationId, extraData);
+    super([], "type", externalId, internalId, extraData);
 
     this._name = name;
     this._publicId = publicId;
@@ -124,7 +124,7 @@ export namespace Type {
         Option.from(json.publicId),
         Option.from(json.systemId),
         json.externalId,
-        json.serializationId,
+        json.internalId,
       ),
     );
   }
@@ -141,7 +141,7 @@ export namespace Type {
         type.publicId,
         type.systemId,
         type.externalId,
-        type.serializationId,
+        type.internalId,
       ),
     );
   }

--- a/packages/alfa-dom/test/h.spec.ts
+++ b/packages/alfa-dom/test/h.spec.ts
@@ -65,8 +65,8 @@ test("h() put elements in the correct namespace", (t) => {
   );
 });
 
-test("h() accepts a serializationId which is set on the Element", (t) => {
-  const serializationId = crypto.randomUUID();
+test("h() accepts a internalId which is set on the Element", (t) => {
+  const internalId = crypto.randomUUID();
   const elm = h(
     "div",
     undefined,
@@ -75,18 +75,18 @@ test("h() accepts a serializationId which is set on the Element", (t) => {
     undefined,
     Device.standard(),
     undefined,
-    serializationId,
+    internalId,
   );
 
-  t.equal(elm.serializationId, serializationId);
+  t.equal(elm.internalId, internalId);
 });
 
-test("h() creates serializationId when it is not provided", (t) => {
+test("h() creates internalId when it is not provided", (t) => {
   const elm = h("div");
 
   t.equal(
-    elm.serializationId.length,
+    elm.internalId.length,
     36,
-    "serializationId should be a UUID of length 36",
+    "internalId should be a UUID of length 36",
   );
 });

--- a/packages/alfa-dom/test/node.spec.tsx
+++ b/packages/alfa-dom/test/node.spec.tsx
@@ -307,7 +307,7 @@ test(`#toJSON() serializes box of descendant inside content`, (t) => {
   ]);
 });
 
-function docWithSerializationIds(
+function docWithinternalIds(
   docId: string,
   elmId: string,
   attrId: string,
@@ -333,12 +333,12 @@ function docWithSerializationIds(
   );
 }
 
-test("#toJSON() includes only serializationId when verbosity is minimal", (t) => {
+test("#toJSON() includes only internalId when verbosity is minimal", (t) => {
   const docId = crypto.randomUUID();
   const elmId = crypto.randomUUID();
   const attrId = crypto.randomUUID();
 
-  const doc = docWithSerializationIds(docId, elmId, attrId);
+  const doc = docWithinternalIds(docId, elmId, attrId);
 
   const device = Device.standard();
 
@@ -355,26 +355,26 @@ test("#toJSON() includes only serializationId when verbosity is minimal", (t) =>
 
     t.deepEqual(doc.toJSON(options), {
       type: "document",
-      serializationId: docId,
+      internalId: docId,
     });
 
     const elm = doc.children().first().getUnsafe() as Element<"div">;
 
     t.deepEqual(elm.toJSON(options), {
       type: "element",
-      serializationId: elmId,
+      internalId: elmId,
     });
 
     const attr = elm.attributes.first().getUnsafe() as Attribute<"id">;
 
     t.deepEqual(attr.toJSON(options), {
       type: "attribute",
-      serializationId: attrId,
+      internalId: attrId,
     });
   }
 });
 
-test("#toJSON() includes everything except serializationId when options is undefined or verbosity is medium", (t) => {
+test("#toJSON() includes everything except internalId when options is undefined or verbosity is medium", (t) => {
   const doc = h.document([<div id="foo"></div>]);
 
   const device = Device.standard();
@@ -417,12 +417,12 @@ test("#toJSON() includes everything except serializationId when options is undef
   }
 });
 
-test("#toJSON() includes everything including serializationId and assigned slot when verbosity is high", (t) => {
+test("#toJSON() includes everything including internalId and assigned slot when verbosity is high", (t) => {
   const docId = crypto.randomUUID();
   const elmId = crypto.randomUUID();
   const attrId = crypto.randomUUID();
 
-  const doc = docWithSerializationIds(docId, elmId, attrId);
+  const doc = docWithinternalIds(docId, elmId, attrId);
 
   const options = {
     device: Device.standard(),
@@ -431,17 +431,17 @@ test("#toJSON() includes everything including serializationId and assigned slot 
 
   t.deepEqual(doc.toJSON(options), {
     type: "document",
-    serializationId: docId,
+    internalId: docId,
     style: [],
     children: [
       {
         type: "element",
-        serializationId: elmId,
+        internalId: elmId,
         assignedSlot: null,
         attributes: [
           {
             type: "attribute",
-            serializationId: attrId,
+            internalId: attrId,
             name: "id",
             namespace: null,
             prefix: null,
@@ -461,14 +461,14 @@ test("#toJSON() includes everything including serializationId and assigned slot 
   });
 });
 
-test("#toJSON() includes serializationId of assigned slots when verbosity is high", (t) => {
-  const a = <span serializationId="a"></span>;
-  const b = <span serializationId="b"></span>;
+test("#toJSON() includes internalId of assigned slots when verbosity is high", (t) => {
+  const a = <span internalId="a"></span>;
+  const b = <span internalId="b"></span>;
 
   const div = (
-    <div serializationId="div">
+    <div internalId="div">
       {h.shadow(
-        [<slot serializationId="slot" />, b],
+        [<slot internalId="slot" />, b],
         undefined,
         undefined,
         undefined,
@@ -484,10 +484,10 @@ test("#toJSON() includes serializationId of assigned slots when verbosity is hig
       {
         type: "element",
         children: [],
-        serializationId: "a",
+        internalId: "a",
         assignedSlot: {
           type: "element",
-          serializationId: "slot",
+          internalId: "slot",
         },
         namespace: "http://www.w3.org/1999/xhtml",
         prefix: null,
@@ -499,7 +499,7 @@ test("#toJSON() includes serializationId of assigned slots when verbosity is hig
         box: null,
       },
     ],
-    serializationId: "div",
+    internalId: "div",
     assignedSlot: null,
     namespace: "http://www.w3.org/1999/xhtml",
     prefix: null,
@@ -512,7 +512,7 @@ test("#toJSON() includes serializationId of assigned slots when verbosity is hig
         {
           type: "element",
           children: [],
-          serializationId: "slot",
+          internalId: "slot",
           assignedSlot: null,
           namespace: "http://www.w3.org/1999/xhtml",
           prefix: null,
@@ -526,7 +526,7 @@ test("#toJSON() includes serializationId of assigned slots when verbosity is hig
         {
           type: "element",
           children: [],
-          serializationId: "b",
+          internalId: "b",
           assignedSlot: null,
           namespace: "http://www.w3.org/1999/xhtml",
           prefix: null,
@@ -538,7 +538,7 @@ test("#toJSON() includes serializationId of assigned slots when verbosity is hig
           box: null,
         },
       ],
-      serializationId: "shadow",
+      internalId: "shadow",
       mode: "open",
       style: [],
     },

--- a/packages/alfa-dom/test/node.spec.tsx
+++ b/packages/alfa-dom/test/node.spec.tsx
@@ -356,6 +356,7 @@ test("#toJSON() includes only internalId when verbosity is minimal", (t) => {
     t.deepEqual(doc.toJSON(options), {
       type: "document",
       internalId: docId,
+      serializationId: docId,
     });
 
     const elm = doc.children().first().getUnsafe() as Element<"div">;
@@ -363,6 +364,7 @@ test("#toJSON() includes only internalId when verbosity is minimal", (t) => {
     t.deepEqual(elm.toJSON(options), {
       type: "element",
       internalId: elmId,
+      serializationId: elmId,
     });
 
     const attr = elm.attributes.first().getUnsafe() as Attribute<"id">;
@@ -370,6 +372,7 @@ test("#toJSON() includes only internalId when verbosity is minimal", (t) => {
     t.deepEqual(attr.toJSON(options), {
       type: "attribute",
       internalId: attrId,
+      serializationId: attrId,
     });
   }
 });
@@ -432,16 +435,19 @@ test("#toJSON() includes everything including internalId and assigned slot when 
   t.deepEqual(doc.toJSON(options), {
     type: "document",
     internalId: docId,
+    serializationId: docId,
     style: [],
     children: [
       {
         type: "element",
         internalId: elmId,
+        serializationId: elmId,
         assignedSlot: null,
         attributes: [
           {
             type: "attribute",
             internalId: attrId,
+            serializationId: attrId,
             name: "id",
             namespace: null,
             prefix: null,
@@ -485,9 +491,11 @@ test("#toJSON() includes internalId of assigned slots when verbosity is high", (
         type: "element",
         children: [],
         internalId: "a",
+        serializationId: "a",
         assignedSlot: {
           type: "element",
           internalId: "slot",
+          serializationId: "slot",
         },
         namespace: "http://www.w3.org/1999/xhtml",
         prefix: null,
@@ -500,6 +508,7 @@ test("#toJSON() includes internalId of assigned slots when verbosity is high", (
       },
     ],
     internalId: "div",
+    serializationId: "div",
     assignedSlot: null,
     namespace: "http://www.w3.org/1999/xhtml",
     prefix: null,
@@ -513,6 +522,7 @@ test("#toJSON() includes internalId of assigned slots when verbosity is high", (
           type: "element",
           children: [],
           internalId: "slot",
+          serializationId: "slot",
           assignedSlot: null,
           namespace: "http://www.w3.org/1999/xhtml",
           prefix: null,
@@ -527,6 +537,7 @@ test("#toJSON() includes internalId of assigned slots when verbosity is high", (
           type: "element",
           children: [],
           internalId: "b",
+          serializationId: "b",
           assignedSlot: null,
           namespace: "http://www.w3.org/1999/xhtml",
           prefix: null,
@@ -539,6 +550,7 @@ test("#toJSON() includes internalId of assigned slots when verbosity is high", (
         },
       ],
       internalId: "shadow",
+      serializationId: "shadow",
       mode: "open",
       style: [],
     },

--- a/packages/alfa-rules/test/common/diagnostic/with-bad-elements.spec.tsx
+++ b/packages/alfa-rules/test/common/diagnostic/with-bad-elements.spec.tsx
@@ -44,6 +44,7 @@ test("toJSON() calls toJSON() on error elements and respects serialization optio
         {
           type: "element",
           internalId,
+          serializationId: internalId,
         },
       ],
     },

--- a/packages/alfa-rules/test/common/diagnostic/with-bad-elements.spec.tsx
+++ b/packages/alfa-rules/test/common/diagnostic/with-bad-elements.spec.tsx
@@ -18,7 +18,7 @@ test("toJSON() calls toJSON() on error elements", (t) => {
 });
 
 test("toJSON() calls toJSON() on error elements and respects serialization options", (t) => {
-  const serializationId = crypto.randomUUID();
+  const internalId = crypto.randomUUID();
   const element = h.element(
     "div",
     undefined,
@@ -28,7 +28,7 @@ test("toJSON() calls toJSON() on error elements and respects serialization optio
     undefined,
     undefined,
     undefined,
-    serializationId,
+    internalId,
   );
   const diagnostic = WithBadElements.of("Foo", [element]);
 
@@ -43,7 +43,7 @@ test("toJSON() calls toJSON() on error elements and respects serialization optio
         // @ts-ignore the type checker is not able to infer that the type should be Element.MinimalJSON when the serialization options are passed through WithBadElements.toJSON
         {
           type: "element",
-          serializationId,
+          internalId,
         },
       ],
     },

--- a/packages/alfa-rules/test/sia-r41/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r41/rule.spec.tsx
@@ -181,10 +181,10 @@ test(`toJSON() with minimal verbosity produces target with correct serialization
   const elmId2 = crypto.randomUUID();
 
   const target = [
-    <a href="foo.html" serializationId={elmId1}>
+    <a href="foo.html" internalId={elmId1}>
       {accessibleName}
     </a>,
-    <a href="foo.html" serializationId={elmId2}>
+    <a href="foo.html" internalId={elmId2}>
       {accessibleName}
     </a>,
   ];
@@ -205,11 +205,11 @@ test(`toJSON() with minimal verbosity produces target with correct serialization
     [
       {
         type: "element",
-        serializationId: elmId1,
+        internalId: elmId1,
       },
       {
         type: "element",
-        serializationId: elmId2,
+        internalId: elmId2,
       },
     ],
   );

--- a/packages/alfa-rules/test/sia-r41/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r41/rule.spec.tsx
@@ -206,10 +206,12 @@ test(`toJSON() with minimal verbosity produces target with correct serialization
       {
         type: "element",
         internalId: elmId1,
+        serializationId: elmId1,
       },
       {
         type: "element",
         internalId: elmId2,
+        serializationId: elmId2,
       },
     ],
   );

--- a/packages/alfa-tree/src/tree.ts
+++ b/packages/alfa-tree/src/tree.ts
@@ -101,7 +101,7 @@ export abstract class Node<
   /**
    * @deprecated Aliases to {@link Node#internalId}.
    */
-  public get serializationIdId(): string | undefined {
+  public get serializationId(): string | undefined {
     return this.internalId;
   }
 
@@ -435,6 +435,7 @@ export abstract class Node<
     if (verbosity >= json.Serializable.Verbosity.High) {
       // If verbosity is High or above, include also internalId
       result.internalId = this._internalId;
+      result.serializationId = this.serializationId;
     }
 
     return result;
@@ -465,5 +466,6 @@ export namespace Node {
     children?: Array<JSON>;
     externalId?: string;
     internalId?: string;
+    serializationId?: string;
   }
 }

--- a/packages/alfa-tree/src/tree.ts
+++ b/packages/alfa-tree/src/tree.ts
@@ -50,7 +50,7 @@ export abstract class Node<
   private readonly _externalId: string | undefined;
   private readonly _extraData: any;
 
-  private readonly _serializationId: string;
+  private readonly _internalId: string;
 
   /**
    * Whether the node is frozen.
@@ -69,7 +69,7 @@ export abstract class Node<
     children: Array<Node<F>>,
     type: T,
     externalId?: string,
-    serializationId?: string,
+    internalId?: string,
     extraData?: any,
   ) {
     this._children = (children as Array<Node<F>>).filter((child) =>
@@ -79,7 +79,7 @@ export abstract class Node<
     this._externalId = externalId;
     this._extraData = extraData;
 
-    this._serializationId = serializationId ?? crypto.randomUUID();
+    this._internalId = internalId ?? crypto.randomUUID();
   }
 
   public get type(): T {
@@ -94,8 +94,15 @@ export abstract class Node<
     return this._extraData;
   }
 
-  public get serializationId(): string {
-    return this._serializationId;
+  public get internalId(): string {
+    return this._internalId;
+  }
+
+  /**
+   * @deprecated Aliases to {@link Node#internalId}.
+   */
+  public get serializationIdId(): string | undefined {
+    return this.internalId;
   }
 
   public get frozen(): boolean {
@@ -413,12 +420,12 @@ export abstract class Node<
     };
 
     if (verbosity < json.Serializable.Verbosity.Medium) {
-      // Only type and serializationId
-      result.serializationId = this._serializationId;
+      // Only type and internalId
+      result.internalId = this._internalId;
       return result;
     }
 
-    // If verbosity is Medium or above, include everything (except serializationId)
+    // If verbosity is Medium or above, include everything (except internalId)
     result.children = this._children.map((child) => child.toJSON(options));
 
     if (this._externalId !== undefined) {
@@ -426,8 +433,8 @@ export abstract class Node<
     }
 
     if (verbosity >= json.Serializable.Verbosity.High) {
-      // If verbosity is High or above, include also serializationId
-      result.serializationId = this._serializationId;
+      // If verbosity is High or above, include also internalId
+      result.internalId = this._internalId;
     }
 
     return result;
@@ -457,6 +464,6 @@ export namespace Node {
     type: T;
     children?: Array<JSON>;
     externalId?: string;
-    serializationId?: string;
+    internalId?: string;
   }
 }

--- a/packages/alfa-tree/src/tree.ts
+++ b/packages/alfa-tree/src/tree.ts
@@ -422,6 +422,7 @@ export abstract class Node<
     if (verbosity < json.Serializable.Verbosity.Medium) {
       // Only type and internalId
       result.internalId = this._internalId;
+      result.serializationId = this.serializationId;
       return result;
     }
 


### PR DESCRIPTION
This makes it a bit more general.