### PR TITLE
Add filtering of visible descendants in clickable box computation

### DIFF
--- a/.changeset/grumpy-games-fix.md
+++ b/.changeset/grumpy-games-fix.md
@@ -1,0 +1,7 @@
+---
+"@siteimprove/alfa-rules": minor
+---
+
+**Fixed:** The function `getClickableBox` now only considers visible descendants.
+
+The return type of the function was also changed from `Option` to `Result`.

--- a/.changeset/grumpy-games-fix.md
+++ b/.changeset/grumpy-games-fix.md
@@ -1,7 +1,5 @@
 ---
-"@siteimprove/alfa-rules": minor
+"@siteimprove/alfa-rules": patch
 ---
 
-**Fixed:** The function `getClickableBox` now only considers visible descendants.
-
-The return type of the function was also changed from `Option` to `Result`.
+**Fixed:** SIA-R111 and SIA-R113 now ignores invisible descendants of interactive elements when computing the clickable areas.

--- a/packages/alfa-rules/src/common/applicability/targets-of-pointer-events.ts
+++ b/packages/alfa-rules/src/common/applicability/targets-of-pointer-events.ts
@@ -119,7 +119,7 @@ function isTarget(device: Device): Predicate<Element> {
 }
 
 function hasClickableBox(device: Device): Predicate<Element> {
-  return (element) => getClickableBox(device, element).isSome();
+  return (element) => getClickableBox(device, element).isOk();
 }
 
 const nonTargetTextCache = Cache.empty<Device, Cache<Element, boolean>>();

--- a/packages/alfa-rules/src/common/dom/get-clickable-box.ts
+++ b/packages/alfa-rules/src/common/dom/get-clickable-box.ts
@@ -21,7 +21,7 @@ const cache = Cache.empty<Device, Cache<Element, Result<Rectangle, string>>>();
  * the area that would be clickable if the element could receive pointer events.
  *
  * The clickable box is approximated by the smallest rectangle containing
- * the bounding boxes of the element and all it's visible descendants.
+ * the bounding boxes of the element and all its visible descendants.
  *
  * @internal
  */


### PR DESCRIPTION
This PR fixes an issue in the clickable box computation where the bounding boxes of all descendants would be used. For invisible descendants their bounding boxes would be an empty rectangle located at (0, 0) and since we are letting the clickable area be the convex hull of the boxes (the smallest containing rectangle), this would give wildly incorrect clickable areas in some cases. This was uncovered after `<select>`s were made visible.

More work will be needed to refine how R111 and R113 use the clickable boxes for sizing and spacing detection.