### PR TITLE
SIA-R83: accept more breakpoints

### DIFF
--- a/.changeset/poor-hounds-perform.md
+++ b/.changeset/poor-hounds-perform.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-rules": patch
+---
+
+**Fixed:** SIA-R83 is now better at detecting soft wrap opportunity in text nodes.

--- a/.changeset/shy-radios-sip.md
+++ b/.changeset/shy-radios-sip.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-string": minor
+---
+
+**Added:** A `String.hasSoftWrapOpportunity` predicate is now available.

--- a/docs/review/api/alfa-string.api.md
+++ b/docs/review/api/alfa-string.api.md
@@ -10,6 +10,7 @@ type String_2 = globalThis.String;
 // @public (undocumented)
 namespace String_2 {
     function flatten(input: string): string;
+    function hasSoftWrapOpportunity(input: string): boolean;
     function hasWhitespace(input: string): boolean;
     function indent(input: string): string;
     function isWhitespace(input: string, allowEmpty?: boolean): boolean;

--- a/packages/alfa-rules/src/sia-r83/rule.ts
+++ b/packages/alfa-rules/src/sia-r83/rule.ts
@@ -378,8 +378,7 @@ namespace ClippingAncestor {
       _softWrapPointsCache.get(device, Cache.empty).get(node, () => {
         if (isText(node)) {
           // This is not fully correct, depending on languages
-          // See https://drafts.csswg.org/css-text/#line-breaking
-          return String.hasWhitespace(node.data);
+          return String.hasSoftWrapOpportunity(node.data);
         }
 
         if (isElement(node)) {

--- a/packages/alfa-string/package.json
+++ b/packages/alfa-string/package.json
@@ -24,5 +24,8 @@
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"
+  },
+  "devDependencies": {
+    "@siteimprove/alfa-test": "workspace:^0.93.8"
   }
 }

--- a/packages/alfa-string/src/string.ts
+++ b/packages/alfa-string/src/string.ts
@@ -53,4 +53,19 @@ export namespace String {
   export function hasWhitespace(input: string): boolean {
     return /\s/.test(input);
   }
+
+  /**
+   * Checks whether the string contains soft break points
+   * {@link https://drafts.csswg.org/css-text/#line-breaking}
+   *
+   * @remarks
+   * Spaces are always soft break points. Other are hard to correctly detect.
+   * We do not want here to have a full break point detection which, based on
+   * language, requires lexical analysis.
+   * We accept punctuation as soft break points since they would act so in most
+   * Western languages.
+   */
+  export function hasSoftWrapOpportunity(input: string): boolean {
+    return /\s|\p{P}/u.test(input);
+  }
 }

--- a/packages/alfa-string/test/string.spec.ts
+++ b/packages/alfa-string/test/string.spec.ts
@@ -1,0 +1,7 @@
+import { test } from "@siteimprove/alfa-test";
+
+import { String } from "../dist/string.js";
+
+test(".hasSoftWrapOpportunity() accepts dashes", (t) => {
+  t.deepEqual(String.hasSoftWrapOpportunity("foo-bar"), true);
+});

--- a/packages/alfa-string/test/tsconfig.json
+++ b/packages/alfa-string/test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "."
+  },
+  "files": ["./string.spec.ts"],
+  "references": [{ "path": "../src" }, { "path": "../../alfa-test" }]
+}

--- a/packages/alfa-string/tsconfig.json
+++ b/packages/alfa-string/tsconfig.json
@@ -2,5 +2,5 @@
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "../tsconfig.json",
   "files": [],
-  "references": [{ "path": "./src" }]
+  "references": [{ "path": "./src" }, { "path": "./test" }]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1600,6 +1600,8 @@ __metadata:
 "@siteimprove/alfa-string@workspace:^0.93.8, @siteimprove/alfa-string@workspace:packages/alfa-string":
   version: 0.0.0-use.local
   resolution: "@siteimprove/alfa-string@workspace:packages/alfa-string"
+  dependencies:
+    "@siteimprove/alfa-test": "workspace:^0.93.8"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
In https://github.com/Siteimprove/alfa/pull/1694 SIA-R83 started detecting soft wrap points in string and use them to detect whether a text node can wrap or not. It was then only acting on spaces.

A frequent use case in several languages is to have dashes as composite word separators. This PR accepts any punctuation which should also catch some incorrectly spaced sentences, … 