### PR TITLE
Fix a couple of CSS feature bugs

### DIFF
--- a/.changeset/pretty-scissors-explode.md
+++ b/.changeset/pretty-scissors-explode.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-device": patch
+---
+
+**Fixed:** Values of undefined user preferences are now correctly set to their default.

--- a/.changeset/short-bees-behave.md
+++ b/.changeset/short-bees-behave.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-css-feature": patch
+---
+
+**Fixed:** Matching of user-preferences in the boolean context now correctly handles non-`none` defaults.

--- a/.changeset/short-bees-behave.md
+++ b/.changeset/short-bees-behave.md
@@ -2,4 +2,4 @@
 "@siteimprove/alfa-css-feature": patch
 ---
 
-**Fixed:** Matching of user-preferences in the boolean context now correctly handles non-`none` defaults.
+**Fixed:** Matching of user-preferences in the boolean context now correctly handles `none` defaults.

--- a/packages/alfa-css-feature/src/media/feature/discrete.ts
+++ b/packages/alfa-css-feature/src/media/feature/discrete.ts
@@ -1,5 +1,5 @@
 import { Keyword, type Parser as CSSParser } from "@siteimprove/alfa-css";
-import type { Device} from "@siteimprove/alfa-device";
+import type { Device } from "@siteimprove/alfa-device";
 import { Preference } from "@siteimprove/alfa-device";
 import { None, Option } from "@siteimprove/alfa-option";
 
@@ -41,7 +41,7 @@ export namespace Discrete {
 
         return this._value
           .map((value) => value.matches(Keyword.of(deviceValue)))
-          .getOr(deviceValue !== booleanFalse ?? "none");
+          .getOr(deviceValue !== (booleanFalse ?? "none"));
       }
 
       private static _from(value: Option<Value<Keyword<K>>>): Discrete {

--- a/packages/alfa-css-feature/test/media.spec.ts
+++ b/packages/alfa-css-feature/test/media.spec.ts
@@ -1,7 +1,12 @@
 import { test } from "@siteimprove/alfa-test";
 
 import { Lexer } from "@siteimprove/alfa-css";
-import { Device, Viewport, Display } from "@siteimprove/alfa-device";
+import {
+  Device,
+  Display,
+  Preference,
+  Viewport,
+} from "@siteimprove/alfa-device";
 
 import { Feature } from "../dist/index.js";
 
@@ -460,7 +465,7 @@ test("#matches() matches ranges", (t) => {
   t.deepEqual(isGoldylocks.matches(largeLandscape), false);
 });
 
-test("#matches correctly behave at boundaries", (t) => {
+test("#matches() correctly behave at boundaries", (t) => {
   // Inclusive bound is matched inclusively
   const isLarge = parse(`(width >= ${width}px)`).getUnsafe();
   // Exclusive bound is matched exclusively
@@ -471,4 +476,20 @@ test("#matches correctly behave at boundaries", (t) => {
   t.deepEqual(isLarge.matches(largeLandscape), true);
   t.deepEqual(isSmall.matches(largeLandscape), false);
   t.deepEqual(isLargeToo.matches(largeLandscape), true);
+});
+
+test("#matches() matches unset prefers-color-scheme", (t) => {
+  const prefersColorScheme = parse("(prefers-color-scheme)").getUnsafe();
+
+  t.deepEqual(prefersColorScheme.matches(smallPortrait), true);
+
+  const withLightScheme = Device.of(
+    Device.Type.Screen,
+    Viewport.of(200, 400, Viewport.Orientation.Portrait),
+    Display.of(300),
+    undefined,
+    [Preference.of("prefers-color-scheme", "light")],
+  );
+
+  t.deepEqual(prefersColorScheme.matches(withLightScheme), false);
 });

--- a/packages/alfa-css-feature/test/media.spec.ts
+++ b/packages/alfa-css-feature/test/media.spec.ts
@@ -1,4 +1,3 @@
-/// <reference lib="dom" />
 import { test } from "@siteimprove/alfa-test";
 
 import { Lexer } from "@siteimprove/alfa-css";

--- a/packages/alfa-css-feature/test/media.spec.ts
+++ b/packages/alfa-css-feature/test/media.spec.ts
@@ -1,3 +1,4 @@
+/// <reference lib="dom" />
 import { test } from "@siteimprove/alfa-test";
 
 import { Lexer } from "@siteimprove/alfa-css";
@@ -478,18 +479,18 @@ test("#matches() correctly behave at boundaries", (t) => {
   t.deepEqual(isLargeToo.matches(largeLandscape), true);
 });
 
-test("#matches() matches unset prefers-color-scheme", (t) => {
-  const prefersColorScheme = parse("(prefers-color-scheme)").getUnsafe();
+test("#matches() matches boolean prefers-reduced-motion", (t) => {
+  const prefersReducedMotion = parse("(prefers-reduced-motion)").getUnsafe();
 
-  t.deepEqual(prefersColorScheme.matches(smallPortrait), true);
+  t.deepEqual(prefersReducedMotion.matches(smallPortrait), false);
 
-  const withLightScheme = Device.of(
+  const withReducedMotion = Device.of(
     Device.Type.Screen,
     Viewport.of(200, 400, Viewport.Orientation.Portrait),
     Display.of(300),
     undefined,
-    [Preference.of("prefers-color-scheme", "light")],
+    [Preference.of("prefers-reduced-motion", "reduce")],
   );
 
-  t.deepEqual(prefersColorScheme.matches(withLightScheme), false);
+  t.deepEqual(prefersReducedMotion.matches(withReducedMotion), true);
 });

--- a/packages/alfa-device/src/device.ts
+++ b/packages/alfa-device/src/device.ts
@@ -84,7 +84,9 @@ export class Device implements Equatable, Hashable, Serializable {
   public preference<N extends Preference.Name>(name: N): Preference<N> {
     return this._preferences
       .get(name)
-      .getOrElse(() => Preference.unset(name)) as Preference<N>;
+      .getOrElse(() =>
+        Preference.of<N>(name, Preference.unset(name)),
+      ) as Preference<N>;
   }
 
   public equals(value: unknown): value is this {

--- a/packages/alfa-device/src/device.ts
+++ b/packages/alfa-device/src/device.ts
@@ -85,7 +85,7 @@ export class Device implements Equatable, Hashable, Serializable {
     return this._preferences
       .get(name)
       .getOrElse(() =>
-        Preference.of<N>(name, Preference.unset(name)),
+        Preference.of(name, Preference.unset(name)),
       ) as Preference<N>;
   }
 


### PR DESCRIPTION
* Getting an unset preference on a device was returning its value, rather than a `Preference` object, making further computations incorrect.
* Testing media queries in the boolean context was done with a poorly parenthesised expression, resulting in incorrect tests (this was probably not impacting anything since all user preferences are defined with an explicit `booleanFalse`, except for `orientation` which cannot be unset).
