### PR TITLE
Remove token from global Renovate config

### DIFF
--- a/config/alfa-renovate.json
+++ b/config/alfa-renovate.json
@@ -8,16 +8,7 @@
   "reviewers": ["team:alfa-owners"],
   "dependencyDashboard": true,
   "postUpdateOptions": ["yarnDedupeHighest"],
-  "npmrc": "@siteimprove:registry=https://npm.pkg.github.com/",
   "rangeStrategy": "replace",
-  "hostRules": [
-      {
-        "hostType": "npm",
-        "matchHost": "https://npm.pkg.github.com/",
-        "description": "Token of a public user with 'Packages:read' permission only, needed due to https://github.com/renovatebot/renovate/discussions/26475",
-        "token": "{{ secrets.RENOVATE_TOKEN }}"
-      }
-    ],
   "packageRules": [
     {
       "description": "Update Alfa as soon as a new release is published",


### PR DESCRIPTION
It seems that the token and host rules cannot be shared easily like that and each repo will need its own. Additionally, repos depending only on public packages can just use the npmjs packages that don't require a token.
