### PR TITLE
Escape SIA-R44 early if there is no orientation media query

### DIFF
--- a/packages/alfa-rules/src/sia-r44/rule.ts
+++ b/packages/alfa-rules/src/sia-r44/rule.ts
@@ -60,7 +60,7 @@ export default Rule.Atomic.of<Page, Element>({
     return {
       applicability() {
         // We first go through all the style rules to see if any of them
-        // if orientation-conditional. If there are no orientation media
+        // is orientation-conditional. If there are no orientation media
         // query at all, we can bail out early and avoid paying the price of
         // resolving the cascade with a different device.
         if (


### PR DESCRIPTION
SIA-R44 has proven to be performing poorly, most likely due to the cost of computing some style properties with a different device (hence without relying on caching), merely for finding out that they are not orientation dependent.

This should improve the performance of the common use case, by doing a first quick lookup through all the style rules and escaping early if there is no orientation media feature in any of the media rules.

See [this discussion](https://siteimprove.slack.com/archives/G0E9EH2AJ/p1730128127722729) for more details.