### PR TITLE
Protected constructors

### DIFF
--- a/.changeset/funny-flies-accept.md
+++ b/.changeset/funny-flies-accept.md
@@ -1,0 +1,46 @@
+---
+"@siteimprove/alfa-compatibility": patch
+"@siteimprove/alfa-css-feature": patch
+"@siteimprove/alfa-performance": patch
+"@siteimprove/alfa-trampoline": patch
+"@siteimprove/alfa-rectangle": patch
+"@siteimprove/alfa-selective": patch
+"@siteimprove/alfa-toolchain": patch
+"@siteimprove/alfa-branched": patch
+"@siteimprove/alfa-selector": patch
+"@siteimprove/alfa-sequence": patch
+"@siteimprove/alfa-cascade": patch
+"@siteimprove/alfa-emitter": patch
+"@siteimprove/alfa-network": patch
+"@siteimprove/alfa-affine": patch
+"@siteimprove/alfa-device": patch
+"@siteimprove/alfa-either": patch
+"@siteimprove/alfa-future": patch
+"@siteimprove/alfa-option": patch
+"@siteimprove/alfa-record": patch
+"@siteimprove/alfa-result": patch
+"@siteimprove/alfa-cache": patch
+"@siteimprove/alfa-graph": patch
+"@siteimprove/alfa-rules": patch
+"@siteimprove/alfa-slice": patch
+"@siteimprove/alfa-style": patch
+"@siteimprove/alfa-table": patch
+"@siteimprove/alfa-xpath": patch
+"@siteimprove/alfa-aria": patch
+"@siteimprove/alfa-http": patch
+"@siteimprove/alfa-iana": patch
+"@siteimprove/alfa-lazy": patch
+"@siteimprove/alfa-list": patch
+"@siteimprove/alfa-time": patch
+"@siteimprove/alfa-wcag": patch
+"@siteimprove/alfa-act": patch
+"@siteimprove/alfa-css": patch
+"@siteimprove/alfa-dom": patch
+"@siteimprove/alfa-fnv": patch
+"@siteimprove/alfa-map": patch
+"@siteimprove/alfa-set": patch
+"@siteimprove/alfa-url": patch
+"@siteimprove/alfa-web": patch
+---
+
+**Changed:** Classes that do not implement the Singleton pattern now have `protected` constructor and can be extended.

--- a/docs/review/api/alfa-act.api.md
+++ b/docs/review/api/alfa-act.api.md
@@ -15,6 +15,7 @@ import type { Hash } from '@siteimprove/alfa-hash';
 import type { Hashable } from '@siteimprove/alfa-hash';
 import { Iterable as Iterable_2 } from '@siteimprove/alfa-iterable';
 import * as json from '@siteimprove/alfa-json';
+import { List } from '@siteimprove/alfa-list';
 import type { Mapper } from '@siteimprove/alfa-mapper';
 import { Maybe } from '@siteimprove/alfa-option';
 import type { Monad } from '@siteimprove/alfa-monad';
@@ -31,6 +32,7 @@ import { Tuple } from '@siteimprove/alfa-tuple';
 
 // @public
 export class Audit<I, T extends Hashable, Q extends Question.Metadata = {}, S = T> {
+    protected constructor(input: I, rules: List<Rule<I, T, Q, S>>, oracle: Oracle<I, T, Q, S>);
     // (undocumented)
     evaluate(performance?: Performance<Rule.Event<I, T, Q, S>>): Future<Iterable_2<Outcome<I, T, Q, S>>>;
     // (undocumented)
@@ -39,6 +41,7 @@ export class Audit<I, T extends Hashable, Q extends Question.Metadata = {}, S = 
 
 // @public (undocumented)
 export class Cache {
+    protected constructor();
     // (undocumented)
     static empty(): Cache;
     // (undocumented)
@@ -142,6 +145,7 @@ export namespace Outcome {
     //
     // (undocumented)
     export class CantTell<I, T extends Hashable, Q extends Question.Metadata = {}, S = T> extends Outcome<I, T, Q, S, Value.CantTell> {
+        protected constructor(rule: Rule<I, T, Q, S>, target: T, diagnostic: Diagnostic, mode: Mode);
         // (undocumented)
         get diagnostic(): Diagnostic;
         // (undocumented)
@@ -205,6 +209,9 @@ export namespace Outcome {
     //
     // (undocumented)
     export class Failed<I, T extends Hashable, Q extends Question.Metadata = {}, S = T> extends Outcome<I, T, Q, S, Value.Failed> {
+        protected constructor(rule: Rule<I, T, Q, S>, target: T, expectations: Record_2<{
+            [key: string]: Result<Diagnostic>;
+        }>, mode: Mode);
         // (undocumented)
         equals<I, T extends Hashable, Q extends Question.Metadata, S>(value: Failed<I, T, Q, S>): boolean;
         // (undocumented)
@@ -272,6 +279,7 @@ export namespace Outcome {
     //
     // (undocumented)
     export class Inapplicable<I, T extends Hashable, Q extends Question.Metadata = {}, S = T> extends Outcome<I, T, Q, S, Value.Inapplicable> {
+        protected constructor(rule: Rule<I, T, Q, S>, mode: Mode);
         // (undocumented)
         equals<I, T extends Hashable, Q extends Question.Metadata, S>(value: Inapplicable<I, T, Q, S>): boolean;
         // (undocumented)
@@ -338,6 +346,9 @@ export namespace Outcome {
     //
     // (undocumented)
     export class Passed<I, T extends Hashable, Q extends Question.Metadata = {}, S = T> extends Outcome<I, T, Q, S, Value.Passed> {
+        protected constructor(rule: Rule<I, T, Q, S>, target: T, expectations: Record_2<{
+            [key: string]: Result<Diagnostic>;
+        }>, mode: Mode);
         // (undocumented)
         equals<I, T extends Hashable, Q extends Question.Metadata, S>(value: Passed<I, T, Q, S>): boolean;
         // (undocumented)
@@ -600,6 +611,7 @@ export abstract class Rule<I, T extends Hashable, Q extends Question.Metadata = 
 export namespace Rule {
     // (undocumented)
     export class Atomic<I, T extends Hashable, Q extends Question.Metadata = {}, S = T> extends Rule<I, T, Q, S> {
+        protected constructor(uri: string, requirements: Array_2<Requirement>, tags: Array_2<Tag>, evaluate: Atomic.Evaluate<I, T, Q, S>);
         // (undocumented)
         static of<I, T extends Hashable, Q extends Question.Metadata = {}, S = T>(properties: {
             uri: string;
@@ -637,6 +649,7 @@ export namespace Rule {
     }
     // (undocumented)
     export class Composite<I, T extends Hashable, Q extends Question.Metadata = {}, S = T> extends Rule<I, T, Q, S> {
+        protected constructor(uri: string, requirements: Array_2<Requirement>, tags: Array_2<Tag>, composes: Array_2<Rule<I, T, Q, S>>, evaluate: Composite.Evaluate<I, T, Q, S>);
         // (undocumented)
         get composes(): ReadonlyArray<Rule<I, T, Q, S>>;
         // (undocumented)

--- a/docs/review/api/alfa-affine.api.md
+++ b/docs/review/api/alfa-affine.api.md
@@ -12,6 +12,7 @@ import { Vector } from '@siteimprove/alfa-math';
 
 // @public (undocumented)
 export class Transformation implements Equatable, Serializable {
+    protected constructor(matrix: Matrix);
     // (undocumented)
     apply(transformation: Transformation): Transformation;
     // (undocumented)

--- a/docs/review/api/alfa-aria.api.md
+++ b/docs/review/api/alfa-aria.api.md
@@ -30,6 +30,7 @@ import * as tree from '@siteimprove/alfa-tree';
 
 // @public (undocumented)
 export class Attribute<N extends Attribute.Name = Attribute.Name> implements Equatable, Serializable {
+    protected constructor(name: N, value: string);
     // (undocumented)
     get default(): Option<Attribute.Default<N>>;
     // (undocumented)
@@ -80,6 +81,7 @@ export namespace Attribute {
 
 // @public (undocumented)
 export class Container extends Node<"container"> {
+    protected constructor(owner: dom_2.Node, children: Array<Node>, role: Option<Role>);
     // (undocumented)
     clone(parent?: Option<Node>): Container;
     // (undocumented)
@@ -126,6 +128,7 @@ export namespace DOM {
 
 // @public (undocumented)
 export class Element extends Node<"element"> {
+    protected constructor(owner: dom_2.Node, role: Option<Role>, name: Option<Name>, attributes: Array<Attribute>, children: Array<Node>);
     allowedAttributes(): ReadonlyArray<Attribute.Name>;
     // (undocumented)
     attribute<N extends Attribute.Name>(refinement: Refinement<Attribute, Attribute<N>>): Option<Attribute<N>>;
@@ -170,6 +173,7 @@ export namespace Element {
 //
 // @internal (undocumented)
 export class Feature {
+    protected constructor(roleAspect: Feature.Aspect<Role.Name | Iterable_2<Role>>, attributes: Feature.AttributesAspect, name: Feature.NameAspect);
     // (undocumented)
     get attributes(): Feature.AttributesAspect;
     // (undocumented)
@@ -204,6 +208,7 @@ export function hasValue(value: string, ...rest: Array<string>): Predicate<Name>
 
 // @public (undocumented)
 export class Inert extends Node<"inert"> {
+    protected constructor(owner: dom_2.Node);
     // (undocumented)
     clone(): Inert;
     // (undocumented)
@@ -218,6 +223,7 @@ export class Inert extends Node<"inert"> {
 
 // @public (undocumented)
 export class Name implements Equatable, Serializable<Name.JSON> {
+    protected constructor(value: string, sources: Array_2<Source>, spaceBefore: boolean, spaceAfter: boolean);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -406,6 +412,7 @@ export namespace Node {
 
 // @public (undocumented)
 export class Role<N extends Role.Name = Role.Name> implements Equatable, Hashable, Serializable {
+    protected constructor(name: N, supportedAttributes: Array_2<Attribute.Name>, requiredAttributes: Array_2<Attribute.Name>, prohibitedAttributes: Array_2<Attribute.Name>);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -490,6 +497,7 @@ export namespace Source {
     export class Ancestor implements Equatable, Serializable<Ancestor.JSON> {
         // (undocumented)
         [Symbol.iterator](): Iterator<Node_2>;
+        protected constructor(element: Element_2, name: Name);
         // (undocumented)
         get element(): Element_2;
         // (undocumented)
@@ -523,6 +531,7 @@ export namespace Source {
     export class Data implements Equatable, Serializable<Data.JSON> {
         // (undocumented)
         [Symbol.iterator](): Iterator<Node_2>;
+        protected constructor(text: Text_2);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -552,6 +561,7 @@ export namespace Source {
     export class Descendant implements Equatable, Serializable<Descendant.JSON> {
         // (undocumented)
         [Symbol.iterator](): Iterator<Node_2>;
+        protected constructor(element: Element_2, name: Name);
         // (undocumented)
         get element(): Element_2;
         // (undocumented)
@@ -587,6 +597,7 @@ export namespace Source {
     export class Label implements Equatable, Serializable<Label.JSON> {
         // (undocumented)
         [Symbol.iterator](): Iterator<Node_2>;
+        protected constructor(attribute: Attribute_2);
         // (undocumented)
         get attribute(): Attribute_2;
         // (undocumented)
@@ -616,6 +627,7 @@ export namespace Source {
     export class Reference implements Equatable, Serializable<Reference.JSON> {
         // (undocumented)
         [Symbol.iterator](): Iterator<Node_2>;
+        protected constructor(attribute: Attribute_2, name: Name);
         // (undocumented)
         get attribute(): Attribute_2;
         // (undocumented)
@@ -651,6 +663,7 @@ export namespace Source {
 //
 // @internal (undocumented)
 export class State implements Equatable, Serializable<State.JSON> {
+    protected constructor(visited: Array_2<Element_2>, referrer: Option<Element_2>, referred: Option<Element_2>, isRecursing: boolean, isDescending: boolean);
     // (undocumented)
     descend(isDescending: boolean): State;
     // (undocumented)
@@ -698,6 +711,7 @@ export namespace State {
 
 // @public (undocumented)
 export class Text extends Node<"text"> {
+    protected constructor(owner: dom_2.Node, name: Option<Name>);
     // (undocumented)
     clone(): Text;
     // (undocumented)

--- a/docs/review/api/alfa-branched.api.md
+++ b/docs/review/api/alfa-branched.api.md
@@ -6,8 +6,11 @@
 
 import type { Callback } from '@siteimprove/alfa-callback';
 import type { Collection } from '@siteimprove/alfa-collection';
+import { Equatable } from '@siteimprove/alfa-equatable';
 import type { Hash } from '@siteimprove/alfa-hash';
+import type { Hashable } from '@siteimprove/alfa-hash';
 import { Iterable as Iterable_2 } from '@siteimprove/alfa-iterable';
+import { List } from '@siteimprove/alfa-list';
 import type { Mapper } from '@siteimprove/alfa-mapper';
 import type { Option } from '@siteimprove/alfa-option';
 import { Predicate } from '@siteimprove/alfa-predicate';
@@ -19,6 +22,8 @@ import { Serializable } from '@siteimprove/alfa-json';
 export class Branched<T, B = never> implements Collection<T>, Iterable_2<[T, Iterable_2<B>]> {
     // (undocumented)
     [Symbol.iterator](): Iterator<[T, Iterable_2<B>]>;
+    // Warning: (ae-forgotten-export) The symbol "Value" needs to be exported by the entry point index.d.ts
+    protected constructor(values: List<Value<T, B>>);
     // (undocumented)
     apply<U>(mapper: Branched<Mapper<T, U>, B>): Branched<U, B>;
     // (undocumented)

--- a/docs/review/api/alfa-cache.api.md
+++ b/docs/review/api/alfa-cache.api.md
@@ -10,6 +10,7 @@ import { Option } from '@siteimprove/alfa-option';
 
 // @public
 export class Cache<K extends Cache.Key, V> {
+    protected constructor();
     static empty<K extends Cache.Key, V>(): Cache<K, V>;
     get(key: K): Option<V>;
     get<U extends V = V>(key: K, ifMissing: Mapper<this, U>): V;

--- a/docs/review/api/alfa-cascade.api.md
+++ b/docs/review/api/alfa-cascade.api.md
@@ -30,6 +30,7 @@ import type { StyleRule } from '@siteimprove/alfa-dom';
 
 // @public (undocumented)
 export class Cascade implements Serializable {
+    protected constructor(root: Document | Shadow, device: Device);
     // (undocumented)
     static from(node: Document | Shadow, device: Device): Cascade;
     get(element: Element, context?: Context): RuleTree.Node;
@@ -69,6 +70,7 @@ export namespace Encapsulation {
 
 // @public (undocumented)
 export class Layer<ORDERED extends boolean = boolean> implements Serializable<Layer.JSON>, Equatable, Comparable<Layer<true>> {
+    protected constructor(ordered: ORDERED, name: string, importance: boolean, order: number);
     // (undocumented)
     compare(this: Layer<true>, value: Layer<true>): Comparison;
     // (undocumented)
@@ -211,6 +213,7 @@ export namespace Precedence {
 
 // @public
 export class RuleTree implements Serializable {
+    protected constructor();
     // Warning: (ae-forgotten-export) The symbol "Block" needs to be exported by the entry point index.d.ts
     //
     // @internal
@@ -227,6 +230,7 @@ export namespace RuleTree {
     export type JSON = Array<Node.JSON>;
     // (undocumented)
     export class Node implements Serializable {
+        protected constructor(block: Block, children: Array<Node>, parent: Option<Node>);
         // @internal
         add(block: Block): Node;
         // (undocumented)

--- a/docs/review/api/alfa-compatibility.api.md
+++ b/docs/review/api/alfa-compatibility.api.md
@@ -46,6 +46,7 @@ export namespace Browser {
     export function query<N extends Name>(query: Query<N>, scope?: Scope): Scope<N>;
     // (undocumented)
     export class Release<N extends Name = Name, V extends Version<N> = Version<N>> implements Serializable {
+        protected constructor(browser: N, version: V, date: number);
         // (undocumented)
         get browser(): N;
         // @internal (undocumented)

--- a/docs/review/api/alfa-css.api.md
+++ b/docs/review/api/alfa-css.api.md
@@ -39,6 +39,7 @@ export type Angle<U extends Unit.Angle = Unit.Angle> = Angle.Calculated | Angle.
 export namespace Angle {
     // Warning: (ae-incompatible-release-tags) The symbol "Calculated" is marked as @public, but its signature references "Resolvable" which is marked as @internal
     export class Calculated extends Dimension.Calculated<"angle"> implements Resolvable<Canonical, never> {
+        protected constructor(value: Math_2<"angle">);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -58,6 +59,7 @@ export namespace Angle {
     export type Canonical = Fixed<"deg">;
     // Warning: (ae-incompatible-release-tags) The symbol "Fixed" is marked as @public, but its signature references "Resolvable" which is marked as @internal
     export class Fixed<U extends Unit.Angle = Unit.Angle> extends Dimension.Fixed<"angle", U> implements Resolvable<Canonical, never>, Comparable<Fixed<U>> {
+        protected constructor(value: number, unit: U);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -112,6 +114,7 @@ export type AnglePercentage<U extends Unit.Angle = Unit.Angle> = AnglePercentage
 export namespace AnglePercentage {
     // Warning: (ae-incompatible-release-tags) The symbol "Calculated" is marked as @public, but its signature references "Resolvable" which is marked as @internal
     export class Calculated extends Dimension.Calculated<"angle-percentage"> implements Resolvable<Canonical, never> {
+        protected constructor(math: Math_2<"angle-percentage">);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -164,6 +167,7 @@ export namespace AnglePercentage {
 export class Block implements Iterable<Token>, Equatable, Serializable {
     // (undocumented)
     [Symbol.iterator](): Iterator<Token>;
+    protected constructor(token: Block.Open, value: Array<Token>);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -258,6 +262,7 @@ export namespace Box {
 //
 // @public (undocumented)
 export class Circle<R extends Radius = Radius, P extends Position = Position> extends BasicShape<"circle", Value.HasCalculation<[R, P]>> implements Resolvable<Circle.Canonical, Circle.Resolver>, PartiallyResolvable<Circle.PartiallyResolved, Circle.PartialResolver> {
+    protected constructor(radius: R, center: P);
     // (undocumented)
     get center(): P;
     // (undocumented)
@@ -340,6 +345,7 @@ export namespace Comma {
 export class Component implements Iterable<Token>, Equatable, Serializable {
     // (undocumented)
     [Symbol.iterator](): Iterator<Token>;
+    protected constructor(value: Array<Token>);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -375,6 +381,7 @@ export namespace Contain {
 //
 // @public (undocumented)
 export class ContainFlags extends Value<"contain-flags", false> implements Resolvable<ContainFlags, never> {
+    protected constructor(size: boolean, inlineSize: boolean, layout: boolean, style: boolean, paint: boolean);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -454,6 +461,7 @@ export namespace Current {
 //
 // @public (undocumented)
 export class CustomIdent extends Ident<"custom-ident"> implements Resolvable<CustomIdent, never> {
+    protected constructor(value: string);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -472,6 +480,7 @@ export namespace CustomIdent {
 export class Declaration implements Iterable<Token>, Equatable, Serializable {
     // (undocumented)
     [Symbol.iterator](): Iterator<Token>;
+    protected constructor(name: string, value: Array<Token>, important: boolean);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -584,6 +593,7 @@ export namespace Dimension {
 //
 // @public (undocumented)
 export class Ellipse<R extends Radius = Radius, P extends Position = Position> extends BasicShape<"ellipse", Value.HasCalculation<[R, P]>> implements Resolvable<Ellipse.Canonical, Ellipse.Resolver>, PartiallyResolvable<Ellipse.PartiallyResolved, Ellipse.PartialResolver> {
+    protected constructor(rx: R, ry: R, center: P);
     // (undocumented)
     get center(): P;
     // (undocumented)
@@ -705,6 +715,7 @@ export namespace Expression {
 class Function_2 implements Iterable<Token>, Equatable, Serializable {
     // (undocumented)
     [Symbol.iterator](): Iterator<Token>;
+    protected constructor(name: string, value: Array<Token>);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -766,6 +777,7 @@ export namespace Gradient {
 //
 // @public (undocumented)
 export class Hex extends Format<"hex"> {
+    protected constructor(value: number);
     // (undocumented)
     get alpha(): Number_2.Fixed;
     // (undocumented)
@@ -805,6 +817,7 @@ export namespace Hex {
 
 // @public (undocumented)
 export class HSL<H extends Number_2.Fixed | Angle.Fixed = Number_2.Fixed | Angle.Fixed, A extends Number_2.Fixed | Percentage.Fixed<"percentage"> = Number_2.Fixed | Percentage.Fixed<"percentage">> extends Format<"hsl"> {
+    protected constructor(hue: H, saturation: Percentage.Canonical, lightness: Percentage.Canonical, alpha: A);
     // (undocumented)
     get alpha(): A;
     // (undocumented)
@@ -895,6 +908,7 @@ export namespace Ident {
 //
 // @public (undocumented)
 export class Image<I extends URL | Gradient = URL | Gradient> extends Value<"image", Value.HasCalculation<[I]>> implements Resolvable<Image.Canonical, Image.Resolver>, PartiallyResolvable<Image.PartiallyResolved, Image.PartialResolver> {
+    protected constructor(image: I);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -941,6 +955,7 @@ export namespace Image {
 //
 // @public (undocumented)
 export class Inset<O extends Inset.Offset = Inset.Offset, C extends Corner_2 = Corner_2> extends BasicShape<"inset", HasCalculation<O, C>> implements Resolvable<Inset.Canonical, Inset.Resolver>, PartiallyResolvable<Inset.PartiallyResolved, Inset.PartialResolver> {
+    protected constructor(offsets: readonly [O, O, O, O], corners: Option<readonly [C, C, C, C]>);
     // (undocumented)
     get bottom(): O;
     // (undocumented)
@@ -1011,6 +1026,7 @@ export type Integer = Integer.Calculated | Integer.Fixed;
 export namespace Integer {
     // Warning: (ae-incompatible-release-tags) The symbol "Calculated" is marked as @public, but its signature references "Resolvable" which is marked as @internal
     export class Calculated extends Numeric.Calculated<"integer"> implements Resolvable<Canonical, never> {
+        protected constructor(value: Math_2<"number">);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -1032,6 +1048,7 @@ export namespace Integer {
     export type Canonical = Fixed;
     // Warning: (ae-incompatible-release-tags) The symbol "Fixed" is marked as @public, but its signature references "Resolvable" which is marked as @internal
     export class Fixed extends Numeric.Fixed<"integer"> implements Resolvable<Canonical, never> {
+        protected constructor(value: number);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -1077,6 +1094,7 @@ export namespace Integer {
 //
 // @public (undocumented)
 export class Keyword<T extends string = string> extends Ident<"keyword", T> implements Resolvable<Keyword<T>, never> {
+    protected constructor(value: T);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -1104,6 +1122,7 @@ export type Length<U extends Unit.Length = Unit.Length> = Length.Calculated | Le
 export namespace Length {
     // Warning: (ae-incompatible-release-tags) The symbol "Calculated" is marked as @public, but its signature references "Resolvable" which is marked as @internal
     export class Calculated extends Dimension.Calculated<"length"> implements Resolvable<Canonical, Resolver> {
+        protected constructor(math: Math_2<"length">);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -1123,6 +1142,7 @@ export namespace Length {
     export type Canonical = Fixed<Unit.Length.Canonical>;
     // Warning: (ae-incompatible-release-tags) The symbol "Fixed" is marked as @public, but its signature references "Resolvable" which is marked as @internal
     export class Fixed<U extends Unit.Length = Unit.Length> extends Dimension.Fixed<"length", U> implements Resolvable<Canonical, Resolver>, Comparable<Fixed<U>> {
+        protected constructor(value: number, unit: U);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -1191,6 +1211,7 @@ export namespace LengthPercentage {
     // Warning: (ae-incompatible-release-tags) The symbol "Calculated" is marked as @public, but its signature references "Resolvable" which is marked as @internal
     // Warning: (ae-incompatible-release-tags) The symbol "Calculated" is marked as @public, but its signature references "PartiallyResolvable" which is marked as @internal
     export class Calculated extends Dimension.Calculated<"length-percentage"> implements Resolvable<Length.Canonical, Resolver>, PartiallyResolvable<Calculated, PartialResolver> {
+        protected constructor(math: Math_2<"length-percentage">);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -1258,6 +1279,7 @@ export namespace Lexer {
 export class List<V extends Value> extends Value<"list", Value.HasCalculation<[V]>> implements Iterable_2<V>, Resolvable<List<Resolvable.Resolved<V>>, Resolvable.Resolver<V>>, PartiallyResolvable<List<Resolvable.PartiallyResolved<V>>, Resolvable.PartialResolver<V>> {
     // (undocumented)
     [Symbol.iterator](): Iterator<V>;
+    protected constructor(values: Array<V>, separator: string);
     cutOrExtend(length: number): List<V>;
     // (undocumented)
     equals<T extends Value>(value: List<T>): boolean;
@@ -1304,6 +1326,7 @@ export namespace List {
 
 // @public (undocumented)
 class Math_2<out D extends Math_2.Dimension = Math_2.Dimension> {
+    protected constructor(expression: Expression);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -1384,6 +1407,7 @@ export { Math_2 as Math }
 //
 // @public (undocumented)
 export class Matrix extends Function_3<"matrix", false> implements Resolvable<Matrix.Canonical, never> {
+    protected constructor(values: Matrix.Values<Number_2.Canonical>);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -1444,6 +1468,7 @@ export namespace Matrix {
 
 // @public (undocumented)
 export class Named<C extends Named.Color = Named.Color> extends Format<"named"> {
+    protected constructor(color: C);
     // (undocumented)
     get alpha(): Number_2.Fixed;
     // (undocumented)
@@ -1489,6 +1514,7 @@ export namespace Named {
 export class Nth implements Iterable<Token>, Equatable, Serializable {
     // (undocumented)
     [Symbol.iterator](): Iterator<Token>;
+    protected constructor(step: number, offset: number);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -1530,6 +1556,7 @@ type Number_2 = Number_2.Calculated | Number_2.Fixed;
 namespace Number_2 {
     // Warning: (ae-incompatible-release-tags) The symbol "Calculated" is marked as @public, but its signature references "Resolvable" which is marked as @internal
     class Calculated extends Numeric.Calculated<"number"> implements Resolvable<Canonical, never> {
+        protected constructor(value: Math_2<"number">);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -1551,6 +1578,7 @@ namespace Number_2 {
     type Canonical = Fixed;
     // Warning: (ae-incompatible-release-tags) The symbol "Fixed" is marked as @public, but its signature references "Resolvable" which is marked as @internal
     class Fixed extends Numeric.Fixed<"number"> implements Resolvable<Canonical, never> {
+        protected constructor(value: number);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -1704,6 +1732,7 @@ export namespace Percentage {
     // Warning: (ae-incompatible-release-tags) The symbol "Calculated" is marked as @public, but its signature references "Resolvable" which is marked as @internal
     // Warning: (ae-incompatible-release-tags) The symbol "Calculated" is marked as @public, but its signature references "PartiallyResolvable" which is marked as @internal
     export class Calculated<H extends Numeric_2.Type = Numeric_2.Type> extends Numeric.Calculated<"percentage", H, "percentage"> implements Resolvable<Canonicals[H], Resolver<H>>, PartiallyResolvable<PartiallyResolved<H>, PartialResolver> {
+        protected constructor(math: Math_2<"percentage">);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -1731,6 +1760,7 @@ export namespace Percentage {
     // Warning: (ae-incompatible-release-tags) The symbol "Fixed" is marked as @public, but its signature references "Resolvable" which is marked as @internal
     // Warning: (ae-incompatible-release-tags) The symbol "Fixed" is marked as @public, but its signature references "PartiallyResolvable" which is marked as @internal
     export class Fixed<H extends Numeric_2.Type = Numeric_2.Type> extends Numeric.Fixed<"percentage", "percentage" | H, "percentage"> implements Resolvable<Canonical | Canonicals[H], Resolver<H>>, PartiallyResolvable<PartiallyResolved<H>, PartialResolver> {
+        protected constructor(value: number);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -1788,6 +1818,7 @@ export namespace Percentage {
 //
 // @public (undocumented)
 export class Perspective<D extends Length = Length> extends Function_3<"perspective", Value.HasCalculation<[D]>> implements Resolvable<Perspective.Canonical, Perspective.Resolver> {
+    protected constructor(depth: D);
     // (undocumented)
     get depth(): D;
     // (undocumented)
@@ -1828,6 +1859,7 @@ export namespace Perspective {
 //
 // @public (undocumented)
 export class Polygon<F extends Polygon.Fill = Polygon.Fill, V extends LengthPercentage = LengthPercentage> extends BasicShape<"polygon", Value.HasCalculation<[V]>> implements Resolvable<Polygon.Canonical, Polygon.Resolver>, PartiallyResolvable<Polygon.PartiallyResolved, Polygon.PartialResolver> {
+    protected constructor(fill: Option<F>, vertices: Array_2<Polygon.Vertex<V>>);
     // (undocumented)
     equals(value: Polygon): boolean;
     // (undocumented)
@@ -1885,6 +1917,7 @@ export namespace Polygon {
 //
 // @public (undocumented)
 export class Position<H extends Position.Keywords.Horizontal = Position.Keywords.Horizontal, V extends Position.Keywords.Vertical = Position.Keywords.Vertical, HC extends Position.Component<H> = Position.Component<H>, VC extends Position.Component<V> = Position.Component<V>> extends Value<"position", Value.HasCalculation<[HC, VC]>> implements Resolvable<Position.Canonical<H, V>, Position.Resolver>, PartiallyResolvable<Position.PartiallyResolved<H, V>, Position.PartialResolver> {
+    protected constructor(horizontal: HC, vertical: VC);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -1940,6 +1973,7 @@ export namespace Position {
 //
 // @public (undocumented)
 export class Radius<R extends LengthPercentage | Radius.Side = LengthPercentage | Radius.Side> extends BasicShape<"radius", Value.HasCalculation<[R]>> implements Resolvable<Radius.Canonical, Radius.Resolver>, PartiallyResolvable<Radius.PartiallyResolved, Radius.PartialResolver> {
+    protected constructor(value: R);
     // (undocumented)
     equals(value: Radius): boolean;
     // (undocumented)
@@ -1994,6 +2028,7 @@ export namespace Radius {
 //
 // @public @deprecated (undocumented)
 export class Rectangle<O extends Length | Rectangle.Auto = Length | Rectangle.Auto> extends BasicShape<"rectangle", Value.HasCalculation<[O, O, O, O]>> implements Resolvable<Rectangle.Canonical, Rectangle.Resolver> {
+    protected constructor(top: O, right: O, bottom: O, left: O);
     // (undocumented)
     get bottom(): O;
     // (undocumented)
@@ -2072,6 +2107,7 @@ export namespace Resolvable {
 
 // @public (undocumented)
 export class RGB<C extends Number_2.Canonical | Percentage.Canonical = Number_2.Canonical | Percentage.Fixed<"percentage">, A extends Number_2.Canonical | Percentage.Canonical = Number_2.Canonical | Percentage.Fixed<"percentage">> extends Format<"rgb"> {
+    protected constructor(red: C, green: C, blue: C, alpha: A);
     // (undocumented)
     get alpha(): A;
     // (undocumented)
@@ -2123,6 +2159,7 @@ export namespace RGB {
 //
 // @public (undocumented)
 export class Rotate extends Function_3<"rotate", false> implements Resolvable<Rotate.Canonical, never> {
+    protected constructor(x: Number_2.Canonical, y: Number_2.Canonical, z: Number_2.Canonical, angle: Angle.Canonical);
     // (undocumented)
     get angle(): Angle.Canonical;
     // (undocumented)
@@ -2170,6 +2207,7 @@ export namespace Rotate {
 //
 // @public
 export class Scale<X extends Number_2.Canonical | Percentage.Canonical = Number_2.Canonical | Percentage.Fixed<"percentage">, Y extends Number_2.Canonical | Percentage.Canonical = Number_2.Canonical | Percentage.Fixed<"percentage">, Z extends Number_2.Canonical | Percentage.Canonical = Number_2.Canonical | Percentage.Fixed<"percentage">> extends Function_3<"scale", false> implements Resolvable<Scale.Canonical, never> {
+    protected constructor(x: X, y: Y, z?: Z);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -2231,6 +2269,7 @@ export namespace Scale {
 //
 // @public (undocumented)
 export class Shadow<H extends Length = Length, V extends Length = H, B extends Length = Length, S extends Length = Length, C extends Color = Color> extends Value<"shadow", Value.HasCalculation<[H, V, B, S, C]>> implements Resolvable<Shadow.Canonical, Shadow.Resolver> {
+    protected constructor(horizontal: H, vertical: V, blur: B, spread: S, color: C, isInset: boolean);
     // (undocumented)
     get blur(): B;
     // (undocumented)
@@ -2296,6 +2335,7 @@ export namespace Shadow {
 //
 // @public (undocumented)
 export class Shape<S extends Shape.Basic = Shape.Basic, B extends Box.Geometry = Box.Geometry> extends Value<"shape", Value.HasCalculation<[S]>> implements Resolvable<Shape.Canonical, Shape.Resolver>, PartiallyResolvable<Shape.PartiallyResolved, Shape.PartialResolver> {
+    protected constructor(shape: S, box: B);
     // (undocumented)
     get box(): B;
     // (undocumented)
@@ -2362,6 +2402,7 @@ export namespace Shape {
 //
 // @public (undocumented)
 export class Skew extends Function_3<"skew", false> implements Resolvable<Skew.Canonical, never> {
+    protected constructor(x: Angle.Canonical, y: Angle.Canonical);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -2401,6 +2442,7 @@ export namespace Skew {
 //
 // @public (undocumented)
 class String_2 extends Value<"string", false> implements Resolvable<String_2, never> {
+    protected constructor(value: string);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -2449,6 +2491,7 @@ export type Token = Token.Ident | Token.Function | Token.AtKeyword | Token.Hash 
 export namespace Token {
     // (undocumented)
     export class AtKeyword implements Equatable, Serializable<AtKeyword.JSON> {
+        protected constructor(value: string);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -2669,6 +2712,7 @@ export namespace Token {
     }
     // (undocumented)
     export class Delim implements Equatable, Serializable<Delim.JSON> {
+        protected constructor(value: number);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -2701,6 +2745,7 @@ export namespace Token {
     }
     // (undocumented)
     export class Dimension implements Equatable, Serializable<Dimension.JSON> {
+        protected constructor(value: number, unit: string, isInteger: boolean, isSigned: boolean);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -2744,6 +2789,7 @@ export namespace Token {
     badURL: typeof BadURL.of;
     // (undocumented)
     export class Function implements Equatable, Serializable<Function.JSON> {
+        protected constructor(value: string);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -2778,6 +2824,7 @@ export namespace Token {
     isDelim: typeof Delim.isDelim;
     // (undocumented)
     export class Hash implements Equatable, Serializable<Hash.JSON> {
+        protected constructor(value: string, isIdentifier: boolean);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -2811,6 +2858,7 @@ export namespace Token {
     }
     // (undocumented)
     export class Ident implements Equatable, Serializable<Ident.JSON> {
+        protected constructor(value: string);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -2845,6 +2893,7 @@ export namespace Token {
     export type JSON = Ident.JSON | Function.JSON | AtKeyword.JSON | Hash.JSON | String.JSON | URL.JSON | BadURL.JSON | Delim.JSON | Number.JSON | Percentage.JSON | Dimension.JSON | Whitespace.JSON | Colon.JSON | Semicolon.JSON | Comma.JSON | OpenParenthesis.JSON | CloseParenthesis.JSON | OpenSquareBracket.JSON | CloseSquareBracket.JSON | OpenCurlyBracket.JSON | CloseCurlyBracket.JSON | OpenComment.JSON | CloseComment.JSON;
     // (undocumented)
     export class Number implements Equatable, Serializable<Number.JSON> {
+        protected constructor(value: number, isInteger: boolean, isSigned: boolean);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -3047,6 +3096,7 @@ export namespace Token {
     parseOpenSquareBracket: Parser_2<Slice<Token>, OpenSquareBracket, string, []>;
     // (undocumented)
     export class Percentage implements Equatable, Serializable<Percentage.JSON> {
+        protected constructor(value: number, isInteger: boolean);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -3115,6 +3165,7 @@ export namespace Token {
     parseOpenCurlyBracket: Parser_2<Slice<Token>, OpenCurlyBracket, string, []>;
     // (undocumented)
     export class String implements Equatable, Serializable<String.JSON> {
+        protected constructor(value: string);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -3149,6 +3200,7 @@ export namespace Token {
     parseCloseCurlyBracket: Parser_2<Slice<Token>, CloseCurlyBracket, string, []>;
     // (undocumented)
     export class URL implements Equatable, Serializable<URL.JSON> {
+        protected constructor(value: string);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -3253,6 +3305,7 @@ export namespace Transform {
 //
 // @public (undocumented)
 export class Translate<X extends LengthPercentage = LengthPercentage, Y extends LengthPercentage = LengthPercentage, Z extends Length = Length> extends Function_3<"translate", Value.HasCalculation<[X, Y, Z]>> implements Resolvable<Translate.Canonical, Translate.Resolver>, PartiallyResolvable<Translate.PartiallyResolved, Translate.PartialResolver> {
+    protected constructor(x: X, y: Y, z: Z);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -3307,6 +3360,7 @@ export namespace Translate {
 //
 // @public (undocumented)
 export class Tuple<T extends Array<Value>> extends Value<"tuple", Value.HasCalculation<T>> implements Resolvable<Tuple<Tuple.Resolved<T>>, Tuple.Resolver<T>>, PartiallyResolvable<Tuple<Tuple.PartiallyResolved<T>>, Tuple.PartialResolver<T>> {
+    protected constructor(values: Readonly<T>);
     // (undocumented)
     equals<T extends Array<Value>>(value: Tuple<T>): boolean;
     // (undocumented)
@@ -3456,6 +3510,7 @@ export namespace Unit {
 //
 // @public (undocumented)
 export class URL extends Value<"url", false> implements Resolvable<URL, never> {
+    protected constructor(url: string);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)

--- a/docs/review/api/alfa-device.api.md
+++ b/docs/review/api/alfa-device.api.md
@@ -9,10 +9,12 @@ import type { Hash } from '@siteimprove/alfa-hash';
 import type { Hashable } from '@siteimprove/alfa-hash';
 import { Iterable as Iterable_2 } from '@siteimprove/alfa-iterable';
 import type * as json from '@siteimprove/alfa-json';
+import { Map as Map_2 } from '@siteimprove/alfa-map';
 import type { Serializable } from '@siteimprove/alfa-json';
 
 // @public (undocumented)
 export class Device implements Equatable, Hashable, Serializable {
+    protected constructor(type: Device.Type, viewport: Viewport, display: Display, scripting: Scripting, preferences: Map_2<Preference.Name, Preference>);
     // (undocumented)
     get display(): Display;
     // (undocumented)
@@ -69,6 +71,7 @@ export namespace Device {
 
 // @public (undocumented)
 export class Display implements Equatable, Hashable, Serializable {
+    protected constructor(resolution: number, scan: Display.Scan);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -109,6 +112,7 @@ export namespace Display {
 
 // @public (undocumented)
 export class Preference<N extends Preference.Name = Preference.Name> implements Equatable, Hashable, Serializable {
+    protected constructor(name: N, value: Preference.Value<N>);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -158,6 +162,7 @@ export namespace Preference {
 
 // @public (undocumented)
 export class Scripting implements Equatable, Hashable, Serializable {
+    protected constructor(enabled: boolean);
     // (undocumented)
     get enabled(): boolean;
     // (undocumented)
@@ -187,6 +192,7 @@ export namespace Scripting {
 
 // @public (undocumented)
 export class Viewport implements Equatable, Hashable, Serializable {
+    protected constructor(width: number, height: number, orientation: Viewport.Orientation);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)

--- a/docs/review/api/alfa-dom.api.md
+++ b/docs/review/api/alfa-dom.api.md
@@ -27,6 +27,7 @@ import * as tree from '@siteimprove/alfa-tree';
 
 // @public (undocumented)
 export class Attribute<N extends string = string> extends Node<"attribute"> {
+    protected constructor(namespace: Option<Namespace>, prefix: Option<string>, name: N, value: string, externalId?: string, internalId?: string, extraData?: any);
     // @internal (undocumented)
     _attachOwner(owner: Element): boolean;
     // @internal (undocumented)
@@ -100,6 +101,7 @@ export namespace Attribute {
 export class Block implements Iterable_2<Declaration>, Equatable, Serializable {
     // (undocumented)
     [Symbol.iterator](): Iterator<Declaration>;
+    protected constructor(declarations: Array<Declaration>);
     // (undocumented)
     declaration(predicate: string | Predicate<Declaration>): Option<Declaration>;
     // (undocumented)
@@ -128,6 +130,7 @@ export namespace Block {
 
 // @public (undocumented)
 export class Comment extends Node<"comment"> {
+    protected constructor(data: string, externalId?: string, internalId?: string, extraData?: any);
     // (undocumented)
     get data(): string;
     // (undocumented)
@@ -188,6 +191,7 @@ export namespace ConditionRule {
 
 // @public (undocumented)
 export class Declaration implements Equatable, Serializable {
+    protected constructor(name: string, value: string, important: boolean);
     // (undocumented)
     ancestors(): Iterable<Rule>;
     // @internal (undocumented)
@@ -232,6 +236,7 @@ export namespace Declaration {
 
 // @public (undocumented)
 export class Document extends Node<"document"> {
+    protected constructor(children: Array_2<Node>, style: Iterable_2<Sheet>, externalId?: string, internalId?: string, extraData?: any);
     // @internal (undocumented)
     _attachFrame(frame: Element): boolean;
     // @internal (undocumented)
@@ -278,6 +283,7 @@ export namespace Document {
 
 // @public (undocumented)
 export class Element<N extends string = string> extends Node<"element"> implements Slot, Slotable {
+    protected constructor(namespace: Option<Namespace>, prefix: Option<string>, name: N, attributes: Array<Attribute>, children: Array<Node>, style: Option<Block>, box: Option<Rectangle>, device: Option<Device>, externalId?: string, internalId?: string, extraData?: any);
     // (undocumented)
     assignedNodes(): Iterable_2<Slotable>;
     // (undocumented)
@@ -404,6 +410,7 @@ export namespace Element {
 
 // @public (undocumented)
 export class FontFaceRule extends Rule<"font-face"> {
+    protected constructor(declarations: Array<Declaration>);
     // (undocumented)
     static of(declarations: Iterable<Declaration>): FontFaceRule;
     // (undocumented)
@@ -429,6 +436,7 @@ export namespace FontFaceRule {
 
 // @public (undocumented)
 export class Fragment extends Node<"fragment"> {
+    protected constructor(children: Array<Node>, externalId?: string, internalId?: string, extraData?: any);
     // @internal (undocumented)
     _attachParent(): boolean;
     // (undocumented)
@@ -532,6 +540,7 @@ export namespace h {
 
 // @public (undocumented)
 export class ImportRule extends ConditionRule<"import"> {
+    protected constructor(href: string, sheet: Sheet, mediaCondition: Option<string>, supportCondition: Option<string>, layer: Option<string>);
     // (undocumented)
     get href(): string;
     // (undocumented)
@@ -604,6 +613,7 @@ export namespace jsx {
 
 // @public (undocumented)
 export class KeyframeRule extends Rule<"keyframe"> {
+    protected constructor(key: string, declarations: Array<Declaration>);
     // (undocumented)
     get key(): string;
     // (undocumented)
@@ -633,6 +643,7 @@ export namespace KeyframeRule {
 
 // @public (undocumented)
 export class KeyframesRule extends GroupingRule<"keyframes"> {
+    protected constructor(name: string, rules: Array<Rule>);
     // (undocumented)
     get name(): string;
     // (undocumented)
@@ -660,6 +671,7 @@ export namespace KeyframesRule {
 export namespace Layer {
     // (undocumented)
     export class BlockRule extends GroupingRule<"layer-block"> {
+        protected constructor(layer: Option<string>, rules: Array_2<Rule>);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -685,6 +697,7 @@ export namespace Layer {
     }
     // (undocumented)
     export class StatementRule extends Rule<"layer-statement"> {
+        protected constructor(layers: Array_2<string>);
         // (undocumented)
         get layers(): Iterable<string>;
         // (undocumented)
@@ -710,6 +723,7 @@ export namespace Layer {
 
 // @public (undocumented)
 export class MediaRule extends ConditionRule<"media"> {
+    protected constructor(condition: string, rules: Array<Rule>);
     // (undocumented)
     static of(condition: string, rules: Iterable_2<Rule>): MediaRule;
     // (undocumented)
@@ -757,6 +771,7 @@ export namespace Namespace {
 
 // @public (undocumented)
 export class NamespaceRule extends Rule<"namespace"> {
+    protected constructor(namespace: string, prefix: Option<string>);
     // (undocumented)
     get namespace(): string;
     // (undocumented)
@@ -965,6 +980,7 @@ export namespace Node {
 
 // @public (undocumented)
 export class PageRule extends Rule<"page"> {
+    protected constructor(selector: string, declarations: Array<Declaration>);
     // (undocumented)
     static of(selector: string, declarations: Iterable<Declaration>): PageRule;
     // (undocumented)
@@ -1078,6 +1094,7 @@ export namespace Rule {
 
 // @public (undocumented)
 export class Shadow extends Node<"shadow"> {
+    protected constructor(children: Array<Node>, style: Array<Sheet>, mode: Shadow.Mode, externalId?: string, internalId?: string, extraData?: any);
     // @internal (undocumented)
     _attachHost(host: Element): boolean;
     // @internal (undocumented)
@@ -1137,6 +1154,7 @@ export namespace Shadow {
 
 // @public (undocumented)
 export class Sheet implements Equatable, Serializable {
+    protected constructor(rules: Array<Rule>, disabled: boolean, condition: Option<string>);
     // (undocumented)
     children(): Iterable<Rule>;
     // (undocumented)
@@ -1210,6 +1228,7 @@ export namespace Slotable {
 
 // @public (undocumented)
 export class StyleRule extends Rule<"style"> {
+    protected constructor(selector: string, declarations: Array<Declaration>, hint: boolean);
     // (undocumented)
     get hint(): boolean;
     // (undocumented)
@@ -1243,6 +1262,7 @@ export namespace StyleRule {
 
 // @public (undocumented)
 export class SupportsRule extends ConditionRule<"supports"> {
+    protected constructor(condition: string, rules: Array<Rule>);
     // (undocumented)
     static of(condition: string, rules: Iterable<Rule>): SupportsRule;
     // (undocumented)
@@ -1268,6 +1288,7 @@ export namespace SupportsRule {
 
 // @public (undocumented)
 export class Text extends Node<"text"> implements Slotable {
+    protected constructor(data: string, externalId?: string, internalId?: string, extraData?: any);
     // (undocumented)
     assignedSlot(): Option<Slot>;
     // (undocumented)
@@ -1308,6 +1329,7 @@ export namespace Text {
 
 // @public (undocumented)
 export class Type<N extends string = string> extends Node<"type"> {
+    protected constructor(name: N, publicId: Option<string>, systemId: Option<string>, externalId?: string, internalId?: string, extraData?: any);
     // (undocumented)
     static empty(): Type;
     // (undocumented)

--- a/docs/review/api/alfa-either.api.md
+++ b/docs/review/api/alfa-either.api.md
@@ -77,6 +77,7 @@ export namespace Either {
 export class Left<L> implements Either<L, never> {
     // (undocumented)
     [Symbol.iterator](): Iterator<L>;
+    protected constructor(value: L);
     // (undocumented)
     apply(): Left<L>;
     // (undocumented)
@@ -138,6 +139,7 @@ export namespace Left {
 export class Right<R> implements Either<never, R> {
     // (undocumented)
     [Symbol.iterator](): Iterator<R>;
+    protected constructor(value: R);
     // (undocumented)
     apply<L, T>(mapper: Either<L, Mapper<R, T>>): Either<L, T>;
     // (undocumented)

--- a/docs/review/api/alfa-emitter.api.md
+++ b/docs/review/api/alfa-emitter.api.md
@@ -12,6 +12,7 @@ import type { Mapper } from '@siteimprove/alfa-mapper';
 export class Emitter<T> implements Functor.Invariant<T>, AsyncIterable<T> {
     // (undocumented)
     [Symbol.asyncIterator](): AsyncIterator<T>;
+    protected constructor(listeners: Map<Callback<never>, Callback<T>>);
     // (undocumented)
     asyncIterator(): AsyncIterator<T>;
     // (undocumented)

--- a/docs/review/api/alfa-fnv.api.md
+++ b/docs/review/api/alfa-fnv.api.md
@@ -8,6 +8,7 @@ import { Hash } from '@siteimprove/alfa-hash';
 
 // @public (undocumented)
 export class FNV extends Hash {
+    protected constructor();
     // (undocumented)
     static empty(): Hash;
     // (undocumented)

--- a/docs/review/api/alfa-graph.api.md
+++ b/docs/review/api/alfa-graph.api.md
@@ -17,6 +17,7 @@ import { Set as Set_2 } from '@siteimprove/alfa-set';
 export class Graph<T> implements Iterable_2<[T, Iterable_2<T>]>, Equatable, Hashable, Serializable<Graph.JSON<T>> {
     // (undocumented)
     [Symbol.iterator](): Iterator<[T, Iterable_2<T>]>;
+    protected constructor(nodes: Map_2<T, Set_2<T>>);
     // (undocumented)
     add(node: T): Graph<T>;
     // (undocumented)

--- a/docs/review/api/alfa-http.api.md
+++ b/docs/review/api/alfa-http.api.md
@@ -8,6 +8,7 @@ import type * as earl from '@siteimprove/alfa-earl';
 import type { Equatable } from '@siteimprove/alfa-equatable';
 import { Iterable as Iterable_2 } from '@siteimprove/alfa-iterable';
 import type * as json from '@siteimprove/alfa-json';
+import { Map as Map_2 } from '@siteimprove/alfa-map';
 import type { Option } from '@siteimprove/alfa-option';
 import type { Result } from '@siteimprove/alfa-result';
 import type { Serializable } from '@siteimprove/alfa-json';
@@ -40,6 +41,7 @@ export namespace Body {
 
 // @public (undocumented)
 export class Cookie implements Equatable, Serializable<Cookie.JSON> {
+    protected constructor(name: string, value: string);
     // (undocumented)
     equals(value: Cookie): boolean;
     // (undocumented)
@@ -77,6 +79,7 @@ export namespace Cookie {
 export class Cookies implements Iterable_2<Cookie>, Serializable<Cookies.JSON> {
     // (undocumented)
     [Symbol.iterator](): Iterator<Cookie>;
+    protected constructor(cookies: Map_2<string, Cookie>);
     // (undocumented)
     add(cookie: Cookie): Cookies;
     // (undocumented)
@@ -110,6 +113,7 @@ export namespace Cookies {
 
 // @public (undocumented)
 export class Header implements Equatable, json.Serializable<Header.JSON>, earl.Serializable<Header.EARL> {
+    protected constructor(name: string, value: string);
     // (undocumented)
     equals(value: Header): boolean;
     // (undocumented)
@@ -162,6 +166,7 @@ export namespace Header {
 export class Headers implements Iterable_2<Header>, json.Serializable<Headers.JSON>, earl.Serializable<Headers.EARL> {
     // (undocumented)
     [Symbol.iterator](): Iterator<Header>;
+    protected constructor(headers: Map_2<string, Header>);
     // (undocumented)
     add(header: Header): Headers;
     // (undocumented)
@@ -206,6 +211,7 @@ export namespace Headers {
 
 // @public (undocumented)
 export class Request implements Body, json.Serializable<Request.JSON>, earl.Serializable<Request.EARL> {
+    protected constructor(method: string, url: URL, headers: Headers, body: ArrayBuffer);
     // (undocumented)
     get body(): ArrayBuffer;
     // (undocumented)
@@ -266,6 +272,7 @@ export namespace Request {
 
 // @public (undocumented)
 export class Response implements Body, json.Serializable<Response.JSON>, earl.Serializable<Response.EARL> {
+    protected constructor(url: URL, status: number, headers: Headers, body: ArrayBuffer);
     // (undocumented)
     get body(): ArrayBuffer;
     // (undocumented)

--- a/docs/review/api/alfa-iana.api.md
+++ b/docs/review/api/alfa-iana.api.md
@@ -37,6 +37,7 @@ export class Language implements Equatable, Serializable {
 export namespace Language {
     // (undocumented)
     export class Extended extends Subtag<"extended", Extended.Name> {
+        protected constructor(name: Extended.Name);
         // (undocumented)
         equals(value: Extended): boolean;
         // (undocumented)
@@ -83,6 +84,7 @@ export namespace Language {
     }
     // (undocumented)
     export class Primary extends Subtag<"primary", Primary.Name> {
+        protected constructor(name: Primary.Name);
         // (undocumented)
         equals(value: Primary): boolean;
         // (undocumented)
@@ -114,6 +116,7 @@ export namespace Language {
     }
     // (undocumented)
     export class Region extends Subtag<"region", Region.Name> {
+        protected constructor(name: Region.Name);
         // (undocumented)
         equals(value: Region): boolean;
         // (undocumented)
@@ -149,6 +152,7 @@ export namespace Language {
     isExtendedName: typeof Extended.isName;
     // (undocumented)
     export class Script extends Subtag<"script", Script.Name> {
+        protected constructor(name: Script.Name);
         // (undocumented)
         equals(value: Script): boolean;
         // (undocumented)
@@ -212,6 +216,7 @@ export namespace Language {
     isRegionName: typeof Region.isName;
     // (undocumented)
     export class Variant extends Subtag<"variant", Variant.Name> {
+        protected constructor(name: Variant.Name);
         // (undocumented)
         equals(value: Variant): boolean;
         // (undocumented)

--- a/docs/review/api/alfa-lazy.api.md
+++ b/docs/review/api/alfa-lazy.api.md
@@ -11,11 +11,13 @@ import type { Mapper } from '@siteimprove/alfa-mapper';
 import type { Monad } from '@siteimprove/alfa-monad';
 import { Serializable } from '@siteimprove/alfa-json';
 import type { Thunk } from '@siteimprove/alfa-thunk';
+import { Trampoline } from '@siteimprove/alfa-trampoline';
 
 // @public (undocumented)
 export class Lazy<T> implements Functor<T>, Applicative<T>, Monad<T>, Iterable<T>, Equatable, Serializable<Lazy.JSON<T>> {
     // (undocumented)
     [Symbol.iterator](): Iterator<T>;
+    protected constructor(value: Trampoline<T>);
     // (undocumented)
     apply<U>(mapper: Lazy<Mapper<T, U>>): Lazy<U>;
     // (undocumented)

--- a/docs/review/api/alfa-list.api.md
+++ b/docs/review/api/alfa-list.api.md
@@ -28,6 +28,7 @@ import { Serializable } from '@siteimprove/alfa-json';
 export class Branch<T> implements Node<T> {
     // (undocumented)
     [Symbol.iterator](): Iterator<T>;
+    protected constructor(nodes: Array<Branch<T> | Leaf<T>>);
     // (undocumented)
     clone(): Branch<T>;
     // (undocumented)
@@ -65,6 +66,7 @@ export const Empty: Empty;
 export class Leaf<T> implements Node<T> {
     // (undocumented)
     [Symbol.iterator](): Iterator<T>;
+    protected constructor(values: Array<T>);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -89,6 +91,10 @@ export class Leaf<T> implements Node<T> {
 export class List<T> implements Collection.Indexed<T> {
     // (undocumented)
     [Symbol.iterator](): Iterator<T>;
+    // Warning: (ae-incompatible-release-tags) The symbol "__constructor" is marked as @public, but its signature references "Empty" which is marked as @internal
+    // Warning: (ae-incompatible-release-tags) The symbol "__constructor" is marked as @public, but its signature references "Leaf" which is marked as @internal
+    // Warning: (ae-incompatible-release-tags) The symbol "__constructor" is marked as @public, but its signature references "Branch" which is marked as @internal
+    protected constructor(head: Empty | Leaf<T> | Branch<T>, tail: Empty | Leaf<T>, shift: number, size: number);
     // (undocumented)
     append(value: T): List<T>;
     // (undocumented)

--- a/docs/review/api/alfa-map.api.md
+++ b/docs/review/api/alfa-map.api.md
@@ -24,6 +24,7 @@ import { Serializable } from '@siteimprove/alfa-json';
 export class Collision<K, V> implements Node<K, V> {
     // (undocumented)
     [Symbol.iterator](): Iterator<[K, V]>;
+    protected constructor(hash: number, nodes: Array<Leaf<K, V>>);
     // (undocumented)
     delete(key: K, hash: number): Status<Node<K, V>>;
     // (undocumented)
@@ -59,6 +60,7 @@ export const Empty: Empty;
 export class Leaf<K, V> implements Node<K, V> {
     // (undocumented)
     [Symbol.iterator](): Iterator<[K, V]>;
+    protected constructor(hash: number, key: K, value: V);
     // (undocumented)
     delete(key: K, hash: number): Status<Node<K, V>>;
     // (undocumented)
@@ -85,6 +87,8 @@ export class Leaf<K, V> implements Node<K, V> {
 class Map_2<K, V> implements Collection.Keyed<K, V> {
     // (undocumented)
     [Symbol.iterator](): Iterator<[K, V]>;
+    // Warning: (ae-incompatible-release-tags) The symbol "__constructor" is marked as @public, but its signature references "Node" which is marked as @internal
+    protected constructor(root: Node<K, V>, size: number);
     apply<U>(mapper: Map_2<K, Mapper<V, U>>): Map_2<K, U>;
     // (undocumented)
     collect<U>(mapper: Mapper<V, Option<U>, [key: K]>): Map_2<K, U>;
@@ -219,6 +223,7 @@ export namespace Node {
 export class Sparse<K, V> implements Node<K, V> {
     // (undocumented)
     [Symbol.iterator](): Iterator<[K, V]>;
+    protected constructor(mask: number, nodes: Array<Node<K, V>>);
     // (undocumented)
     delete(key: K, hash: number, shift: number): Status<Node<K, V>>;
     // (undocumented)

--- a/docs/review/api/alfa-network.api.md
+++ b/docs/review/api/alfa-network.api.md
@@ -18,6 +18,7 @@ import { Set as Set_2 } from '@siteimprove/alfa-set';
 export class Network<N, E> implements Iterable_2<[N, Iterable_2<[N, Iterable_2<E>]>]>, Equatable, Hashable, Serializable<Network.JSON<N, E>> {
     // (undocumented)
     [Symbol.iterator](): Iterator<[N, Iterable_2<[N, Iterable_2<E>]>]>;
+    protected constructor(nodes: Map_2<N, Map_2<N, Set_2<E>>>);
     // (undocumented)
     add(node: N): Network<N, E>;
     // (undocumented)

--- a/docs/review/api/alfa-option.api.md
+++ b/docs/review/api/alfa-option.api.md
@@ -146,6 +146,7 @@ export namespace Option {
 export class Some<T> implements Option<T> {
     // (undocumented)
     [Symbol.iterator](): Iterator<T>;
+    protected constructor(value: T);
     // (undocumented)
     and<U>(option: Option<U>): Option<U>;
     // (undocumented)

--- a/docs/review/api/alfa-performance.api.md
+++ b/docs/review/api/alfa-performance.api.md
@@ -12,6 +12,7 @@ import { Serializable } from '@siteimprove/alfa-json';
 export class Performance<T> implements AsyncIterable<Performance.Entry<T>>, Serializable<Performance.JSON> {
     // (undocumented)
     [Symbol.asyncIterator](): AsyncIterator<Performance.Entry<T>>;
+    protected constructor();
     // (undocumented)
     asyncIterator(): AsyncIterator<Performance.Entry<T>>;
     // (undocumented)
@@ -56,6 +57,7 @@ export namespace Performance {
     }
     // (undocumented)
     export class Mark<T> implements Serializable<Mark.JSON<T>> {
+        protected constructor(data: T, start: number);
         // (undocumented)
         get data(): T;
         // (undocumented)
@@ -88,6 +90,7 @@ export namespace Performance {
     isMark: typeof Mark.isMark;
     // (undocumented)
     export class Measure<T> implements Serializable<Measure.JSON<T>> {
+        protected constructor(data: T, start: number, duration: number);
         // (undocumented)
         get data(): T;
         // (undocumented)

--- a/docs/review/api/alfa-record.api.md
+++ b/docs/review/api/alfa-record.api.md
@@ -7,6 +7,7 @@
 import type { Equatable } from '@siteimprove/alfa-equatable';
 import type { Foldable } from '@siteimprove/alfa-foldable';
 import { Iterable as Iterable_2 } from '@siteimprove/alfa-iterable';
+import { List } from '@siteimprove/alfa-list';
 import type { Option } from '@siteimprove/alfa-option';
 import type { Predicate } from '@siteimprove/alfa-predicate';
 import type { Reducer } from '@siteimprove/alfa-reducer';
@@ -16,6 +17,7 @@ import { Serializable } from '@siteimprove/alfa-json';
 class Record_2<T> implements Foldable<Record_2.Value<T>>, Iterable_2<Record_2.Entry<T>>, Equatable, Serializable<Record_2.JSON<T>> {
     // (undocumented)
     [Symbol.iterator](): Iterator<Record_2.Entry<T>>;
+    protected constructor(indices: ReadonlyMap<string, number>, keys: ReadonlyArray<Record_2.Key<T>>, values: List<T[Record_2.Key<T>]>);
     // (undocumented)
     entries(): Iterable_2<Record_2.Entry<T>>;
     // (undocumented)

--- a/docs/review/api/alfa-rectangle.api.md
+++ b/docs/review/api/alfa-rectangle.api.md
@@ -12,6 +12,7 @@ import type { Serializable } from '@siteimprove/alfa-json';
 
 // @public (undocumented)
 export class Rectangle implements Equatable, Hashable, Serializable<Rectangle.JSON> {
+    protected constructor(x: number, y: number, width: number, height: number);
     // (undocumented)
     get area(): number;
     // (undocumented)

--- a/docs/review/api/alfa-result.api.md
+++ b/docs/review/api/alfa-result.api.md
@@ -24,6 +24,7 @@ import type { Thunk } from '@siteimprove/alfa-thunk';
 export class Err<E> implements Result<never, E> {
     // (undocumented)
     [Symbol.iterator](): Generator<never, void, unknown>;
+    protected constructor(error: E);
     // (undocumented)
     and(): Err<E>;
     // (undocumented)
@@ -127,6 +128,7 @@ export namespace Err {
 export class Ok<T> implements Result<T, never> {
     // (undocumented)
     [Symbol.iterator](): Generator<T, void, unknown>;
+    protected constructor(value: T);
     // (undocumented)
     and<U, F>(result: Result<U, F>): Result<U, F>;
     // (undocumented)

--- a/docs/review/api/alfa-rules.api.md
+++ b/docs/review/api/alfa-rules.api.md
@@ -31,6 +31,7 @@ export const alfaVersion = "0.97.0";
 
 // @public (undocumented)
 export class ARIA extends Requirement<"ARIA"> {
+    protected constructor(uri: string);
     // (undocumented)
     static of(uri: string): ARIA;
     // (undocumented)
@@ -48,6 +49,7 @@ export namespace ARIA {
 
 // @public (undocumented)
 export class BestPractice extends Requirement<"best practice"> {
+    protected constructor(uri: string);
     // (undocumented)
     static of(uri: string): BestPractice;
     // (undocumented)
@@ -174,6 +176,7 @@ export default FlattenedRules;
 export class Group<T extends Hashable> implements Iterable<T>, Equatable, Hashable, json.Serializable<Group.JSON<T>>, earl.Serializable<Group.EARL>, sarif.Serializable<sarif.Location> {
     // (undocumented)
     [Symbol.iterator](): Iterator<T>;
+    protected constructor(members: ReadonlyArray<T>);
     // (undocumented)
     equals(value: unknown): value is this;
     // (undocumented)
@@ -401,6 +404,7 @@ export const Rules: Record_2<typeof rules>;
 
 // @public (undocumented)
 export class Scope<S extends string = string> extends Tag<"scope"> {
+    protected constructor(scope: S);
     // (undocumented)
     equals(value: Scope): boolean;
     // (undocumented)
@@ -428,6 +432,7 @@ export namespace Scope {
 
 // @public (undocumented)
 export class Stability<S extends string = string> extends Tag<"stability"> {
+    protected constructor(stability: S);
     // (undocumented)
     equals(value: Stability): boolean;
     // (undocumented)
@@ -456,6 +461,7 @@ export namespace Stability {
 
 // @public (undocumented)
 export class Version<N extends number = number> extends Tag<"version"> {
+    protected constructor(version: N);
     // (undocumented)
     equals(value: Version): boolean;
     // (undocumented)

--- a/docs/review/api/alfa-selective.api.md
+++ b/docs/review/api/alfa-selective.api.md
@@ -21,6 +21,7 @@ import type { Serializable } from '@siteimprove/alfa-json';
 export class Selective<S, T = never> implements Functor<T>, Applicative<T>, Monad<T>, Iterable<S | T>, Equatable, Hashable, Serializable<Selective.JSON<S, T>> {
     // (undocumented)
     [Symbol.iterator](): Iterator<S | T>;
+    protected constructor(value: Either<S, T>);
     // (undocumented)
     apply<U>(mapper: Selective<S, Mapper<T, U>>): Selective<S, U>;
     // (undocumented)

--- a/docs/review/api/alfa-selector.api.md
+++ b/docs/review/api/alfa-selector.api.md
@@ -12,6 +12,7 @@ import type { Hash } from '@siteimprove/alfa-hash';
 import type { Hashable } from '@siteimprove/alfa-hash';
 import type { Iterable as Iterable_2 } from '@siteimprove/alfa-iterable';
 import type * as json from '@siteimprove/alfa-json';
+import { Map as Map_2 } from '@siteimprove/alfa-map';
 import { Maybe } from '@siteimprove/alfa-option';
 import { Nth } from '@siteimprove/alfa-css';
 import { Option } from '@siteimprove/alfa-option';
@@ -41,6 +42,7 @@ export namespace Absolute {
 export class Attribute extends WithName<"attribute"> {
     // (undocumented)
     [Symbol.iterator](): Iterator<Attribute>;
+    protected constructor(namespace: Option<string>, name: string, value: Option<string>, matcher: Option<Attribute.Matcher>, modifier: Option<Attribute.Modifier>);
     // (undocumented)
     equals(value: Attribute): boolean;
     // (undocumented)
@@ -108,6 +110,7 @@ export namespace Attribute {
 export class Class extends WithName<"class"> {
     // (undocumented)
     [Symbol.iterator](): Iterator<Class>;
+    protected constructor(name: string);
     // (undocumented)
     equals(value: Class): boolean;
     // (undocumented)
@@ -159,6 +162,7 @@ export namespace Combinator {
 export class Complex extends Selector_2<"complex"> {
     // (undocumented)
     [Symbol.iterator](): Iterator<Complex>;
+    protected constructor(combinator: Combinator, left: Simple | Compound | Complex, right: Simple | Compound);
     // (undocumented)
     get combinator(): Combinator;
     // (undocumented)
@@ -201,6 +205,7 @@ export namespace Complex {
 export class Compound extends Selector_2<"compound"> {
     // (undocumented)
     [Symbol.iterator](): Iterator<Compound>;
+    protected constructor(selectors: Array_2<Simple>);
     // (undocumented)
     equals(value: Compound): boolean;
     // (undocumented)
@@ -236,6 +241,7 @@ export namespace Compound {
 
 // @public (undocumented)
 export class Context {
+    protected constructor(state: Map_2<Element, Context.State>);
     // (undocumented)
     active(element: Element): Context;
     // (undocumented)
@@ -299,6 +305,7 @@ export namespace Context {
 export class Id extends WithName<"id"> {
     // (undocumented)
     [Symbol.iterator](): Iterator<Id>;
+    protected constructor(name: string);
     // (undocumented)
     equals(value: Id): boolean;
     // (undocumented)
@@ -332,6 +339,7 @@ export namespace Id {
 export class List<T extends Item = Item> extends Selector_2<"list"> {
     // (undocumented)
     [Symbol.iterator](): Iterator<T>;
+    protected constructor(selectors: Array_2<T>);
     // (undocumented)
     equals(value: List): boolean;
     // (undocumented)
@@ -446,6 +454,7 @@ export namespace PseudoElement {
 export class Relative extends Selector_2<"relative"> {
     // (undocumented)
     [Symbol.iterator](): Iterator<Relative>;
+    protected constructor(combinator: Combinator, selector: Simple | Compound | Complex);
     // (undocumented)
     get combinator(): Combinator;
     // (undocumented)
@@ -507,6 +516,7 @@ export namespace Simple {
 
 // @public (undocumented)
 export class Specificity implements Serializable<Specificity.JSON>, Equatable, Hashable {
+    protected constructor(a: number, b: number, c: number);
     // (undocumented)
     get a(): number;
     // (undocumented)
@@ -558,6 +568,7 @@ export namespace Specificity {
 export class Type extends WithName<"type"> {
     // (undocumented)
     [Symbol.iterator](): Iterator<Type>;
+    protected constructor(namespace: Option<string>, name: string);
     // (undocumented)
     equals(value: Type): boolean;
     // (undocumented)
@@ -593,6 +604,7 @@ export namespace Type {
 export class Universal extends Selector_2<"universal"> {
     // (undocumented)
     [Symbol.iterator](): Iterator<Universal>;
+    protected constructor(namespace: Option<string>);
     // (undocumented)
     static empty(): Universal;
     // (undocumented)

--- a/docs/review/api/alfa-sequence.api.md
+++ b/docs/review/api/alfa-sequence.api.md
@@ -26,6 +26,7 @@ import { Set as Set_2 } from '@siteimprove/alfa-set';
 export class Cons<T> implements Sequence<T> {
     // (undocumented)
     [Symbol.iterator](): Iterator<T>;
+    protected constructor(head: T, tail: Lazy<Sequence<T>>);
     // (undocumented)
     append(value: T): Cons<T>;
     // (undocumented)

--- a/docs/review/api/alfa-set.api.md
+++ b/docs/review/api/alfa-set.api.md
@@ -9,6 +9,7 @@ import type { Callback } from '@siteimprove/alfa-callback';
 import type { Collection } from '@siteimprove/alfa-collection';
 import type { Hash } from '@siteimprove/alfa-hash';
 import { Iterable as Iterable_2 } from '@siteimprove/alfa-iterable';
+import { Map as Map_2 } from '@siteimprove/alfa-map';
 import type { Mapper } from '@siteimprove/alfa-mapper';
 import type { Option } from '@siteimprove/alfa-option';
 import { Predicate } from '@siteimprove/alfa-predicate';
@@ -20,6 +21,7 @@ import { Serializable } from '@siteimprove/alfa-json';
 class Set_2<T> implements Collection.Unkeyed<T> {
     // (undocumented)
     [Symbol.iterator](): Iterator<T>;
+    protected constructor(values: Map_2<T, T>);
     // (undocumented)
     add(value: T): Set_2<T>;
     // (undocumented)

--- a/docs/review/api/alfa-slice.api.md
+++ b/docs/review/api/alfa-slice.api.md
@@ -23,6 +23,7 @@ import { Serializable } from '@siteimprove/alfa-json';
 export class Slice<T> implements Collection.Indexed<T> {
     // (undocumented)
     [Symbol.iterator](): Iterator<T>;
+    protected constructor(array: ReadonlyArray<T>, offset: number, length: number);
     // (undocumented)
     append(value: T): Slice<T>;
     // (undocumented)

--- a/docs/review/api/alfa-style.api.md
+++ b/docs/review/api/alfa-style.api.md
@@ -85,6 +85,7 @@ import type { Value as Value_2 } from '@siteimprove/alfa-css';
 //
 // @internal (undocumented)
 export class Longhand<SPECIFIED = unknown, COMPUTED = SPECIFIED> {
+    protected constructor(initial: COMPUTED, parseBase: parser.Parser<Slice<Token>, SPECIFIED, string>, compute: Mapper<Value<SPECIFIED>, Value<COMPUTED>, [style: Style]>, inherits: boolean, use: Mapper<Value<COMPUTED>, Option<Value<COMPUTED>>, [style: Style]>);
     // (undocumented)
     get compute(): Mapper<Value<SPECIFIED>, Value<COMPUTED>, [style: Style]>;
     // (undocumented)
@@ -297,6 +298,7 @@ export namespace Resolver {
 //
 // @internal (undocumented)
 export class Shorthand<N extends Name_2 = never> {
+    protected constructor(properties: Array<N>, parse: Shorthand.Parser<N>);
     // (undocumented)
     static of<N extends Name_2>(properties: Array<N>, parse: Shorthand.Parser<N>): Shorthand<N>;
     // (undocumented)
@@ -371,7 +373,7 @@ export namespace Shorthands {
 // @public (undocumented)
 export class Style implements Serializable<Style.JSON> {
     // Warning: (ae-forgotten-export) The symbol "Name" needs to be exported by the entry point index.d.ts
-    //
+    protected constructor(owner: Option<Element>, device: Device, parent: Option<Style>, variables: Map_2<string, Value<Slice<Token>>>, properties: Map_2<Name, Value>);
     // (undocumented)
     cascaded<N extends Name>(name: N): Option<Value<Style.Cascaded<N>>>;
     // (undocumented)
@@ -469,6 +471,7 @@ export namespace Style {
 export class Value<T = unknown> implements Functor<T>, Applicative<T>, Monad<T>, Iterable<T>, Equatable, Serializable<Value.JSON<T>> {
     // (undocumented)
     [Symbol.iterator](): Iterator<T>;
+    protected constructor(value: T, source: Option<Declaration>);
     // (undocumented)
     apply<U>(mapper: Value<Mapper<T, U>>): Value<U>;
     // (undocumented)

--- a/docs/review/api/alfa-table.api.md
+++ b/docs/review/api/alfa-table.api.md
@@ -80,6 +80,7 @@ export abstract class Cell implements Anchored, Equatable, Serializable<Cell.JSO
 export namespace Cell {
     // (undocumented)
     export class Data extends Cell {
+        protected constructor(element: Element, anchor: Slot, width: number, height: number, headers: Array_2<Slot>);
         // (undocumented)
         equals(cell: Data): boolean;
         // (undocumented)
@@ -109,6 +110,7 @@ export namespace Cell {
     hasElement: typeof predicate.hasElement;
     // (undocumented)
     export class Header extends Cell {
+        protected constructor(element: Element, anchor: Slot, width: number, height: number, headers: Array_2<Slot>, scope: Scope);
         // (undocumented)
         equals(cell: Header): boolean;
         // (undocumented)
@@ -165,6 +167,7 @@ export namespace Cell {
 //
 // @public (undocumented)
 export class Column implements Anchored, Equatable, Serializable<Column.JSON> {
+    protected constructor(x: number);
     // (undocumented)
     get anchor(): Slot;
     // (undocumented)
@@ -187,6 +190,7 @@ export namespace Column {
     //
     // (undocumented)
     export class Group implements Anchored, Equatable, Serializable<Group.JSON> {
+        protected constructor(element: Element, x: number, width: number);
         // (undocumented)
         get anchor(): Slot;
         // (undocumented)
@@ -255,6 +259,7 @@ export namespace Group {
 //
 // @public (undocumented)
 export class Row implements Anchored, Equatable, Serializable<Row.JSON> {
+    protected constructor(y: number);
     // (undocumented)
     get anchor(): Slot;
     // (undocumented)
@@ -277,6 +282,7 @@ export namespace Row {
     //
     // (undocumented)
     export class Group implements Anchored, Equatable, Serializable<Group.JSON> {
+        protected constructor(element: Element, y: number, height: number);
         // (undocumented)
         get anchor(): Slot;
         // (undocumented)
@@ -337,6 +343,7 @@ export namespace Scope {
 
 // @public (undocumented)
 export class Slot implements Comparable<Slot>, Equatable, Serializable<Slot.JSON> {
+    protected constructor(x: number, y: number);
     // (undocumented)
     compare(slot: Slot): Comparison;
     // (undocumented)
@@ -370,6 +377,7 @@ export namespace Slot {
 
 // @public (undocumented)
 export class Table implements Equatable, Serializable<Table.JSON> {
+    protected constructor(element: Element, cells: Array_2<Cell>, groups: Array_2<Group>);
     // (undocumented)
     get cells(): Sequence<Cell>;
     // (undocumented)

--- a/docs/review/api/alfa-time.api.md
+++ b/docs/review/api/alfa-time.api.md
@@ -19,6 +19,7 @@ export class Time {
 
 // @public (undocumented)
 export class Timeout {
+    protected constructor(timeout: number, time: Time);
     // (undocumented)
     elapsed(now?: number): number;
     // (undocumented)

--- a/docs/review/api/alfa-url.api.md
+++ b/docs/review/api/alfa-url.api.md
@@ -16,6 +16,7 @@ import type { Serializable } from '@siteimprove/alfa-json';
 
 // @public (undocumented)
 export class URL implements Equatable, Hashable, Serializable<URL.JSON> {
+    protected constructor(scheme: string, username: Option<string>, password: Option<string>, host: Option<string>, port: Option<number>, path: Sequence<string>, query: Option<string>, fragment: Option<string>, cannotBeABase: boolean);
     // (undocumented)
     static blank(): URL;
     // (undocumented)

--- a/docs/review/api/alfa-wcag.api.md
+++ b/docs/review/api/alfa-wcag.api.md
@@ -21,6 +21,7 @@ export namespace Conformance {
 
 // @public (undocumented)
 export class Criterion<C extends Criterion.Chapter = Criterion.Chapter, U extends Criterion.URI<C, "2.1" | "2.2"> = Criterion.URI<C, "2.1" | "2.2">> extends Requirement<"criterion", U> {
+    protected constructor(chapter: C, uri: U);
     get chapter(): C;
     get level(): Branched<Criterion.Level, Criterion.Version>;
     // (undocumented)
@@ -91,6 +92,7 @@ export namespace Criterion {
 
 // @public (undocumented)
 export class Technique<N extends Technique.Name = Technique.Name> extends Requirement<"technique", Technique.URI<N>> {
+    protected constructor(name: N, uri: Technique.URI<N>);
     get name(): N;
     // (undocumented)
     static of<N extends Technique.Name>(name: N): Technique<N>;

--- a/docs/review/api/alfa-web.api.md
+++ b/docs/review/api/alfa-web.api.md
@@ -17,6 +17,7 @@ import type * as sarif from '@siteimprove/alfa-sarif';
 
 // @public (undocumented)
 export class Page implements Resource, json.Serializable<Page.JSON>, earl.Serializable<Page.EARL>, sarif.Serializable<sarif.Artifact> {
+    protected constructor(request: Request, response: Response, document: Document, device: Device);
     // (undocumented)
     get device(): Device;
     // (undocumented)
@@ -88,6 +89,7 @@ export namespace Resource {
 
 // @public (undocumented)
 export class Site<R extends Resource = Resource> implements json.Serializable<Site.JSON<R>> {
+    protected constructor(resources: Graph<R>);
     // (undocumented)
     static of<R extends Resource>(resources: Graph<R>): Site<R>;
     // (undocumented)

--- a/docs/review/api/alfa-xpath.api.md
+++ b/docs/review/api/alfa-xpath.api.md
@@ -241,6 +241,7 @@ export type Expression = Expression.Primary | Expression.Path | Expression.Axis 
 export namespace Expression {
     // (undocumented)
     export class Axis implements Equatable, Serializable {
+        protected constructor(axis: Axis.Type, test: Option<Test>, predicates: Array<Expression>);
         // (undocumented)
         get axis(): Axis.Type;
         // (undocumented)
@@ -299,6 +300,7 @@ export namespace Expression {
     }
     // (undocumented)
     export class Decimal implements Equatable, Serializable {
+        protected constructor(value: number);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -326,6 +328,7 @@ export namespace Expression {
     }
     // (undocumented)
     export class Double implements Equatable, Serializable {
+        protected constructor(value: number);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -353,6 +356,7 @@ export namespace Expression {
     }
     // (undocumented)
     export class Filter implements Equatable, Serializable {
+        protected constructor(base: Expression, predicates: Array<Expression>);
         // (undocumented)
         get base(): Expression;
         // (undocumented)
@@ -384,6 +388,7 @@ export namespace Expression {
     }
     // (undocumented)
     export class FunctionCall implements Equatable, Serializable {
+        protected constructor(prefix: Option<string>, name: string, arity: number, parameters: Array<Expression>);
         // (undocumented)
         get arity(): number;
         // (undocumented)
@@ -423,6 +428,7 @@ export namespace Expression {
     }
     // (undocumented)
     export class Integer implements Equatable, Serializable {
+        protected constructor(value: number);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -459,6 +465,7 @@ export namespace Expression {
     }
     // (undocumented)
     export class Path implements Equatable, Serializable {
+        protected constructor(left: Expression, right: Expression);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -511,6 +518,7 @@ export namespace Expression {
     }
     // (undocumented)
     export class String implements Equatable, Serializable {
+        protected constructor(value: string);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -542,6 +550,7 @@ export namespace Expression {
     export namespace Test {
         // (undocumented)
         export class Attribute implements Equatable, Serializable {
+            protected constructor(name: Option<string>);
             // (undocumented)
             equals(value: unknown): value is this;
             // (undocumented)
@@ -627,6 +636,7 @@ export namespace Expression {
         }
         // (undocumented)
         export class Element implements Equatable, Serializable {
+            protected constructor(name: Option<string>);
             // (undocumented)
             equals(value: unknown): value is this;
             // (undocumented)
@@ -667,6 +677,7 @@ export namespace Expression {
         }
         // (undocumented)
         export class Name implements Equatable, Serializable {
+            protected constructor(prefix: Option<string>, name: string);
             // (undocumented)
             equals(value: unknown): value is this;
             // (undocumented)
@@ -899,6 +910,7 @@ export type Token = Token.Integer | Token.Decimal | Token.Double | Token.String 
 export namespace Token {
     // (undocumented)
     export class Character implements Equatable, Serializable<Character.JSON> {
+        protected constructor(value: number);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -926,6 +938,7 @@ export namespace Token {
     }
     // (undocumented)
     export class Comment implements Equatable, Serializable<Comment.JSON> {
+        protected constructor(value: string);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -955,6 +968,7 @@ export namespace Token {
     parseInteger: Parser_2<Slice<Token>, Integer, string, []>;
     // (undocumented)
     export class Decimal implements Equatable, Serializable<Decimal.JSON> {
+        protected constructor(value: number);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -982,6 +996,7 @@ export namespace Token {
     }
     // (undocumented)
     export class Double implements Equatable, Serializable<Double.JSON> {
+        protected constructor(value: number);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -1011,6 +1026,7 @@ export namespace Token {
     }
     // (undocumented)
     export class Integer implements Equatable, Serializable<Integer.JSON> {
+        protected constructor(value: number);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -1060,6 +1076,7 @@ export namespace Token {
     export type JSON = Integer.JSON | Decimal.JSON | Double.JSON | String.JSON | Comment.JSON | Name.JSON | Character.JSON;
     // (undocumented)
     export class Name implements Equatable, Serializable<Name.JSON> {
+        protected constructor(prefix: Option<string>, value: string);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)
@@ -1093,6 +1110,7 @@ export namespace Token {
     }
     // (undocumented)
     export class String implements Equatable, Serializable<String.JSON> {
+        protected constructor(value: string);
         // (undocumented)
         equals(value: unknown): value is this;
         // (undocumented)

--- a/packages/alfa-act/src/audit.ts
+++ b/packages/alfa-act/src/audit.ts
@@ -41,7 +41,7 @@ export class Audit<
   private readonly _rules: List<Rule<I, T, Q, S>>;
   private readonly _oracle: Oracle<I, T, Q, S>;
 
-  private constructor(
+  protected constructor(
     input: I,
     rules: List<Rule<I, T, Q, S>>,
     oracle: Oracle<I, T, Q, S>,

--- a/packages/alfa-act/src/cache.ts
+++ b/packages/alfa-act/src/cache.ts
@@ -16,7 +16,7 @@ export class Cache {
 
   private readonly _storage = new WeakMap<object, unknown>();
 
-  private constructor() {}
+  protected constructor() {}
 
   public get<I, T extends Hashable, Q extends Question.Metadata, S>(
     rule: Rule<I, T, Q, S>,

--- a/packages/alfa-act/src/outcome.ts
+++ b/packages/alfa-act/src/outcome.ts
@@ -202,7 +202,7 @@ export namespace Outcome {
       [key: string]: Result<Diagnostic>;
     }>;
 
-    private constructor(
+    protected constructor(
       rule: Rule<I, T, Q, S>,
       target: T,
       expectations: Record<{
@@ -381,7 +381,7 @@ export namespace Outcome {
       [key: string]: Result<Diagnostic>;
     }>;
 
-    private constructor(
+    protected constructor(
       rule: Rule<I, T, Q, S>,
       target: T,
       expectations: Record<{
@@ -565,7 +565,7 @@ export namespace Outcome {
     private readonly _target: T;
     private readonly _diagnostic: Diagnostic;
 
-    private constructor(
+    protected constructor(
       rule: Rule<I, T, Q, S>,
       target: T,
       diagnostic: Diagnostic,
@@ -745,7 +745,7 @@ export namespace Outcome {
       return new Inapplicable(rule, mode);
     }
 
-    private constructor(rule: Rule<I, T, Q, S>, mode: Mode) {
+    protected constructor(rule: Rule<I, T, Q, S>, mode: Mode) {
       super(Value.Inapplicable, rule, mode);
     }
 

--- a/packages/alfa-act/src/rule.ts
+++ b/packages/alfa-act/src/rule.ts
@@ -254,7 +254,7 @@ export namespace Rule {
       );
     }
 
-    private constructor(
+    protected constructor(
       uri: string,
       requirements: Array<Requirement>,
       tags: Array<Tag>,
@@ -456,7 +456,7 @@ export namespace Rule {
 
     private readonly _composes: Array<Rule<I, T, Q, S>>;
 
-    private constructor(
+    protected constructor(
       uri: string,
       requirements: Array<Requirement>,
       tags: Array<Tag>,

--- a/packages/alfa-affine/src/transformation.ts
+++ b/packages/alfa-affine/src/transformation.ts
@@ -35,7 +35,7 @@ export class Transformation implements Equatable, Serializable {
 
   private readonly _matrix: Matrix;
 
-  private constructor(matrix: Matrix) {
+  protected constructor(matrix: Matrix) {
     this._matrix = matrix;
   }
 

--- a/packages/alfa-aria/src/attribute.ts
+++ b/packages/alfa-aria/src/attribute.ts
@@ -25,7 +25,7 @@ export class Attribute<N extends Attribute.Name = Attribute.Name>
   private readonly _name: N;
   private readonly _value: string;
 
-  private constructor(name: N, value: string) {
+  protected constructor(name: N, value: string) {
     this._name = name;
     this._value = value;
   }

--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -39,7 +39,7 @@ export class Feature {
   private readonly _attributes: Feature.AttributesAspect;
   private readonly _name: Feature.NameAspect;
 
-  private constructor(
+  protected constructor(
     roleAspect: Feature.Aspect<Role.Name | Iterable<Role>>,
     attributes: Feature.AttributesAspect,
     name: Feature.NameAspect,

--- a/packages/alfa-aria/src/name/name.ts
+++ b/packages/alfa-aria/src/name/name.ts
@@ -88,7 +88,7 @@ export class Name implements Equatable, Serializable<Name.JSON> {
   private readonly _spaceBefore: boolean;
   private readonly _spaceAfter: boolean;
 
-  private constructor(
+  protected constructor(
     value: string,
     sources: Array<Source>,
     spaceBefore: boolean,

--- a/packages/alfa-aria/src/name/source.ts
+++ b/packages/alfa-aria/src/name/source.ts
@@ -39,7 +39,7 @@ export namespace Source {
 
     private readonly _text: Text;
 
-    private constructor(text: Text) {
+    protected constructor(text: Text) {
       this._text = text;
     }
 
@@ -87,7 +87,7 @@ export namespace Source {
     private readonly _element: Element;
     private readonly _name: Name;
 
-    private constructor(element: Element, name: Name) {
+    protected constructor(element: Element, name: Name) {
       this._element = element;
       this._name = name;
     }
@@ -147,7 +147,7 @@ export namespace Source {
     private readonly _element: Element;
     private readonly _name: Name;
 
-    private constructor(element: Element, name: Name) {
+    protected constructor(element: Element, name: Name) {
       this._element = element;
       this._name = name;
     }
@@ -206,7 +206,7 @@ export namespace Source {
 
     private readonly _attribute: Attribute;
 
-    private constructor(attribute: Attribute) {
+    protected constructor(attribute: Attribute) {
       this._attribute = attribute;
     }
 
@@ -254,7 +254,7 @@ export namespace Source {
     private readonly _attribute: Attribute;
     private readonly _name: Name;
 
-    private constructor(attribute: Attribute, name: Name) {
+    protected constructor(attribute: Attribute, name: Name) {
       this._attribute = attribute;
       this._name = name;
     }

--- a/packages/alfa-aria/src/name/state.ts
+++ b/packages/alfa-aria/src/name/state.ts
@@ -25,7 +25,7 @@ export class State implements Equatable, Serializable<State.JSON> {
   private readonly _isRecursing: boolean;
   private readonly _isDescending: boolean;
 
-  private constructor(
+  protected constructor(
     visited: Array<Element>,
     referrer: Option<Element>,
     referred: Option<Element>,

--- a/packages/alfa-aria/src/node.ts
+++ b/packages/alfa-aria/src/node.ts
@@ -299,7 +299,7 @@ export namespace Node {
     private readonly _isPresentational: boolean;
     private readonly _isVisible: boolean;
 
-    private constructor(isPresentational: boolean, isVisible: boolean) {
+    protected constructor(isPresentational: boolean, isVisible: boolean) {
       this._isPresentational = isPresentational;
       this._isVisible = isVisible;
     }

--- a/packages/alfa-aria/src/node/container.ts
+++ b/packages/alfa-aria/src/node/container.ts
@@ -29,7 +29,7 @@ export class Container extends Node<"container"> {
 
   private readonly _role: Option<Role>;
 
-  private constructor(
+  protected constructor(
     owner: dom.Node,
     children: Array<Node>,
     role: Option<Role>,

--- a/packages/alfa-aria/src/node/element.ts
+++ b/packages/alfa-aria/src/node/element.ts
@@ -40,7 +40,7 @@ export class Element extends Node<"element"> {
   private readonly _name: Option<Name>;
   private readonly _attributes: Array<Attribute>;
 
-  private constructor(
+  protected constructor(
     owner: dom.Node,
     role: Option<Role>,
     name: Option<Name>,

--- a/packages/alfa-aria/src/node/inert.ts
+++ b/packages/alfa-aria/src/node/inert.ts
@@ -10,7 +10,7 @@ export class Inert extends Node<"inert"> {
     return new Inert(owner);
   }
 
-  private constructor(owner: dom.Node) {
+  protected constructor(owner: dom.Node) {
     super(owner, [], "inert");
   }
 

--- a/packages/alfa-aria/src/node/text.ts
+++ b/packages/alfa-aria/src/node/text.ts
@@ -15,7 +15,7 @@ export class Text extends Node<"text"> {
 
   private readonly _name: Option<Name>;
 
-  private constructor(owner: dom.Node, name: Option<Name>) {
+  protected constructor(owner: dom.Node, name: Option<Name>) {
     super(owner, [], "text");
 
     this._name = name;

--- a/packages/alfa-aria/src/role.ts
+++ b/packages/alfa-aria/src/role.ts
@@ -81,7 +81,7 @@ export class Role<N extends Role.Name = Role.Name>
   private readonly _requiredAttributes: ReadonlyArray<Attribute.Name>;
   private readonly _prohibitedAttributes: ReadonlyArray<Attribute.Name>;
 
-  private constructor(
+  protected constructor(
     name: N,
     supportedAttributes: Array<Attribute.Name>,
     requiredAttributes: Array<Attribute.Name>,

--- a/packages/alfa-branched/src/branched.ts
+++ b/packages/alfa-branched/src/branched.ts
@@ -36,7 +36,7 @@ export class Branched<T, B = never>
 
   private readonly _values: List<Value<T, B>>;
 
-  private constructor(values: List<Value<T, B>>) {
+  protected constructor(values: List<Value<T, B>>) {
     this._values = values;
   }
 
@@ -362,7 +362,7 @@ class Value<T, B> implements Equatable, Hashable {
   private readonly _value: T;
   private readonly _branches: Option<List<B>>;
 
-  private constructor(value: T, branches: Option<List<B>>) {
+  protected constructor(value: T, branches: Option<List<B>>) {
     this._value = value;
     this._branches = branches;
   }

--- a/packages/alfa-cache/src/cache.ts
+++ b/packages/alfa-cache/src/cache.ts
@@ -34,7 +34,7 @@ export class Cache<K extends Cache.Key, V> {
 
   private readonly _storage = new WeakMap<K, V>();
 
-  private constructor() {}
+  protected constructor() {}
 
   /**
    * Returns the value (if it exists) associated with the given key.

--- a/packages/alfa-cascade/src/ancestor-filter.ts
+++ b/packages/alfa-cascade/src/ancestor-filter.ts
@@ -76,7 +76,7 @@ export class AncestorFilter implements Serializable<AncestorFilter.JSON> {
   private readonly _classes = Bucket.empty();
   private readonly _types = Bucket.empty();
 
-  private constructor() {}
+  protected constructor() {}
 
   public add(element: Element): void {
     for (const id of element.id) {
@@ -206,7 +206,7 @@ export class Bucket implements Serializable<Bucket.JSON> {
 
   private readonly _entries = new Map<string, number>();
 
-  private constructor() {}
+  protected constructor() {}
 
   public has(entry: string): boolean {
     return this._entries.has(entry);

--- a/packages/alfa-cascade/src/cascade.ts
+++ b/packages/alfa-cascade/src/cascade.ts
@@ -64,7 +64,7 @@ export class Cascade implements Serializable {
     Cache<Context, RuleTree.Node>
   >();
 
-  private constructor(root: Document | Shadow, device: Device) {
+  protected constructor(root: Document | Shadow, device: Device) {
     this._root = root;
     this._depth = getDepth(root);
     this._device = device;

--- a/packages/alfa-cascade/src/precedence/layer.ts
+++ b/packages/alfa-cascade/src/precedence/layer.ts
@@ -70,7 +70,7 @@ export class Layer<ORDERED extends boolean = boolean>
   private _ordered: ORDERED;
   private _order: number;
 
-  private constructor(
+  protected constructor(
     ordered: ORDERED,
     name: string,
     importance: boolean,

--- a/packages/alfa-cascade/src/rule-tree.ts
+++ b/packages/alfa-cascade/src/rule-tree.ts
@@ -87,7 +87,7 @@ export class RuleTree implements Serializable {
     None,
   );
 
-  private constructor() {}
+  protected constructor() {}
 
   /**
    * Add a bunch of items to the tree. Returns the last node created, which is
@@ -148,7 +148,7 @@ export namespace RuleTree {
     private readonly _children: Array<Node>;
     private readonly _parent: Option<Node>;
 
-    private constructor(
+    protected constructor(
       block: Block,
       children: Array<Node>,
       parent: Option<Node>,

--- a/packages/alfa-cascade/src/selector-map.ts
+++ b/packages/alfa-cascade/src/selector-map.ts
@@ -110,7 +110,7 @@ export class SelectorMap implements Serializable {
   private readonly _other: Array<Block<Block.Source>>;
   private readonly _shadow: Array<Block<Block.Source>>;
 
-  private constructor(
+  protected constructor(
     ids: SelectorMap.Bucket,
     classes: SelectorMap.Bucket,
     types: SelectorMap.Bucket,
@@ -494,7 +494,7 @@ export namespace SelectorMap {
 
     private readonly _nodes: Map<string, Array<Block<Block.Source>>>;
 
-    private constructor(nodes: Map<string, Array<Block<Block.Source>>>) {
+    protected constructor(nodes: Map<string, Array<Block<Block.Source>>>) {
       this._nodes = nodes;
     }
 

--- a/packages/alfa-compatibility/src/browser.ts
+++ b/packages/alfa-compatibility/src/browser.ts
@@ -48,7 +48,7 @@ export namespace Browser {
     private readonly _version: V;
     private readonly _date: number;
 
-    private constructor(browser: N, version: V, date: number) {
+    protected constructor(browser: N, version: V, date: number) {
       this._browser = browser;
       this._version = version;
       this._date = date;

--- a/packages/alfa-css-feature/src/condition/and.ts
+++ b/packages/alfa-css-feature/src/condition/and.ts
@@ -21,7 +21,7 @@ export class And<F extends Feature<F>> implements Feature<F, And.JSON<F>> {
   private readonly _left: Condition<F>;
   private readonly _right: Condition<F>;
 
-  private constructor(left: Condition<F>, right: Condition<F>) {
+  protected constructor(left: Condition<F>, right: Condition<F>) {
     this._left = left;
     this._right = right;
   }

--- a/packages/alfa-css-feature/src/condition/not.ts
+++ b/packages/alfa-css-feature/src/condition/not.ts
@@ -17,7 +17,7 @@ export class Not<F extends Feature<F>> implements Feature<F, Not.JSON<F>> {
 
   private readonly _condition: Condition<F>;
 
-  private constructor(condition: Condition<F>) {
+  protected constructor(condition: Condition<F>) {
     this._condition = condition;
   }
 

--- a/packages/alfa-css-feature/src/condition/or.ts
+++ b/packages/alfa-css-feature/src/condition/or.ts
@@ -21,7 +21,7 @@ export class Or<F extends Feature<F>> implements Feature<F, Or.JSON<F>> {
   private readonly _left: Condition<F>;
   private readonly _right: Condition<F>;
 
-  private constructor(left: Condition<F>, right: Condition<F>) {
+  protected constructor(left: Condition<F>, right: Condition<F>) {
     this._left = left;
     this._right = right;
   }

--- a/packages/alfa-css-feature/src/media/feature/discrete.ts
+++ b/packages/alfa-css-feature/src/media/feature/discrete.ts
@@ -28,7 +28,7 @@ export namespace Discrete {
 
       private static _boolean = new Discrete(None);
 
-      private constructor(value: Option<Value<Keyword<K>>>) {
+      protected constructor(value: Option<Value<Keyword<K>>>) {
         super(name, value);
       }
 

--- a/packages/alfa-css-feature/src/media/feature/height.ts
+++ b/packages/alfa-css-feature/src/media/feature/height.ts
@@ -18,7 +18,7 @@ export class Height extends Media<"height", Length.Fixed> {
 
   private static _boolean = new Height(None);
 
-  private constructor(value: Option<Value<Length.Fixed>>) {
+  protected constructor(value: Option<Value<Length.Fixed>>) {
     super("height", value);
   }
 

--- a/packages/alfa-css-feature/src/media/feature/scripting.ts
+++ b/packages/alfa-css-feature/src/media/feature/scripting.ts
@@ -17,7 +17,7 @@ export class Scripting extends Media<"scripting", Keyword> {
 
   private static _boolean = new Scripting(None);
 
-  private constructor(value: Option<Value<Keyword>>) {
+  protected constructor(value: Option<Value<Keyword>>) {
     super("scripting", value);
   }
 

--- a/packages/alfa-css-feature/src/media/feature/value/bound.ts
+++ b/packages/alfa-css-feature/src/media/feature/value/bound.ts
@@ -20,7 +20,7 @@ export class Bound<T = unknown>
   private readonly _value: T;
   private readonly _isInclusive: boolean;
 
-  private constructor(value: T, isInclusive: boolean) {
+  protected constructor(value: T, isInclusive: boolean) {
     this._value = value;
     this._isInclusive = isInclusive;
   }

--- a/packages/alfa-css-feature/src/media/feature/value/discrete.ts
+++ b/packages/alfa-css-feature/src/media/feature/value/discrete.ts
@@ -20,7 +20,7 @@ export class Discrete<T = unknown>
 
   private readonly _value: T;
 
-  private constructor(value: T) {
+  protected constructor(value: T) {
     this._value = value;
   }
 

--- a/packages/alfa-css-feature/src/media/feature/value/range.ts
+++ b/packages/alfa-css-feature/src/media/feature/value/range.ts
@@ -35,7 +35,7 @@ export class Range<T = unknown>
   private readonly _minimum: Option<Bound<T>>;
   private readonly _maximum: Option<Bound<T>>;
 
-  private constructor(minimum: Option<Bound<T>>, maximum: Option<Bound<T>>) {
+  protected constructor(minimum: Option<Bound<T>>, maximum: Option<Bound<T>>) {
     this._minimum = minimum;
     this._maximum = maximum;
   }

--- a/packages/alfa-css-feature/src/media/feature/width.ts
+++ b/packages/alfa-css-feature/src/media/feature/width.ts
@@ -18,7 +18,7 @@ export class Width extends Media<"width", Length.Fixed> {
 
   private static _boolean = new Width(None);
 
-  private constructor(value: Option<Value<Length.Fixed>>) {
+  protected constructor(value: Option<Value<Length.Fixed>>) {
     super("width", value);
   }
 

--- a/packages/alfa-css-feature/src/media/list.ts
+++ b/packages/alfa-css-feature/src/media/list.ts
@@ -22,7 +22,7 @@ export class List implements Feature<Query, List.JSON> {
 
   private readonly _queries: Array<Query>;
 
-  private constructor(queries: Iterable<Query>) {
+  protected constructor(queries: Iterable<Query>) {
     this._queries = Array.from(queries);
   }
 

--- a/packages/alfa-css-feature/src/media/query.ts
+++ b/packages/alfa-css-feature/src/media/query.ts
@@ -35,7 +35,7 @@ export class Query implements Feature<Condition<Media>, Query.JSON> {
   private readonly _type: Option<Type>;
   private readonly _condition: Option<Condition<Media>>;
 
-  private constructor(
+  protected constructor(
     modifier: Option<Modifier>,
     type: Option<Type>,
     condition: Option<Condition<Media>>,

--- a/packages/alfa-css-feature/src/media/type.ts
+++ b/packages/alfa-css-feature/src/media/type.ts
@@ -19,7 +19,7 @@ export class Type implements Feature<Type> {
 
   private readonly _name: string;
 
-  private constructor(name: string) {
+  protected constructor(name: string) {
     this._name = name;
   }
 

--- a/packages/alfa-css-feature/src/supports/feature/property.ts
+++ b/packages/alfa-css-feature/src/supports/feature/property.ts
@@ -22,7 +22,7 @@ export class Property<N extends string = string>
   private readonly _name: N;
   private readonly _value: string;
 
-  private constructor(name: N, value: string) {
+  protected constructor(name: N, value: string) {
     this._name = name;
     this._value = value;
   }

--- a/packages/alfa-css-feature/src/supports/query.ts
+++ b/packages/alfa-css-feature/src/supports/query.ts
@@ -25,7 +25,7 @@ export class Query implements Feature<Condition<Property>, Query.JSON> {
 
   private readonly _condition: Condition<Property>;
 
-  private constructor(condition: Condition<Property>) {
+  protected constructor(condition: Condition<Property>) {
     this._condition = condition;
   }
 

--- a/packages/alfa-css/src/calculation/math-expression/function.ts
+++ b/packages/alfa-css/src/calculation/math-expression/function.ts
@@ -69,7 +69,7 @@ export namespace Function {
       return new Calculation([expression], expression.kind);
     }
 
-    private constructor(args: [Expression], kind: Kind) {
+    protected constructor(args: [Expression], kind: Kind) {
       super("calculation", args, kind);
     }
 
@@ -107,7 +107,10 @@ export namespace Function {
       return kind.map((kind) => new Max([first, ...expressions], kind));
     }
 
-    private constructor(args: [Expression, ...Array<Expression>], kind: Kind) {
+    protected constructor(
+      args: [Expression, ...Array<Expression>],
+      kind: Kind,
+    ) {
       super("max", args, kind);
     }
 

--- a/packages/alfa-css/src/calculation/math-expression/kind.ts
+++ b/packages/alfa-css/src/calculation/math-expression/kind.ts
@@ -37,7 +37,7 @@ export class Kind implements Equatable, Serializable {
 
   private readonly _hint: Option<Kind.Hint>;
 
-  private constructor(kinds: Kind.Map, hint: Option<Kind.Hint>) {
+  protected constructor(kinds: Kind.Map, hint: Option<Kind.Hint>) {
     this._kinds = kinds;
     this._hint = hint;
   }

--- a/packages/alfa-css/src/calculation/math-expression/math.ts
+++ b/packages/alfa-css/src/calculation/math-expression/math.ts
@@ -12,14 +12,8 @@ import {
 } from "../../syntax/index.js";
 import type { Unit } from "../../unit/index.js";
 
-import type {
-  Numeric} from "../numeric/index.js";
-import {
-  Angle,
-  Length,
-  Number,
-  Percentage,
-} from "../numeric/index.js";
+import type { Numeric } from "../numeric/index.js";
+import { Angle, Length, Number, Percentage } from "../numeric/index.js";
 
 import type { Expression } from "./expression.js";
 import { Function } from "./function.js";
@@ -57,7 +51,7 @@ export class Math<out D extends Math.Dimension = Math.Dimension> {
   private readonly _expression: Expression;
   private readonly _type = "math expression";
 
-  private constructor(expression: Expression) {
+  protected constructor(expression: Expression) {
     this._expression = expression;
   }
 

--- a/packages/alfa-css/src/calculation/math-expression/operation.ts
+++ b/packages/alfa-css/src/calculation/math-expression/operation.ts
@@ -3,8 +3,7 @@ import type { Result } from "@siteimprove/alfa-result";
 
 import { Unit } from "../../unit/index.js";
 
-import type {
-  Numeric} from "../numeric/index.js";
+import type { Numeric } from "../numeric/index.js";
 import {
   Angle,
   Dimension,
@@ -104,7 +103,7 @@ export namespace Operation {
 
       return kind.map((kind) => new Sum(operands, kind));
     }
-    private constructor(operands: [Expression, Expression], kind: Kind) {
+    protected constructor(operands: [Expression, Expression], kind: Kind) {
       super("sum", operands, kind);
     }
 
@@ -165,7 +164,7 @@ export namespace Operation {
       return new Negate([operand], operand.kind);
     }
 
-    private constructor(operand: [Expression], kind: Kind) {
+    protected constructor(operand: [Expression], kind: Kind) {
       super("negate", operand, kind);
     }
 
@@ -226,7 +225,7 @@ export namespace Operation {
       return kind.map((kind) => new Product(operands, kind));
     }
 
-    private constructor(operands: [Expression, Expression], kind: Kind) {
+    protected constructor(operands: [Expression, Expression], kind: Kind) {
       super("product", operands, kind);
     }
 
@@ -286,7 +285,7 @@ export namespace Operation {
       return new Invert([operand], operand.kind.invert());
     }
 
-    private constructor(operand: [Expression], kind: Kind) {
+    protected constructor(operand: [Expression], kind: Kind) {
       super("invert", operand, kind);
     }
 

--- a/packages/alfa-css/src/calculation/math-expression/value.ts
+++ b/packages/alfa-css/src/calculation/math-expression/value.ts
@@ -5,14 +5,8 @@ import { Selective } from "@siteimprove/alfa-selective";
 
 import { Unit } from "../../unit/index.js";
 
-import type {
-  Numeric} from "../numeric/index.js";
-import {
-  Angle,
-  Length,
-  Number,
-  Percentage,
-} from "../numeric/index.js";
+import type { Numeric } from "../numeric/index.js";
+import { Angle, Length, Number, Percentage } from "../numeric/index.js";
 
 import { Expression } from "./expression.js";
 import { Kind } from "./kind.js";
@@ -42,7 +36,7 @@ export class Value<N extends Numeric = Numeric> extends Expression {
 
   private readonly _value: N;
 
-  private constructor(value: N, kind: Kind) {
+  protected constructor(value: N, kind: Kind) {
     super("value", kind);
 
     this._value = value;

--- a/packages/alfa-css/src/calculation/numeric/angle.ts
+++ b/packages/alfa-css/src/calculation/numeric/angle.ts
@@ -20,7 +20,7 @@ export class Angle<U extends Unit.Angle = Unit.Angle> extends Dimension<
     return new Angle(value, unit);
   }
 
-  private constructor(value: number, unit: U) {
+  protected constructor(value: number, unit: U) {
     super(value, unit, "angle");
   }
 

--- a/packages/alfa-css/src/calculation/numeric/integer.ts
+++ b/packages/alfa-css/src/calculation/numeric/integer.ts
@@ -22,7 +22,7 @@ export class Integer extends Numeric<"integer"> {
     return new Integer(Math.round(value) | 0);
   }
 
-  private constructor(value: number) {
+  protected constructor(value: number) {
     super(value, "integer");
   }
 

--- a/packages/alfa-css/src/calculation/numeric/length.ts
+++ b/packages/alfa-css/src/calculation/numeric/length.ts
@@ -21,7 +21,7 @@ export class Length<U extends Unit.Length = Unit.Length> extends Dimension<
     return new Length(value, unit);
   }
 
-  private constructor(value: number, unit: U) {
+  protected constructor(value: number, unit: U) {
     super(value, unit, "length");
   }
 

--- a/packages/alfa-css/src/calculation/numeric/number.ts
+++ b/packages/alfa-css/src/calculation/numeric/number.ts
@@ -15,7 +15,7 @@ export class Number extends Numeric<"number"> {
     return new Number(value);
   }
 
-  private constructor(value: number) {
+  protected constructor(value: number) {
     super(value, "number");
   }
 

--- a/packages/alfa-css/src/calculation/numeric/percentage.ts
+++ b/packages/alfa-css/src/calculation/numeric/percentage.ts
@@ -15,7 +15,7 @@ export class Percentage extends Numeric<"percentage"> {
     return new Percentage(value);
   }
 
-  private constructor(value: number) {
+  protected constructor(value: number) {
     super(value, "percentage");
   }
 

--- a/packages/alfa-css/src/syntax/block.ts
+++ b/packages/alfa-css/src/syntax/block.ts
@@ -23,7 +23,7 @@ export class Block implements Iterable<Token>, Equatable, Serializable {
   private readonly _token: Block.Open;
   private readonly _value: Array<Token>;
 
-  private constructor(token: Block.Open, value: Array<Token>) {
+  protected constructor(token: Block.Open, value: Array<Token>) {
     this._token = token;
     this._value = value;
   }

--- a/packages/alfa-css/src/syntax/component.ts
+++ b/packages/alfa-css/src/syntax/component.ts
@@ -23,7 +23,7 @@ export class Component implements Iterable<Token>, Equatable, Serializable {
 
   private readonly _value: Array<Token>;
 
-  private constructor(value: Array<Token>) {
+  protected constructor(value: Array<Token>) {
     this._value = value;
   }
 

--- a/packages/alfa-css/src/syntax/declaration.ts
+++ b/packages/alfa-css/src/syntax/declaration.ts
@@ -32,7 +32,7 @@ export class Declaration implements Iterable<Token>, Equatable, Serializable {
   private readonly _value: Array<Token>;
   private readonly _important: boolean;
 
-  private constructor(name: string, value: Array<Token>, important: boolean) {
+  protected constructor(name: string, value: Array<Token>, important: boolean) {
     this._name = name;
     this._value = value;
     this._important = important;

--- a/packages/alfa-css/src/syntax/function.ts
+++ b/packages/alfa-css/src/syntax/function.ts
@@ -39,7 +39,7 @@ export class Function implements Iterable<Token>, Equatable, Serializable {
   private readonly _name: string;
   private readonly _value: Array<Token>;
 
-  private constructor(name: string, value: Array<Token>) {
+  protected constructor(name: string, value: Array<Token>) {
     this._name = name;
     this._value = value;
   }

--- a/packages/alfa-css/src/syntax/nth.ts
+++ b/packages/alfa-css/src/syntax/nth.ts
@@ -22,7 +22,7 @@ export class Nth implements Iterable<Token>, Equatable, Serializable {
   private readonly _step: number;
   private readonly _offset: number;
 
-  private constructor(step: number, offset: number) {
+  protected constructor(step: number, offset: number) {
     this._step = step;
     this._offset = offset;
   }

--- a/packages/alfa-css/src/syntax/token.ts
+++ b/packages/alfa-css/src/syntax/token.ts
@@ -88,7 +88,7 @@ export namespace Token {
 
     private readonly _value: string;
 
-    private constructor(value: string) {
+    protected constructor(value: string) {
       this._value = value;
     }
 
@@ -151,7 +151,7 @@ export namespace Token {
 
     private readonly _value: string;
 
-    private constructor(value: string) {
+    protected constructor(value: string) {
       this._value = value;
     }
 
@@ -212,7 +212,7 @@ export namespace Token {
 
     private readonly _value: string;
 
-    private constructor(value: string) {
+    protected constructor(value: string) {
       this._value = value;
     }
 
@@ -258,7 +258,7 @@ export namespace Token {
     private readonly _value: string;
     private readonly _isIdentifier: boolean;
 
-    private constructor(value: string, isIdentifier: boolean) {
+    protected constructor(value: string, isIdentifier: boolean) {
       this._value = value;
       this._isIdentifier = isIdentifier;
     }
@@ -322,7 +322,7 @@ export namespace Token {
 
     private readonly _value: string;
 
-    private constructor(value: string) {
+    protected constructor(value: string) {
       this._value = value;
     }
 
@@ -375,7 +375,7 @@ export namespace Token {
 
     private readonly _value: string;
 
-    private constructor(value: string) {
+    protected constructor(value: string) {
       this._value = value;
     }
 
@@ -472,7 +472,7 @@ export namespace Token {
 
     private readonly _value: number;
 
-    private constructor(value: number) {
+    protected constructor(value: number) {
       this._value = value;
     }
 
@@ -543,7 +543,11 @@ export namespace Token {
     private readonly _isInteger: boolean;
     private readonly _isSigned: boolean;
 
-    private constructor(value: number, isInteger: boolean, isSigned: boolean) {
+    protected constructor(
+      value: number,
+      isInteger: boolean,
+      isSigned: boolean,
+    ) {
       this._value = value;
       this._isInteger = isInteger;
       this._isSigned = isSigned;
@@ -620,7 +624,7 @@ export namespace Token {
     private readonly _value: number;
     private readonly _isInteger: boolean;
 
-    private constructor(value: number, isInteger: boolean) {
+    protected constructor(value: number, isInteger: boolean) {
       this._value = value;
       this._isInteger = isInteger;
     }
@@ -694,7 +698,7 @@ export namespace Token {
     private readonly _isInteger: boolean;
     private readonly _isSigned: boolean;
 
-    private constructor(
+    protected constructor(
       value: number,
       unit: string,
       isInteger: boolean,

--- a/packages/alfa-css/src/syntax/token.ts
+++ b/packages/alfa-css/src/syntax/token.ts
@@ -422,8 +422,10 @@ export namespace Token {
   }
 
   export class BadURL implements Equatable, Serializable<BadURL.JSON> {
+    private static _instance = new BadURL();
+
     public static of(): BadURL {
-      return new BadURL();
+      return BadURL._instance;
     }
 
     private constructor() {}

--- a/packages/alfa-css/src/value/collection/list.ts
+++ b/packages/alfa-css/src/value/collection/list.ts
@@ -34,7 +34,7 @@ export class List<V extends Value>
   private readonly _values: Array<V>;
   private readonly _separator: string;
 
-  private constructor(values: Array<V>, separator: string) {
+  protected constructor(values: Array<V>, separator: string) {
     super("list", Value.hasCalculation(...values));
     this._values = values;
     this._separator = separator;

--- a/packages/alfa-css/src/value/collection/tuple.ts
+++ b/packages/alfa-css/src/value/collection/tuple.ts
@@ -22,7 +22,7 @@ export class Tuple<T extends Array<Value>>
 
   private readonly _values: Readonly<T>;
 
-  private constructor(values: Readonly<T>) {
+  protected constructor(values: Readonly<T>) {
     super("tuple", Value.hasCalculation(...values));
     this._values = values;
   }

--- a/packages/alfa-css/src/value/color/hex.ts
+++ b/packages/alfa-css/src/value/color/hex.ts
@@ -20,7 +20,7 @@ export class Hex extends Format<"hex"> {
 
   private readonly _value: number;
 
-  private constructor(value: number) {
+  protected constructor(value: number) {
     super("hex");
 
     // Make sure that only the lower 4 bytes are stored.

--- a/packages/alfa-css/src/value/color/hsl.ts
+++ b/packages/alfa-css/src/value/color/hsl.ts
@@ -82,7 +82,7 @@ export class HSL<
   private readonly _blue: Percentage.Canonical;
   private readonly _alpha: A;
 
-  private constructor(
+  protected constructor(
     hue: H,
     saturation: Percentage.Canonical,
     lightness: Percentage.Canonical,

--- a/packages/alfa-css/src/value/color/named.ts
+++ b/packages/alfa-css/src/value/color/named.ts
@@ -22,7 +22,7 @@ export class Named<
 
   private readonly _color: C;
 
-  private constructor(color: C) {
+  protected constructor(color: C) {
     super("named");
     this._color = color;
   }

--- a/packages/alfa-css/src/value/color/rgb.ts
+++ b/packages/alfa-css/src/value/color/rgb.ts
@@ -75,7 +75,7 @@ export class RGB<
   private readonly _blue: C;
   private readonly _alpha: A;
 
-  private constructor(red: C, green: C, blue: C, alpha: A) {
+  protected constructor(red: C, green: C, blue: C, alpha: A) {
     super("rgb");
     this._red = red;
     this._green = green;

--- a/packages/alfa-css/src/value/contain.ts
+++ b/packages/alfa-css/src/value/contain.ts
@@ -45,7 +45,7 @@ export class ContainFlags
   private readonly _style: boolean;
   private readonly _paint: boolean;
 
-  private constructor(
+  protected constructor(
     size: boolean,
     inlineSize: boolean,
     layout: boolean,

--- a/packages/alfa-css/src/value/image/gradient/item/hint.ts
+++ b/packages/alfa-css/src/value/image/gradient/item/hint.ts
@@ -25,7 +25,7 @@ export class Hint<P extends LengthPercentage = LengthPercentage>
 
   private readonly _position: P;
 
-  private constructor(position: P) {
+  protected constructor(position: P) {
     super("hint", Value.hasCalculation(position));
     this._position = position;
   }

--- a/packages/alfa-css/src/value/image/gradient/item/stop.ts
+++ b/packages/alfa-css/src/value/image/gradient/item/stop.ts
@@ -33,7 +33,7 @@ export class Stop<
   private readonly _color: C;
   private readonly _position: Option<P>;
 
-  private constructor(color: C, position: Option<P>) {
+  protected constructor(color: C, position: Option<P>) {
     super(
       "stop",
       (Value.hasCalculation(color) ||

--- a/packages/alfa-css/src/value/image/gradient/linear/corner.ts
+++ b/packages/alfa-css/src/value/image/gradient/linear/corner.ts
@@ -27,7 +27,7 @@ export class Corner
   private readonly _vertical: Position.Vertical;
   private readonly _horizontal: Position.Horizontal;
 
-  private constructor(
+  protected constructor(
     vertical: Position.Vertical,
     horizontal: Position.Horizontal,
   ) {

--- a/packages/alfa-css/src/value/image/gradient/linear/linear.ts
+++ b/packages/alfa-css/src/value/image/gradient/linear/linear.ts
@@ -41,7 +41,7 @@ export class Linear<I extends Item = Item, D extends Direction = Direction>
   private readonly _items: Array<I>;
   private readonly _repeats: boolean;
 
-  private constructor(direction: D, items: Array<I>, repeats: boolean) {
+  protected constructor(direction: D, items: Array<I>, repeats: boolean) {
     super("gradient", Value.hasCalculation(direction, ...items));
     this._direction = direction;
     this._items = items;

--- a/packages/alfa-css/src/value/image/gradient/linear/side.ts
+++ b/packages/alfa-css/src/value/image/gradient/linear/side.ts
@@ -23,7 +23,7 @@ export class Side
 
   private readonly _side: Position.Vertical | Position.Horizontal;
 
-  private constructor(side: Position.Vertical | Position.Horizontal) {
+  protected constructor(side: Position.Vertical | Position.Horizontal) {
     super("side", false);
     this._side = side;
   }

--- a/packages/alfa-css/src/value/image/gradient/radial/circle.ts
+++ b/packages/alfa-css/src/value/image/gradient/radial/circle.ts
@@ -23,7 +23,7 @@ export class Circle<R extends Length = Length>
 
   private readonly _radius: R;
 
-  private constructor(radius: R) {
+  protected constructor(radius: R) {
     super("circle", Value.hasCalculation(radius));
     this._radius = radius;
   }

--- a/packages/alfa-css/src/value/image/gradient/radial/ellipse.ts
+++ b/packages/alfa-css/src/value/image/gradient/radial/ellipse.ts
@@ -32,7 +32,7 @@ export class Ellipse<R extends LengthPercentage = LengthPercentage>
   private readonly _horizontal: R;
   private readonly _vertical: R;
 
-  private constructor(horizontal: R, vertical: R) {
+  protected constructor(horizontal: R, vertical: R) {
     super("ellipse", Value.hasCalculation(horizontal, vertical));
     this._horizontal = horizontal;
     this._vertical = vertical;

--- a/packages/alfa-css/src/value/image/gradient/radial/extent.ts
+++ b/packages/alfa-css/src/value/image/gradient/radial/extent.ts
@@ -27,7 +27,7 @@ export class Extent
   private readonly _shape: Extent.Shape;
   private readonly _size: Extent.Size;
 
-  private constructor(shape: Extent.Shape, size: Extent.Size) {
+  protected constructor(shape: Extent.Shape, size: Extent.Size) {
     super("extent", false);
     this._shape = shape;
     this._size = size;

--- a/packages/alfa-css/src/value/image/gradient/radial/radial.ts
+++ b/packages/alfa-css/src/value/image/gradient/radial/radial.ts
@@ -55,7 +55,7 @@ export class Radial<
   private readonly _items: Array<I>;
   private readonly _repeats: boolean;
 
-  private constructor(
+  protected constructor(
     shape: S,
     position: P,
     items: Array<I>,

--- a/packages/alfa-css/src/value/image/image.ts
+++ b/packages/alfa-css/src/value/image/image.ts
@@ -29,7 +29,7 @@ export class Image<I extends URL | Gradient = URL | Gradient>
 
   private readonly _image: I;
 
-  private constructor(image: I) {
+  protected constructor(image: I) {
     super("image", Value.hasCalculation(image));
     this._image = image;
   }

--- a/packages/alfa-css/src/value/numeric/angle-percentage.ts
+++ b/packages/alfa-css/src/value/numeric/angle-percentage.ts
@@ -44,7 +44,7 @@ export namespace AnglePercentage {
       return new Calculated(value);
     }
 
-    private constructor(math: Math<"angle-percentage">) {
+    protected constructor(math: Math<"angle-percentage">) {
       super(math, "angle-percentage");
     }
 

--- a/packages/alfa-css/src/value/numeric/angle.ts
+++ b/packages/alfa-css/src/value/numeric/angle.ts
@@ -47,7 +47,7 @@ export namespace Angle {
       return new Calculated(value);
     }
 
-    private constructor(value: Math<"angle">) {
+    protected constructor(value: Math<"angle">) {
       super(value, "angle");
     }
 
@@ -99,7 +99,7 @@ export namespace Angle {
       return new Fixed(value.value, value.unit);
     }
 
-    private constructor(value: number, unit: U) {
+    protected constructor(value: number, unit: U) {
       super(value, unit, "angle");
     }
 

--- a/packages/alfa-css/src/value/numeric/integer.ts
+++ b/packages/alfa-css/src/value/numeric/integer.ts
@@ -42,7 +42,7 @@ export namespace Integer {
       return new Calculated(value);
     }
 
-    private constructor(value: Calculation<"number">) {
+    protected constructor(value: Calculation<"number">) {
       super(value, "integer");
     }
 
@@ -101,7 +101,7 @@ export namespace Integer {
       );
     }
 
-    private constructor(value: number) {
+    protected constructor(value: number) {
       super(value, "integer");
     }
 

--- a/packages/alfa-css/src/value/numeric/length-percentage.ts
+++ b/packages/alfa-css/src/value/numeric/length-percentage.ts
@@ -54,7 +54,7 @@ export namespace LengthPercentage {
       return new Calculated(value);
     }
 
-    private constructor(math: Math<"length-percentage">) {
+    protected constructor(math: Math<"length-percentage">) {
       super(math, "length-percentage");
     }
 

--- a/packages/alfa-css/src/value/numeric/length.ts
+++ b/packages/alfa-css/src/value/numeric/length.ts
@@ -40,7 +40,7 @@ export namespace Length {
       return new Calculated(value);
     }
 
-    private constructor(math: Math<"length">) {
+    protected constructor(math: Math<"length">) {
       super(math, "length");
     }
 
@@ -89,7 +89,7 @@ export namespace Length {
       return new Fixed(value.value, value.unit);
     }
 
-    private constructor(value: number, unit: U) {
+    protected constructor(value: number, unit: U) {
       super(value, unit, "length");
     }
 

--- a/packages/alfa-css/src/value/numeric/number.ts
+++ b/packages/alfa-css/src/value/numeric/number.ts
@@ -40,7 +40,7 @@ export namespace Number {
       return new Calculated(value);
     }
 
-    private constructor(value: Math<"number">) {
+    protected constructor(value: Math<"number">) {
       super(value, "number");
     }
 
@@ -84,7 +84,7 @@ export namespace Number {
       return new Fixed(BaseNumber.isNumber(value) ? value.value : value);
     }
 
-    private constructor(value: number) {
+    protected constructor(value: number) {
       super(value, "number");
     }
 

--- a/packages/alfa-css/src/value/numeric/percentage.ts
+++ b/packages/alfa-css/src/value/numeric/percentage.ts
@@ -3,8 +3,7 @@ import { Selective } from "@siteimprove/alfa-selective";
 import type { Slice } from "@siteimprove/alfa-slice";
 
 import { type Expression, Math } from "../../calculation/index.js";
-import type {
-  Numeric as BaseNumeric} from "../../calculation/numeric/index.js";
+import type { Numeric as BaseNumeric } from "../../calculation/numeric/index.js";
 import {
   Angle as BaseAngle,
   Integer as BaseInteger,
@@ -77,7 +76,7 @@ export namespace Percentage {
       return new Calculated(value);
     }
 
-    private constructor(math: Math<"percentage">) {
+    protected constructor(math: Math<"percentage">) {
       super(math, "percentage");
     }
 
@@ -172,7 +171,7 @@ export namespace Percentage {
       );
     }
 
-    private constructor(value: number) {
+    protected constructor(value: number) {
       super(value, "percentage");
     }
 

--- a/packages/alfa-css/src/value/position/position.ts
+++ b/packages/alfa-css/src/value/position/position.ts
@@ -53,7 +53,7 @@ export class Position<
   private readonly _horizontal: HC;
   private readonly _vertical: VC;
 
-  private constructor(horizontal: HC, vertical: VC) {
+  protected constructor(horizontal: HC, vertical: VC) {
     super("position", Value.hasCalculation(horizontal, vertical));
     this._horizontal = horizontal;
     this._vertical = vertical;

--- a/packages/alfa-css/src/value/position/side.ts
+++ b/packages/alfa-css/src/value/position/side.ts
@@ -53,7 +53,7 @@ export class Side<
   private readonly _side: S;
   private readonly _offset: Option<O>;
 
-  private constructor(side: S, offset: Option<O>) {
+  protected constructor(side: S, offset: Option<O>) {
     super(
       "side",
       offset.some(Value.hasCalculation) as Value.HasCalculation<[O]>,

--- a/packages/alfa-css/src/value/shadow.ts
+++ b/packages/alfa-css/src/value/shadow.ts
@@ -50,7 +50,7 @@ export class Shadow<
   private readonly _color: C;
   private readonly _isInset: boolean;
 
-  private constructor(
+  protected constructor(
     horizontal: H,
     vertical: V,
     blur: B,

--- a/packages/alfa-css/src/value/shape/circle.ts
+++ b/packages/alfa-css/src/value/shape/circle.ts
@@ -38,7 +38,7 @@ export class Circle<R extends Radius = Radius, P extends Position = Position>
   private readonly _radius: R;
   private readonly _center: P;
 
-  private constructor(radius: R, center: P) {
+  protected constructor(radius: R, center: P) {
     super("circle", Value.hasCalculation(radius, center));
     this._radius = radius;
     this._center = center;

--- a/packages/alfa-css/src/value/shape/ellipse.ts
+++ b/packages/alfa-css/src/value/shape/ellipse.ts
@@ -40,7 +40,7 @@ export class Ellipse<R extends Radius = Radius, P extends Position = Position>
   private readonly _ry: R;
   private readonly _center: P;
 
-  private constructor(rx: R, ry: R, center: P) {
+  protected constructor(rx: R, ry: R, center: P) {
     super(
       "ellipse",
       // TS sees the first as Value.HasCalculation<[R, R, P]>

--- a/packages/alfa-css/src/value/shape/inset.ts
+++ b/packages/alfa-css/src/value/shape/inset.ts
@@ -48,7 +48,7 @@ export class Inset<
   private readonly _offsets: readonly [O, O, O, O];
   private readonly _corners: Option<readonly [C, C, C, C]>;
 
-  private constructor(
+  protected constructor(
     offsets: readonly [O, O, O, O],
     corners: Option<readonly [C, C, C, C]>,
   ) {

--- a/packages/alfa-css/src/value/shape/polygon.ts
+++ b/packages/alfa-css/src/value/shape/polygon.ts
@@ -45,7 +45,7 @@ export class Polygon<
   private readonly _fill: Option<F>;
   private readonly _vertices: Array<Polygon.Vertex<V>>;
 
-  private constructor(fill: Option<F>, vertices: Array<Polygon.Vertex<V>>) {
+  protected constructor(fill: Option<F>, vertices: Array<Polygon.Vertex<V>>) {
     super(
       "polygon",
       vertices.reduce(

--- a/packages/alfa-css/src/value/shape/radius.ts
+++ b/packages/alfa-css/src/value/shape/radius.ts
@@ -34,7 +34,7 @@ export class Radius<
 
   private readonly _value: R;
 
-  private constructor(value: R) {
+  protected constructor(value: R) {
     super("radius", Value.hasCalculation(value));
     this._value = value;
   }

--- a/packages/alfa-css/src/value/shape/rectangle.ts
+++ b/packages/alfa-css/src/value/shape/rectangle.ts
@@ -43,7 +43,7 @@ export class Rectangle<
   public readonly _bottom: O;
   public readonly _left: O;
 
-  private constructor(top: O, right: O, bottom: O, left: O) {
+  protected constructor(top: O, right: O, bottom: O, left: O) {
     super("rectangle", Value.hasCalculation(top, right, bottom, left));
     this._top = top;
     this._right = right;

--- a/packages/alfa-css/src/value/shape/shape.ts
+++ b/packages/alfa-css/src/value/shape/shape.ts
@@ -41,7 +41,7 @@ export class Shape<
   private readonly _shape: S;
   private readonly _box: B;
 
-  private constructor(shape: S, box: B) {
+  protected constructor(shape: S, box: B) {
     super("shape", Value.hasCalculation(shape));
     this._shape = shape;
     this._box = box;

--- a/packages/alfa-css/src/value/textual/custom-ident.ts
+++ b/packages/alfa-css/src/value/textual/custom-ident.ts
@@ -22,7 +22,7 @@ export class CustomIdent
     return new CustomIdent(value);
   }
 
-  private constructor(value: string) {
+  protected constructor(value: string) {
     super("custom-ident", value);
   }
 

--- a/packages/alfa-css/src/value/textual/keyword.ts
+++ b/packages/alfa-css/src/value/textual/keyword.ts
@@ -23,7 +23,7 @@ export class Keyword<T extends string = string>
     return new Keyword(value);
   }
 
-  private constructor(value: T) {
+  protected constructor(value: T) {
     super("keyword", value);
   }
 

--- a/packages/alfa-css/src/value/textual/string.ts
+++ b/packages/alfa-css/src/value/textual/string.ts
@@ -23,7 +23,7 @@ export class String
 
   private readonly _value: string;
 
-  private constructor(value: string) {
+  protected constructor(value: string) {
     super("string", false);
     this._value = value;
   }

--- a/packages/alfa-css/src/value/textual/url.ts
+++ b/packages/alfa-css/src/value/textual/url.ts
@@ -24,7 +24,7 @@ export class URL extends Value<"url", false> implements Resolvable<URL, never> {
 
   private readonly _url: string;
 
-  private constructor(url: string) {
+  protected constructor(url: string) {
     super("url", false);
     this._url = url;
   }

--- a/packages/alfa-css/src/value/transform/matrix.ts
+++ b/packages/alfa-css/src/value/transform/matrix.ts
@@ -28,7 +28,7 @@ export class Matrix
 
   private readonly _values: Matrix.Values<Number.Canonical>;
 
-  private constructor(values: Matrix.Values<Number.Canonical>) {
+  protected constructor(values: Matrix.Values<Number.Canonical>) {
     super("matrix", false);
     this._values = values;
   }

--- a/packages/alfa-css/src/value/transform/perspective.ts
+++ b/packages/alfa-css/src/value/transform/perspective.ts
@@ -24,7 +24,7 @@ export class Perspective<D extends Length = Length>
 
   private readonly _depth: D;
 
-  private constructor(depth: D) {
+  protected constructor(depth: D) {
     super("perspective", Value.hasCalculation(depth));
     this._depth = depth;
   }

--- a/packages/alfa-css/src/value/transform/rotate.ts
+++ b/packages/alfa-css/src/value/transform/rotate.ts
@@ -32,7 +32,7 @@ export class Rotate
   private readonly _z: Number.Canonical;
   private readonly _angle: Angle.Canonical;
 
-  private constructor(
+  protected constructor(
     x: Number.Canonical,
     y: Number.Canonical,
     z: Number.Canonical,

--- a/packages/alfa-css/src/value/transform/scale.ts
+++ b/packages/alfa-css/src/value/transform/scale.ts
@@ -74,7 +74,7 @@ export class Scale<
   private readonly _y: Y;
   private readonly _z: Option<Z>;
 
-  private constructor(x: X, y: Y, z?: Z) {
+  protected constructor(x: X, y: Y, z?: Z) {
     super("scale", false);
     this._x = x;
     this._y = y;

--- a/packages/alfa-css/src/value/transform/skew.ts
+++ b/packages/alfa-css/src/value/transform/skew.ts
@@ -25,7 +25,7 @@ export class Skew
   private readonly _x: Angle.Canonical;
   private readonly _y: Angle.Canonical;
 
-  private constructor(x: Angle.Canonical, y: Angle.Canonical) {
+  protected constructor(x: Angle.Canonical, y: Angle.Canonical) {
     super("skew", false);
     this._x = x;
     this._y = y;

--- a/packages/alfa-css/src/value/transform/translate.ts
+++ b/packages/alfa-css/src/value/transform/translate.ts
@@ -41,7 +41,7 @@ export class Translate<
   private readonly _y: Y;
   private readonly _z: Z;
 
-  private constructor(x: X, y: Y, z: Z) {
+  protected constructor(x: X, y: Y, z: Z) {
     super("translate", Value.hasCalculation(x, y, z));
     this._x = x;
     this._y = y;

--- a/packages/alfa-device/src/device.ts
+++ b/packages/alfa-device/src/device.ts
@@ -47,7 +47,7 @@ export class Device implements Equatable, Hashable, Serializable {
   private readonly _scripting: Scripting;
   private readonly _preferences: Map<Preference.Name, Preference>;
 
-  private constructor(
+  protected constructor(
     type: Device.Type,
     viewport: Viewport,
     display: Display,

--- a/packages/alfa-device/src/display.ts
+++ b/packages/alfa-device/src/display.ts
@@ -18,7 +18,7 @@ export class Display implements Equatable, Hashable, Serializable {
   private readonly _resolution: number;
   private readonly _scan: Display.Scan;
 
-  private constructor(resolution: number, scan: Display.Scan) {
+  protected constructor(resolution: number, scan: Display.Scan) {
     this._resolution = resolution;
     this._scan = scan;
   }

--- a/packages/alfa-device/src/preference.ts
+++ b/packages/alfa-device/src/preference.ts
@@ -22,7 +22,7 @@ export class Preference<N extends Preference.Name = Preference.Name>
   private readonly _name: N;
   private readonly _value: Preference.Value<N>;
 
-  private constructor(name: N, value: Preference.Value<N>) {
+  protected constructor(name: N, value: Preference.Value<N>) {
     this._name = name;
     this._value = value;
   }

--- a/packages/alfa-device/src/scripting.ts
+++ b/packages/alfa-device/src/scripting.ts
@@ -22,7 +22,7 @@ export class Scripting implements Equatable, Hashable, Serializable {
 
   private readonly _enabled: boolean;
 
-  private constructor(enabled: boolean) {
+  protected constructor(enabled: boolean) {
     this._enabled = enabled;
   }
 

--- a/packages/alfa-device/src/viewport.ts
+++ b/packages/alfa-device/src/viewport.ts
@@ -20,7 +20,7 @@ export class Viewport implements Equatable, Hashable, Serializable {
   private readonly _height: number;
   private readonly _orientation: Viewport.Orientation;
 
-  private constructor(
+  protected constructor(
     width: number,
     height: number,
     orientation: Viewport.Orientation,

--- a/packages/alfa-dom/src/node/attribute.ts
+++ b/packages/alfa-dom/src/node/attribute.ts
@@ -46,7 +46,7 @@ export class Attribute<N extends string = string> extends Node<"attribute"> {
   private readonly _value: string;
   private _owner: Option<Element> = None;
 
-  private constructor(
+  protected constructor(
     namespace: Option<Namespace>,
     prefix: Option<string>,
     name: N,

--- a/packages/alfa-dom/src/node/comment.ts
+++ b/packages/alfa-dom/src/node/comment.ts
@@ -23,7 +23,7 @@ export class Comment extends Node<"comment"> {
 
   private readonly _data: string;
 
-  private constructor(
+  protected constructor(
     data: string,
     externalId?: string,
     internalId?: string,

--- a/packages/alfa-dom/src/node/document.ts
+++ b/packages/alfa-dom/src/node/document.ts
@@ -38,7 +38,7 @@ export class Document extends Node<"document"> {
   private readonly _style: Array<Sheet>;
   private _frame: Option<Element> = None;
 
-  private constructor(
+  protected constructor(
     children: Array<Node>,
     style: Iterable<Sheet>,
     externalId?: string,

--- a/packages/alfa-dom/src/node/element.ts
+++ b/packages/alfa-dom/src/node/element.ts
@@ -74,7 +74,7 @@ export class Element<N extends string = string>
   private readonly _classes: Array<string>;
   private readonly _boxes: Cache<Device, Rectangle>;
 
-  private constructor(
+  protected constructor(
     namespace: Option<Namespace>,
     prefix: Option<string>,
     name: N,

--- a/packages/alfa-dom/src/node/fragment.ts
+++ b/packages/alfa-dom/src/node/fragment.ts
@@ -28,7 +28,7 @@ export class Fragment extends Node<"fragment"> {
     return new Fragment([]);
   }
 
-  private constructor(
+  protected constructor(
     children: Array<Node>,
     externalId?: string,
     internalId?: string,

--- a/packages/alfa-dom/src/node/shadow.ts
+++ b/packages/alfa-dom/src/node/shadow.ts
@@ -40,7 +40,7 @@ export class Shadow extends Node<"shadow"> {
   private _host: Option<Element> = None;
   private readonly _style: Array<Sheet>;
 
-  private constructor(
+  protected constructor(
     children: Array<Node>,
     style: Array<Sheet>,
     mode: Shadow.Mode,

--- a/packages/alfa-dom/src/node/text.ts
+++ b/packages/alfa-dom/src/node/text.ts
@@ -26,7 +26,7 @@ export class Text extends Node<"text"> implements Slotable {
 
   private readonly _data: string;
 
-  private constructor(
+  protected constructor(
     data: string,
     externalId?: string,
     internalId?: string,

--- a/packages/alfa-dom/src/node/type.ts
+++ b/packages/alfa-dom/src/node/type.ts
@@ -35,7 +35,7 @@ export class Type<N extends string = string> extends Node<"type"> {
   private readonly _publicId: Option<string>;
   private readonly _systemId: Option<string>;
 
-  private constructor(
+  protected constructor(
     name: N,
     publicId: Option<string>,
     systemId: Option<string>,

--- a/packages/alfa-dom/src/style/block.ts
+++ b/packages/alfa-dom/src/style/block.ts
@@ -17,7 +17,7 @@ export class Block implements Iterable<Declaration>, Equatable, Serializable {
 
   private _declarations: Array<Declaration>;
 
-  private constructor(declarations: Array<Declaration>) {
+  protected constructor(declarations: Array<Declaration>) {
     this._declarations = declarations;
   }
 

--- a/packages/alfa-dom/src/style/declaration.ts
+++ b/packages/alfa-dom/src/style/declaration.ts
@@ -40,7 +40,7 @@ export class Declaration implements Equatable, Serializable {
    */
   private _owner: Option<Element> = None;
 
-  private constructor(name: string, value: string, important: boolean) {
+  protected constructor(name: string, value: string, important: boolean) {
     this._name = name;
     this._value = value;
     this._important = important;

--- a/packages/alfa-dom/src/style/rule/font-face.ts
+++ b/packages/alfa-dom/src/style/rule/font-face.ts
@@ -15,7 +15,7 @@ export class FontFaceRule extends Rule<"font-face"> {
 
   private readonly _style: Block;
 
-  private constructor(declarations: Array<Declaration>) {
+  protected constructor(declarations: Array<Declaration>) {
     super("font-face");
 
     this._style = Block.of(

--- a/packages/alfa-dom/src/style/rule/import.ts
+++ b/packages/alfa-dom/src/style/rule/import.ts
@@ -36,7 +36,7 @@ export class ImportRule extends ConditionRule<"import"> {
   // CSSImportRule interface
   private _layer: Option<string>;
 
-  private constructor(
+  protected constructor(
     href: string,
     sheet: Sheet,
     mediaCondition: Option<string>,

--- a/packages/alfa-dom/src/style/rule/keyframe.ts
+++ b/packages/alfa-dom/src/style/rule/keyframe.ts
@@ -19,7 +19,7 @@ export class KeyframeRule extends Rule<"keyframe"> {
   private readonly _key: string;
   private readonly _style: Block;
 
-  private constructor(key: string, declarations: Array<Declaration>) {
+  protected constructor(key: string, declarations: Array<Declaration>) {
     super("keyframe");
 
     this._key = key;

--- a/packages/alfa-dom/src/style/rule/keyframes.ts
+++ b/packages/alfa-dom/src/style/rule/keyframes.ts
@@ -14,7 +14,7 @@ export class KeyframesRule extends GroupingRule<"keyframes"> {
 
   private readonly _name: string;
 
-  private constructor(name: string, rules: Array<Rule>) {
+  protected constructor(name: string, rules: Array<Rule>) {
     super("keyframes", rules);
 
     this._name = name;

--- a/packages/alfa-dom/src/style/rule/layer.ts
+++ b/packages/alfa-dom/src/style/rule/layer.ts
@@ -31,7 +31,7 @@ export namespace Layer {
 
     private readonly _layers: Array<string>;
 
-    private constructor(layers: Array<string>) {
+    protected constructor(layers: Array<string>) {
       super("layer-statement");
       this._layers = layers;
     }
@@ -82,7 +82,7 @@ export namespace Layer {
 
     private readonly _layer: Option<string>;
 
-    private constructor(layer: Option<string>, rules: Array<Rule>) {
+    protected constructor(layer: Option<string>, rules: Array<Rule>) {
       super("layer-block", rules);
       this._layer = layer;
     }

--- a/packages/alfa-dom/src/style/rule/media.ts
+++ b/packages/alfa-dom/src/style/rule/media.ts
@@ -19,7 +19,7 @@ export class MediaRule extends ConditionRule<"media"> {
 
   private readonly _queries: Feature.Media.List;
 
-  private constructor(condition: string, rules: Array<Rule>) {
+  protected constructor(condition: string, rules: Array<Rule>) {
     super("media", condition, rules);
 
     this._queries = Feature.parseMediaQuery(Lexer.lex(condition))

--- a/packages/alfa-dom/src/style/rule/namespace.ts
+++ b/packages/alfa-dom/src/style/rule/namespace.ts
@@ -14,7 +14,7 @@ export class NamespaceRule extends Rule<"namespace"> {
   private readonly _namespace: string;
   private readonly _prefix: Option<string>;
 
-  private constructor(namespace: string, prefix: Option<string>) {
+  protected constructor(namespace: string, prefix: Option<string>) {
     super("namespace");
 
     this._namespace = namespace;

--- a/packages/alfa-dom/src/style/rule/page.ts
+++ b/packages/alfa-dom/src/style/rule/page.ts
@@ -19,7 +19,7 @@ export class PageRule extends Rule<"page"> {
   private readonly _selector: string;
   private readonly _style: Block;
 
-  private constructor(selector: string, declarations: Array<Declaration>) {
+  protected constructor(selector: string, declarations: Array<Declaration>) {
     super("page");
 
     this._selector = selector;

--- a/packages/alfa-dom/src/style/rule/style.ts
+++ b/packages/alfa-dom/src/style/rule/style.ts
@@ -21,7 +21,7 @@ export class StyleRule extends Rule<"style"> {
   private readonly _style: Block;
   private readonly _hint: boolean;
 
-  private constructor(
+  protected constructor(
     selector: string,
     declarations: Array<Declaration>,
     hint: boolean,

--- a/packages/alfa-dom/src/style/rule/supports.ts
+++ b/packages/alfa-dom/src/style/rule/supports.ts
@@ -19,7 +19,7 @@ export class SupportsRule extends ConditionRule<"supports"> {
 
   private readonly _query: Option<Feature.Supports.Query>;
 
-  private constructor(condition: string, rules: Array<Rule>) {
+  protected constructor(condition: string, rules: Array<Rule>) {
     super("supports", condition, rules);
 
     this._query = Feature.parseSupportsQuery(Lexer.lex(condition))

--- a/packages/alfa-dom/src/style/sheet.ts
+++ b/packages/alfa-dom/src/style/sheet.ts
@@ -26,7 +26,7 @@ export class Sheet implements Equatable, Serializable {
   private readonly _disabled: boolean;
   private readonly _condition: Option<string>;
 
-  private constructor(
+  protected constructor(
     rules: Array<Rule>,
     disabled: boolean,
     condition: Option<string>,

--- a/packages/alfa-either/src/left.ts
+++ b/packages/alfa-either/src/left.ts
@@ -20,7 +20,7 @@ export class Left<L> implements Either<L, never> {
 
   private readonly _value: L;
 
-  private constructor(value: L) {
+  protected constructor(value: L) {
     this._value = value;
   }
 

--- a/packages/alfa-either/src/right.ts
+++ b/packages/alfa-either/src/right.ts
@@ -21,7 +21,7 @@ export class Right<R> implements Either<never, R> {
 
   private readonly _value: R;
 
-  private constructor(value: R) {
+  protected constructor(value: R) {
     this._value = value;
   }
 

--- a/packages/alfa-emitter/src/emitter.ts
+++ b/packages/alfa-emitter/src/emitter.ts
@@ -19,7 +19,7 @@ export class Emitter<T> implements Functor.Invariant<T>, AsyncIterable<T> {
    */
   private readonly _listeners: Map<Callback<never>, Callback<T>>;
 
-  private constructor(listeners: Map<Callback<never>, Callback<T>>) {
+  protected constructor(listeners: Map<Callback<never>, Callback<T>>) {
     this._listeners = listeners;
   }
 

--- a/packages/alfa-fnv/src/fnv.ts
+++ b/packages/alfa-fnv/src/fnv.ts
@@ -10,7 +10,7 @@ export class FNV extends Hash {
 
   private _hash = 2166136261;
 
-  private constructor() {
+  protected constructor() {
     super();
   }
 

--- a/packages/alfa-future/src/future.ts
+++ b/packages/alfa-future/src/future.ts
@@ -160,7 +160,7 @@ class Now<T> extends Future<T> {
 
   private readonly _value: T;
 
-  private constructor(value: T) {
+  protected constructor(value: T) {
     super();
     this._value = value;
   }
@@ -205,7 +205,7 @@ class Defer<T> extends Future<T> {
 
   private readonly _continuation: Continuation<T>;
 
-  private constructor(continuation: Continuation<T>) {
+  protected constructor(continuation: Continuation<T>) {
     super();
     this._continuation = continuation;
   }
@@ -251,7 +251,7 @@ namespace Defer {
     private readonly _continuation: Continuation<S>;
     private readonly _mapper: Mapper<S, Future<T>>;
 
-    private constructor(
+    protected constructor(
       continuation: Continuation<S>,
       mapper: Mapper<S, Future<T>>,
     ) {
@@ -303,7 +303,7 @@ class Suspend<T> extends Future<T> {
 
   private readonly _thunk: Thunk<Future<T>>;
 
-  private constructor(thunk: Thunk<Future<T>>) {
+  protected constructor(thunk: Thunk<Future<T>>) {
     super();
     this._thunk = thunk;
   }
@@ -341,7 +341,7 @@ namespace Suspend {
     private readonly _thunk: Thunk<Future<S>>;
     private readonly _mapper: Mapper<S, Future<T>>;
 
-    private constructor(thunk: Thunk<Future<S>>, mapper: Mapper<S, Future<T>>) {
+    protected constructor(thunk: Thunk<Future<S>>, mapper: Mapper<S, Future<T>>) {
       super();
       this._thunk = thunk;
       this._mapper = mapper;

--- a/packages/alfa-graph/src/graph.ts
+++ b/packages/alfa-graph/src/graph.ts
@@ -28,7 +28,7 @@ export class Graph<T>
 
   private readonly _nodes: Map<T, Set<T>>;
 
-  private constructor(nodes: Map<T, Set<T>>) {
+  protected constructor(nodes: Map<T, Set<T>>) {
     this._nodes = nodes;
   }
 

--- a/packages/alfa-http/src/cookie.ts
+++ b/packages/alfa-http/src/cookie.ts
@@ -14,7 +14,7 @@ export class Cookie implements Equatable, Serializable<Cookie.JSON> {
   private readonly _name: string;
   private readonly _value: string;
 
-  private constructor(name: string, value: string) {
+  protected constructor(name: string, value: string) {
     this._name = name;
     this._value = value;
   }

--- a/packages/alfa-http/src/cookies.ts
+++ b/packages/alfa-http/src/cookies.ts
@@ -28,7 +28,7 @@ export class Cookies implements Iterable<Cookie>, Serializable<Cookies.JSON> {
 
   private readonly _cookies: Map<string, Cookie>;
 
-  private constructor(cookies: Map<string, Cookie>) {
+  protected constructor(cookies: Map<string, Cookie>) {
     this._cookies = cookies;
   }
 

--- a/packages/alfa-http/src/header.ts
+++ b/packages/alfa-http/src/header.ts
@@ -19,7 +19,7 @@ export class Header
   private readonly _name: string;
   private readonly _value: string;
 
-  private constructor(name: string, value: string) {
+  protected constructor(name: string, value: string) {
     this._name = name;
     this._value = value;
   }

--- a/packages/alfa-http/src/headers.ts
+++ b/packages/alfa-http/src/headers.ts
@@ -35,7 +35,7 @@ export class Headers
 
   private readonly _headers: Map<string, Header>;
 
-  private constructor(headers: Map<string, Header>) {
+  protected constructor(headers: Map<string, Header>) {
     this._headers = headers;
   }
 

--- a/packages/alfa-http/src/request.ts
+++ b/packages/alfa-http/src/request.ts
@@ -39,7 +39,7 @@ export class Request
   private readonly _headers: Headers;
   private readonly _body: ArrayBuffer;
 
-  private constructor(
+  protected constructor(
     method: string,
     url: URL,
     headers: Headers,

--- a/packages/alfa-http/src/response.ts
+++ b/packages/alfa-http/src/response.ts
@@ -39,7 +39,7 @@ export class Response
   private readonly _headers: Headers;
   private readonly _body: ArrayBuffer;
 
-  private constructor(
+  protected constructor(
     url: URL,
     status: number,
     headers: Headers,

--- a/packages/alfa-iana/src/language.ts
+++ b/packages/alfa-iana/src/language.ts
@@ -177,7 +177,7 @@ export namespace Language {
       return new Primary(name);
     }
 
-    private constructor(name: Primary.Name) {
+    protected constructor(name: Primary.Name) {
       super(name);
     }
 
@@ -235,7 +235,7 @@ export namespace Language {
       return new Extended(name);
     }
 
-    private constructor(name: Extended.Name) {
+    protected constructor(name: Extended.Name) {
       super(name);
     }
 
@@ -293,7 +293,7 @@ export namespace Language {
       return new Script(name);
     }
 
-    private constructor(name: Script.Name) {
+    protected constructor(name: Script.Name) {
       super(name);
     }
 
@@ -341,7 +341,7 @@ export namespace Language {
       return new Region(name);
     }
 
-    private constructor(name: Region.Name) {
+    protected constructor(name: Region.Name) {
       super(name);
     }
 
@@ -389,7 +389,7 @@ export namespace Language {
       return new Variant(name);
     }
 
-    private constructor(name: Variant.Name) {
+    protected constructor(name: Variant.Name) {
       super(name);
     }
 

--- a/packages/alfa-lazy/src/lazy.ts
+++ b/packages/alfa-lazy/src/lazy.ts
@@ -29,7 +29,7 @@ export class Lazy<T>
 
   private _value: Trampoline<T>;
 
-  private constructor(value: Trampoline<T>) {
+  protected constructor(value: Trampoline<T>) {
     this._value = value;
   }
 

--- a/packages/alfa-list/src/list.ts
+++ b/packages/alfa-list/src/list.ts
@@ -44,7 +44,7 @@ export class List<T> implements Collection.Indexed<T> {
   private readonly _shift: number;
   private readonly _size: number;
 
-  private constructor(
+  protected constructor(
     head: Empty | Leaf<T> | Branch<T>,
     tail: Empty | Leaf<T>,
     shift: number,

--- a/packages/alfa-list/src/node.ts
+++ b/packages/alfa-list/src/node.ts
@@ -85,7 +85,7 @@ export class Leaf<T> implements Node<T> {
 
   private readonly _values: Array<T>;
 
-  private constructor(values: Array<T>) {
+  protected constructor(values: Array<T>) {
     this._values = values;
   }
 
@@ -158,7 +158,7 @@ export class Branch<T> implements Node<T> {
 
   private readonly _nodes: Array<Branch<T> | Leaf<T>>;
 
-  private constructor(nodes: Array<Branch<T> | Leaf<T>>) {
+  protected constructor(nodes: Array<Branch<T> | Leaf<T>>) {
     this._nodes = nodes;
   }
 

--- a/packages/alfa-map/src/map.ts
+++ b/packages/alfa-map/src/map.ts
@@ -36,7 +36,7 @@ export class Map<K, V> implements Collection.Keyed<K, V> {
   private readonly _root: Node<K, V>;
   private readonly _size: number;
 
-  private constructor(root: Node<K, V>, size: number) {
+  protected constructor(root: Node<K, V>, size: number) {
     this._root = root;
     this._size = size;
   }

--- a/packages/alfa-map/src/node.ts
+++ b/packages/alfa-map/src/node.ts
@@ -106,7 +106,7 @@ export class Leaf<K, V> implements Node<K, V> {
   private readonly _key: K;
   private readonly _value: V;
 
-  private constructor(hash: number, key: K, value: V) {
+  protected constructor(hash: number, key: K, value: V) {
     this._hash = hash;
     this._key = key;
     this._value = value;
@@ -197,7 +197,7 @@ export class Collision<K, V> implements Node<K, V> {
   private readonly _hash: number;
   private readonly _nodes: Array<Leaf<K, V>>;
 
-  private constructor(hash: number, nodes: Array<Leaf<K, V>>) {
+  protected constructor(hash: number, nodes: Array<Leaf<K, V>>) {
     this._hash = hash;
     this._nodes = nodes;
   }
@@ -314,7 +314,7 @@ export class Sparse<K, V> implements Node<K, V> {
   private readonly _mask: number;
   private readonly _nodes: Array<Node<K, V>>;
 
-  private constructor(mask: number, nodes: Array<Node<K, V>>) {
+  protected constructor(mask: number, nodes: Array<Node<K, V>>) {
     this._mask = mask;
     this._nodes = nodes;
   }

--- a/packages/alfa-map/src/status.ts
+++ b/packages/alfa-map/src/status.ts
@@ -30,7 +30,7 @@ export namespace Status {
       return new Created(result);
     }
 
-    private constructor(result: T) {
+    protected constructor(result: T) {
       super(result);
     }
 
@@ -46,7 +46,7 @@ export namespace Status {
       return new Updated(result);
     }
 
-    private constructor(result: T) {
+    protected constructor(result: T) {
       super(result);
     }
 
@@ -62,7 +62,7 @@ export namespace Status {
       return new Deleted(result);
     }
 
-    private constructor(result: T) {
+    protected constructor(result: T) {
       super(result);
     }
 
@@ -78,7 +78,7 @@ export namespace Status {
       return new Unchanged(result);
     }
 
-    private constructor(result: T) {
+    protected constructor(result: T) {
       super(result);
     }
 

--- a/packages/alfa-network/src/network.ts
+++ b/packages/alfa-network/src/network.ts
@@ -29,7 +29,7 @@ export class Network<N, E>
 
   private readonly _nodes: Map<N, Map<N, Set<E>>>;
 
-  private constructor(nodes: Map<N, Map<N, Set<E>>>) {
+  protected constructor(nodes: Map<N, Map<N, Set<E>>>) {
     this._nodes = nodes;
   }
 

--- a/packages/alfa-option/src/some.ts
+++ b/packages/alfa-option/src/some.ts
@@ -30,7 +30,7 @@ export class Some<T> implements Option<T> {
 
   private readonly _value: T;
 
-  private constructor(value: T) {
+  protected constructor(value: T) {
     this._value = value;
   }
 

--- a/packages/alfa-performance/src/performance.ts
+++ b/packages/alfa-performance/src/performance.ts
@@ -21,7 +21,7 @@ export class Performance<T>
   private readonly _epoch = now();
   private readonly _emitter = Emitter.of<Performance.Entry<T>>();
 
-  private constructor() {}
+  protected constructor() {}
 
   public get epoch(): number {
     return this._epoch;
@@ -131,7 +131,7 @@ export namespace Performance {
     private readonly _data: T;
     private readonly _start: number;
 
-    private constructor(data: T, start: number) {
+    protected constructor(data: T, start: number) {
       this._data = data;
       this._start = start;
     }
@@ -181,7 +181,7 @@ export namespace Performance {
     private readonly _start: number;
     private readonly _duration: number;
 
-    private constructor(data: T, start: number, duration: number) {
+    protected constructor(data: T, start: number, duration: number) {
       this._data = data;
       this._start = start;
       this._duration = duration;

--- a/packages/alfa-record/src/record.ts
+++ b/packages/alfa-record/src/record.ts
@@ -34,7 +34,7 @@ export class Record<T>
   private readonly _keys: ReadonlyArray<Record.Key<T>>;
   private readonly _values: List<Record.Value<T>>;
 
-  private constructor(
+  protected constructor(
     indices: ReadonlyMap<string, number>,
     keys: ReadonlyArray<Record.Key<T>>,
     values: List<T[Record.Key<T>]>,

--- a/packages/alfa-rectangle/src/rectangle.ts
+++ b/packages/alfa-rectangle/src/rectangle.ts
@@ -47,7 +47,7 @@ export class Rectangle
   private readonly _width: number;
   private readonly _height: number;
 
-  private constructor(x: number, y: number, width: number, height: number) {
+  protected constructor(x: number, y: number, width: number, height: number) {
     this._x = x;
     this._y = y;
     this._width = width;
@@ -204,29 +204,28 @@ export class Rectangle
    * where the circle center lies in one of the corners of the padded rectangle.
    *
    * @privateRemarks
-    * To check intersection, we pad the rectangle by the radius of the circle and divide the problem into three cases:
-    *
-    * 1. The circle center is outside the padded rectangle.
-    * 2. The circle center is inside the padded rectangle, but not in one of the corners.
-    * 3. The circle center lies in one of the corners of the padded rectangle in which case we need to compute the distance to the corner
-    *
-    *                 r
-    *              +-------+-------------------------+-------+
-    *              |       |                         |       |
-    *     1        |       |                         |       |
-    *              +-------+-------------------------+-------+
-    *              |       |                         |       |
-    *              |       |                         |       |
-    *              |       |                         |       |
-    *              |       |                         |       |
-    *              |       |                         |       |
-    *              +-------+-------------------------+-------+
-    *              |       |            2            |       |
-    *              | 3     |                         |       |
-    *              +-------+-------------------------+-------+
+   * To check intersection, we pad the rectangle by the radius of the circle and divide the problem into three cases:
+   *
+   * 1. The circle center is outside the padded rectangle.
+   * 2. The circle center is inside the padded rectangle, but not in one of the corners.
+   * 3. The circle center lies in one of the corners of the padded rectangle in which case we need to compute the distance to the corner
+   *
+   *                 r
+   *              +-------+-------------------------+-------+
+   *              |       |                         |       |
+   *     1        |       |                         |       |
+   *              +-------+-------------------------+-------+
+   *              |       |                         |       |
+   *              |       |                         |       |
+   *              |       |                         |       |
+   *              |       |                         |       |
+   *              |       |                         |       |
+   *              +-------+-------------------------+-------+
+   *              |       |            2            |       |
+   *              | 3     |                         |       |
+   *              +-------+-------------------------+-------+
    */
   public intersectsCircle(cx: number, cy: number, r: number): boolean {
-
     const center = this.center;
     const halfWidth = this.width / 2;
     const halfHeight = this.height / 2;

--- a/packages/alfa-result/src/err.ts
+++ b/packages/alfa-result/src/err.ts
@@ -24,7 +24,7 @@ export class Err<E> implements Result<never, E> {
 
   private readonly _error: E;
 
-  private constructor(error: E) {
+  protected constructor(error: E) {
     this._error = error;
   }
 

--- a/packages/alfa-result/src/ok.ts
+++ b/packages/alfa-result/src/ok.ts
@@ -25,7 +25,7 @@ export class Ok<T> implements Result<T, never> {
 
   private readonly _value: T;
 
-  private constructor(value: T) {
+  protected constructor(value: T) {
     this._value = value;
   }
 

--- a/packages/alfa-rules/src/common/act/group.ts
+++ b/packages/alfa-rules/src/common/act/group.ts
@@ -24,7 +24,7 @@ export class Group<T extends Hashable>
 
   private readonly _members: ReadonlyArray<T>;
 
-  private constructor(members: ReadonlyArray<T>) {
+  protected constructor(members: ReadonlyArray<T>) {
     this._members = members;
   }
 

--- a/packages/alfa-rules/src/common/diagnostic/contrast.ts
+++ b/packages/alfa-rules/src/common/diagnostic/contrast.ts
@@ -27,7 +27,7 @@ export class Contrast<N extends Name = Name> extends Diagnostic {
   private readonly _threshold: number;
   private readonly _pairings: Array<Contrast.Pairing<N>>;
 
-  private constructor(
+  protected constructor(
     message: string,
     threshold: number,
     pairings: Array<Contrast.Pairing<N>>,
@@ -113,7 +113,7 @@ export namespace Contrast {
     private readonly _color2: Color<SecondColor<N>>;
     private readonly _contrast: number;
 
-    private constructor(
+    protected constructor(
       color1: Color<FirstColor<N>>,
       color2: Color<SecondColor<N>>,
       contrast: number,
@@ -194,7 +194,7 @@ export namespace Contrast {
     private readonly _name: N;
     private readonly _value: RGB;
 
-    private constructor(name: N, value: RGB) {
+    protected constructor(name: N, value: RGB) {
       this._name = name;
       this._value = value;
     }

--- a/packages/alfa-rules/src/common/diagnostic/text-spacing.ts
+++ b/packages/alfa-rules/src/common/diagnostic/text-spacing.ts
@@ -56,7 +56,7 @@ export class TextSpacing<N extends Longhands.Name> extends Diagnostic {
   // The element with the bad style attribute
   private readonly _owner: Element;
 
-  private constructor(
+  protected constructor(
     message: string,
     property: N,
     value: Length.Canonical,

--- a/packages/alfa-rules/src/common/diagnostic/with-bad-elements.ts
+++ b/packages/alfa-rules/src/common/diagnostic/with-bad-elements.ts
@@ -17,7 +17,7 @@ export class WithBadElements extends Diagnostic implements Iterable<Element> {
 
   private readonly _errors: ReadonlyArray<Element>;
 
-  private constructor(message: string, errors: Array<Element>) {
+  protected constructor(message: string, errors: Array<Element>) {
     super(message);
     this._errors = errors;
   }

--- a/packages/alfa-rules/src/common/diagnostic/with-other-heading.ts
+++ b/packages/alfa-rules/src/common/diagnostic/with-other-heading.ts
@@ -48,7 +48,7 @@ export class WithOtherHeading extends Diagnostic {
   private readonly _otherLevel: number;
   private readonly _otherPosition: HeadingPosition;
 
-  private constructor(
+  protected constructor(
     message: string,
     otherHeading: Option<Element>,
     currentLevel: number,

--- a/packages/alfa-rules/src/common/dom/get-colors/color-error.ts
+++ b/packages/alfa-rules/src/common/dom/get-colors/color-error.ts
@@ -49,7 +49,7 @@ export class ColorErrors<
 
   private readonly _errors: ReadonlyArray<ColorError<T>>;
 
-  private constructor(message: string, errors: ReadonlyArray<ColorError<T>>) {
+  protected constructor(message: string, errors: ReadonlyArray<ColorError<T>>) {
     super(message);
     this._errors = errors;
   }
@@ -474,7 +474,7 @@ export namespace ColorError {
 
     private readonly _color: Color.Computed;
 
-    private constructor(
+    protected constructor(
       element: Element,
       value: Style.Computed<"background-image">,
       color: Color.Computed,
@@ -579,7 +579,7 @@ export namespace ColorError {
 
     private readonly _positionedDescendants: Sequence<Element>;
 
-    private constructor(
+    protected constructor(
       message: string,
       element: Element,
       positionedDescendants: Sequence<Element>,

--- a/packages/alfa-rules/src/common/dom/get-colors/get-layers.ts
+++ b/packages/alfa-rules/src/common/dom/get-colors/get-layers.ts
@@ -26,7 +26,7 @@ export class Layer {
   private readonly _colors: ReadonlyArray<Color.Resolved>;
   private readonly _opacity: number;
 
-  private constructor(colors: ReadonlyArray<Color.Resolved>, opacity: number) {
+  protected constructor(colors: ReadonlyArray<Color.Resolved>, opacity: number) {
     this._colors = colors;
     this._opacity = opacity;
   }

--- a/packages/alfa-rules/src/requirements/aria.ts
+++ b/packages/alfa-rules/src/requirements/aria.ts
@@ -8,7 +8,7 @@ export class ARIA extends Requirement<"ARIA"> {
     return new ARIA(uri);
   }
 
-  private constructor(uri: string) {
+  protected constructor(uri: string) {
     super("ARIA", uri);
   }
 

--- a/packages/alfa-rules/src/requirements/best-practice.ts
+++ b/packages/alfa-rules/src/requirements/best-practice.ts
@@ -8,7 +8,7 @@ export class BestPractice extends Requirement<"best practice"> {
     return new BestPractice(uri);
   }
 
-  private constructor(uri: string) {
+  protected constructor(uri: string) {
     super("best practice", uri);
   }
 

--- a/packages/alfa-rules/src/sia-r109/rule.ts
+++ b/packages/alfa-rules/src/sia-r109/rule.ts
@@ -115,7 +115,7 @@ export class Languages extends Diagnostic {
   private readonly _programmatic: Language;
   private readonly _natural: Option<Language>;
 
-  private constructor(
+  protected constructor(
     message: string,
     programmatic: Language,
     natural: Option<Language>,

--- a/packages/alfa-rules/src/sia-r14/rule.ts
+++ b/packages/alfa-rules/src/sia-r14/rule.ts
@@ -117,7 +117,7 @@ export class LabelAndName extends Diagnostic {
   private readonly _textContent: string;
   private readonly _name: string;
 
-  private constructor(message: string, textContent: string, name: string) {
+  protected constructor(message: string, textContent: string, name: string) {
     super(message);
     this._textContent = textContent;
     this._name = name;

--- a/packages/alfa-rules/src/sia-r16/rule.ts
+++ b/packages/alfa-rules/src/sia-r16/rule.ts
@@ -125,7 +125,7 @@ export class RoleAndRequiredAttributes extends Diagnostic {
   private readonly _requiredAttributes: ReadonlyArray<aria.Attribute.Name>;
   private readonly _missingAttributes: ReadonlyArray<aria.Attribute.Name>;
 
-  private constructor(
+  protected constructor(
     message: string,
     role: Role.Name,
     requiredAttributes: ReadonlyArray<aria.Attribute.Name>,

--- a/packages/alfa-rules/src/sia-r55/rule.ts
+++ b/packages/alfa-rules/src/sia-r55/rule.ts
@@ -156,7 +156,7 @@ export class WithRoleAndName extends WithRole {
 
   private readonly _name: string;
 
-  private constructor(message: string, role: Role.Name, name: string) {
+  protected constructor(message: string, role: Role.Name, name: string) {
     super(message, role);
     this._name = name;
   }

--- a/packages/alfa-rules/src/sia-r56/rule.ts
+++ b/packages/alfa-rules/src/sia-r56/rule.ts
@@ -114,7 +114,7 @@ export class SameNames extends Diagnostic implements Iterable<List<Element>> {
   private readonly _role: Role.Name;
   private readonly _errors: ReadonlyArray<List<Element>>;
 
-  private constructor(
+  protected constructor(
     message: string,
     role: Role.Name,
     errors: ReadonlyArray<List<Element>>,

--- a/packages/alfa-rules/src/sia-r61/rule.ts
+++ b/packages/alfa-rules/src/sia-r61/rule.ts
@@ -105,7 +105,7 @@ export class WithFirstHeading extends Diagnostic {
   private readonly _firstHeading: Element;
   private readonly _level: number;
 
-  private constructor(message: string, firstHeading: Element, level: number) {
+  protected constructor(message: string, firstHeading: Element, level: number) {
     super(message);
     this._firstHeading = firstHeading;
     this._level = level;

--- a/packages/alfa-rules/src/sia-r62/diagnostics.ts
+++ b/packages/alfa-rules/src/sia-r62/diagnostics.ts
@@ -44,7 +44,7 @@ export class ElementDistinguishable
     Contrast.Pairing<["container", "link"]>
   >;
 
-  private constructor(
+  protected constructor(
     distinguishingProperties: ReadonlyArray<ElementDistinguishable.Property>,
     style: Map<Name, string>,
     pairings: ReadonlyArray<Contrast.Pairing<["container", "link"]>>,
@@ -203,7 +203,7 @@ export class DistinguishingStyles extends Diagnostic {
   private readonly _hoverStyles: Sequence<Result<ElementDistinguishable>>;
   private readonly _focusStyles: Sequence<Result<ElementDistinguishable>>;
 
-  private constructor(
+  protected constructor(
     message: string,
     defaultStyles: Sequence<Result<ElementDistinguishable>>,
     hoverStyles: Sequence<Result<ElementDistinguishable>>,

--- a/packages/alfa-rules/src/sia-r65/diagnostics.ts
+++ b/packages/alfa-rules/src/sia-r65/diagnostics.ts
@@ -18,7 +18,7 @@ export class MatchingClasses extends Diagnostic {
   private readonly _matchingTargets: Map<string, number>;
   private readonly _matchingNonTargets: Map<string, number>;
 
-  private constructor(
+  protected constructor(
     message: string,
     matchingTargets: Map<string, number>,
     matchingNonTargets: Map<string, number>,

--- a/packages/alfa-rules/src/sia-r83/rule.ts
+++ b/packages/alfa-rules/src/sia-r83/rule.ts
@@ -632,7 +632,7 @@ export class ClippingAncestors extends Diagnostic {
   private readonly _horizontal: Option<Element>;
   private readonly _vertical: Option<Element>;
 
-  private constructor(
+  protected constructor(
     message: string,
     horizontal: Option<Element>,
     vertical: Option<Element>,

--- a/packages/alfa-rules/src/tags/scope.ts
+++ b/packages/alfa-rules/src/tags/scope.ts
@@ -10,7 +10,7 @@ export class Scope<S extends string = string> extends Tag<"scope"> {
 
   private readonly _scope: S;
 
-  private constructor(scope: S) {
+  protected constructor(scope: S) {
     super();
     this._scope = scope;
   }

--- a/packages/alfa-rules/src/tags/stability.ts
+++ b/packages/alfa-rules/src/tags/stability.ts
@@ -10,7 +10,7 @@ export class Stability<S extends string = string> extends Tag<"stability"> {
 
   private readonly _stability: S;
 
-  private constructor(stability: S) {
+  protected constructor(stability: S) {
     super();
     this._stability = stability;
   }

--- a/packages/alfa-rules/src/tags/version.ts
+++ b/packages/alfa-rules/src/tags/version.ts
@@ -10,7 +10,7 @@ export class Version<N extends number = number> extends Tag<"version"> {
 
   private readonly _version: N;
 
-  private constructor(version: N) {
+  protected constructor(version: N) {
     super();
     this._version = version;
   }

--- a/packages/alfa-selective/src/selective.ts
+++ b/packages/alfa-selective/src/selective.ts
@@ -1,6 +1,6 @@
 import type { Applicative } from "@siteimprove/alfa-applicative";
 import type { Callback } from "@siteimprove/alfa-callback";
-import type { Either} from "@siteimprove/alfa-either";
+import type { Either } from "@siteimprove/alfa-either";
 import { Left, Right } from "@siteimprove/alfa-either";
 import type { Equatable } from "@siteimprove/alfa-equatable";
 import type { Functor } from "@siteimprove/alfa-functor";
@@ -32,7 +32,7 @@ export class Selective<S, T = never>
 
   private readonly _value: Either<S, T>;
 
-  private constructor(value: Either<S, T>) {
+  protected constructor(value: Either<S, T>) {
     this._value = value;
   }
 

--- a/packages/alfa-selector/src/context.ts
+++ b/packages/alfa-selector/src/context.ts
@@ -17,7 +17,7 @@ export class Context {
 
   private readonly _state: Map<Element, Context.State>;
 
-  private constructor(state: Map<Element, Context.State>) {
+  protected constructor(state: Map<Element, Context.State>) {
     this._state = state;
   }
 

--- a/packages/alfa-selector/src/selector/complex.ts
+++ b/packages/alfa-selector/src/selector/complex.ts
@@ -42,7 +42,7 @@ export class Complex extends Selector<"complex"> {
   private readonly _right: Simple | Compound;
   protected readonly _key: Option<Id | Class | Type>;
 
-  private constructor(
+  protected constructor(
     combinator: Combinator,
     left: Simple | Compound | Complex,
     right: Simple | Compound,

--- a/packages/alfa-selector/src/selector/compound.ts
+++ b/packages/alfa-selector/src/selector/compound.ts
@@ -30,7 +30,7 @@ export class Compound extends Selector<"compound"> {
   private readonly _length: number;
   protected readonly _key: Option<Id | Class | Type>;
 
-  private constructor(selectors: Array<Simple>) {
+  protected constructor(selectors: Array<Simple>) {
     super(
       "compound",
       Specificity.sum(...selectors.map((selector) => selector.specificity)),

--- a/packages/alfa-selector/src/selector/list.ts
+++ b/packages/alfa-selector/src/selector/list.ts
@@ -34,7 +34,7 @@ export class List<T extends Item = Item> extends Selector<"list"> {
   private readonly _selectors: Array<T>;
   private readonly _length: number;
 
-  private constructor(selectors: Array<T>) {
+  protected constructor(selectors: Array<T>) {
     super(
       "list",
       Specificity.max(...selectors.map((selector) => selector.specificity)),

--- a/packages/alfa-selector/src/selector/relative.ts
+++ b/packages/alfa-selector/src/selector/relative.ts
@@ -20,7 +20,7 @@ export class Relative extends Selector<"relative"> {
   private readonly _combinator: Combinator;
   private readonly _selector: Simple | Compound | Complex;
 
-  private constructor(
+  protected constructor(
     combinator: Combinator,
     selector: Simple | Compound | Complex,
   ) {

--- a/packages/alfa-selector/src/selector/simple/attribute.ts
+++ b/packages/alfa-selector/src/selector/simple/attribute.ts
@@ -36,7 +36,7 @@ export class Attribute extends WithName<"attribute"> {
   private readonly _matcher: Option<Attribute.Matcher>;
   private readonly _modifier: Option<Attribute.Modifier>;
 
-  private constructor(
+  protected constructor(
     namespace: Option<string>,
     name: string,
     value: Option<string>,

--- a/packages/alfa-selector/src/selector/simple/class.ts
+++ b/packages/alfa-selector/src/selector/simple/class.ts
@@ -21,7 +21,7 @@ export class Class extends WithName<"class"> {
   }
 
   protected readonly _key: Option<Class>;
-  private constructor(name: string) {
+  protected constructor(name: string) {
     super("class", name, Specificity.of(0, 1, 0));
 
     this._key = Option.of(this);

--- a/packages/alfa-selector/src/selector/simple/id.ts
+++ b/packages/alfa-selector/src/selector/simple/id.ts
@@ -21,7 +21,7 @@ export class Id extends WithName<"id"> {
 
   protected readonly _key: Option<Id>;
 
-  private constructor(name: string) {
+  protected constructor(name: string) {
     super("id", name, Specificity.of(1, 0, 0));
 
     this._key = Option.of(this);

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/active.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/active.ts
@@ -12,7 +12,7 @@ export class Active extends PseudoClassSelector<"active"> {
     return new Active();
   }
 
-  private constructor() {
+  protected constructor() {
     super("active");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/any-link.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/any-link.ts
@@ -12,7 +12,7 @@ export class AnyLink extends PseudoClassSelector<"any-link"> {
     return new AnyLink();
   }
 
-  private constructor() {
+  protected constructor() {
     super("any-link");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/checked.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/checked.ts
@@ -14,7 +14,7 @@ export class Checked extends PseudoClassSelector<"checked"> {
     return new Checked();
   }
 
-  private constructor() {
+  protected constructor() {
     super("checked");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/disabled.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/disabled.ts
@@ -13,7 +13,7 @@ export class Disabled extends PseudoClassSelector<"disabled"> {
     return new Disabled();
   }
 
-  private constructor() {
+  protected constructor() {
     super("disabled");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/empty.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/empty.ts
@@ -9,7 +9,7 @@ export class Empty extends PseudoClassSelector<"empty"> {
     return new Empty();
   }
 
-  private constructor() {
+  protected constructor() {
     super("empty");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/enabled.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/enabled.ts
@@ -15,7 +15,7 @@ export class Enabled extends PseudoClassSelector<"enabled"> {
     return new Enabled();
   }
 
-  private constructor() {
+  protected constructor() {
     super("enabled");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/first-child.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/first-child.ts
@@ -12,7 +12,7 @@ export class FirstChild extends PseudoClassSelector<"first-child"> {
     return new FirstChild();
   }
 
-  private constructor() {
+  protected constructor() {
     super("first-child");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/first-of-type.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/first-of-type.ts
@@ -12,7 +12,7 @@ export class FirstOfType extends PseudoClassSelector<"first-of-type"> {
     return new FirstOfType();
   }
 
-  private constructor() {
+  protected constructor() {
     super("first-of-type");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/focus-visible.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/focus-visible.ts
@@ -12,7 +12,7 @@ export class FocusVisible extends PseudoClassSelector<"focus-visible"> {
     return new FocusVisible();
   }
 
-  private constructor() {
+  protected constructor() {
     super("focus-visible");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/focus-within.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/focus-within.ts
@@ -16,7 +16,7 @@ export class FocusWithin extends PseudoClassSelector<"focus-within"> {
     return new FocusWithin();
   }
 
-  private constructor() {
+  protected constructor() {
     super("focus-within");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/focus.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/focus.ts
@@ -12,7 +12,7 @@ export class Focus extends PseudoClassSelector<"focus"> {
     return new Focus();
   }
 
-  private constructor() {
+  protected constructor() {
     super("focus");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/has.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/has.ts
@@ -13,7 +13,7 @@ export class Has extends WithSelector<"has"> {
     return new Has(selector);
   }
 
-  private constructor(selector: Absolute) {
+  protected constructor(selector: Absolute) {
     super("has", selector, selector.specificity);
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/host-context.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/host-context.ts
@@ -28,7 +28,7 @@ export class HostContext extends WithSelector<
     return new HostContext(selector);
   }
 
-  private constructor(selector: Compound | Simple) {
+  protected constructor(selector: Compound | Simple) {
     super(
       "host-context",
       selector,

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/host.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/host.ts
@@ -40,7 +40,7 @@ export class Host extends PseudoClassSelector<"host"> {
 
   private readonly _selector: Option<Compound | Simple>;
 
-  private constructor(selector: Option<Compound | Simple>) {
+  protected constructor(selector: Option<Compound | Simple>) {
     super(
       "host",
       Specificity.sum(

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/hover.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/hover.ts
@@ -16,7 +16,7 @@ export class Hover extends PseudoClassSelector<"hover"> {
     return new Hover();
   }
 
-  private constructor() {
+  protected constructor() {
     super("hover");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/is.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/is.ts
@@ -15,7 +15,7 @@ export class Is extends WithSelector<"is"> {
     return new Is(selector);
   }
 
-  private constructor(selector: Absolute) {
+  protected constructor(selector: Absolute) {
     super("is", selector, selector.specificity);
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/last-child.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/last-child.ts
@@ -12,7 +12,7 @@ export class LastChild extends PseudoClassSelector<"last-child"> {
     return new LastChild();
   }
 
-  private constructor() {
+  protected constructor() {
     super("last-child");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/last-of-type.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/last-of-type.ts
@@ -12,7 +12,7 @@ export class LastOfType extends PseudoClassSelector<"last-of-type"> {
     return new LastOfType();
   }
 
-  private constructor() {
+  protected constructor() {
     super("last-of-type");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/link.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/link.ts
@@ -13,7 +13,7 @@ export class Link extends PseudoClassSelector<"link"> {
     return new Link();
   }
 
-  private constructor() {
+  protected constructor() {
     super("link");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/not.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/not.ts
@@ -15,7 +15,7 @@ export class Not extends WithSelector<"not"> {
     return new Not(selector);
   }
 
-  private constructor(selector: Absolute) {
+  protected constructor(selector: Absolute) {
     super("not", selector, selector.specificity);
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/nth-child.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/nth-child.ts
@@ -23,7 +23,7 @@ export class NthChild extends WithIndexAndSelector<"nth-child"> {
 
   private readonly _indices = new WeakMap<Element, number>();
 
-  private constructor(index: Nth, selector: Option<Absolute>) {
+  protected constructor(index: Nth, selector: Option<Absolute>) {
     super("nth-child", index, selector);
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/nth-last-child.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/nth-last-child.ts
@@ -23,7 +23,7 @@ export class NthLastChild extends WithIndexAndSelector<"nth-last-child"> {
 
   private readonly _indices = new WeakMap<Element, number>();
 
-  private constructor(nth: Nth, selector: Option<Absolute>) {
+  protected constructor(nth: Nth, selector: Option<Absolute>) {
     super("nth-last-child", nth, selector);
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/nth-last-of-type.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/nth-last-of-type.ts
@@ -13,7 +13,7 @@ export class NthLastOfType extends WithIndex<"nth-last-of-type"> {
     return new NthLastOfType(index);
   }
 
-  private constructor(index: Nth) {
+  protected constructor(index: Nth) {
     super("nth-last-of-type", index);
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/nth-of-type.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/nth-of-type.ts
@@ -13,7 +13,7 @@ export class NthOfType extends WithIndex<"nth-of-type"> {
     return new NthOfType(index);
   }
 
-  private constructor(index: Nth) {
+  protected constructor(index: Nth) {
     super("nth-of-type", index);
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/only-child.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/only-child.ts
@@ -12,7 +12,7 @@ export class OnlyChild extends PseudoClassSelector<"only-child"> {
     return new OnlyChild();
   }
 
-  private constructor() {
+  protected constructor() {
     super("only-child");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/only-of-type.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/only-of-type.ts
@@ -12,7 +12,7 @@ export class OnlyOfType extends PseudoClassSelector<"only-of-type"> {
     return new OnlyOfType();
   }
 
-  private constructor() {
+  protected constructor() {
     super("only-of-type");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/root.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/root.ts
@@ -14,7 +14,7 @@ export class Root extends PseudoClassSelector<"root"> {
     return new Root();
   }
 
-  private constructor() {
+  protected constructor() {
     super("root");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/visited.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/visited.ts
@@ -13,7 +13,7 @@ export class Visited extends PseudoClassSelector<"visited"> {
     return new Visited();
   }
 
-  private constructor() {
+  protected constructor() {
     super("visited");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-class/where.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-class/where.ts
@@ -16,7 +16,7 @@ export class Where extends WithSelector<"where"> {
     return new Where(selector);
   }
 
-  private constructor(selector: Absolute) {
+  protected constructor(selector: Absolute) {
     super("where", selector, Specificity.of(0, 0, 0));
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-element/after.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-element/after.ts
@@ -7,7 +7,7 @@ export class After extends PseudoElementSelector<"after"> {
   public static of(): After {
     return new After();
   }
-  private constructor() {
+  protected constructor() {
     super("after");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-element/backdrop.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-element/backdrop.ts
@@ -8,7 +8,7 @@ export class Backdrop extends PseudoElementSelector<"backdrop"> {
     return new Backdrop();
   }
 
-  private constructor() {
+  protected constructor() {
     super("backdrop");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-element/before.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-element/before.ts
@@ -8,7 +8,7 @@ export class Before extends PseudoElementSelector<"before"> {
     return new Before();
   }
 
-  private constructor() {
+  protected constructor() {
     super("before");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-element/cue-region.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-element/cue-region.ts
@@ -23,7 +23,7 @@ export class CueRegion extends PseudoElementSelector<"cue-region"> {
 
   private readonly _selector: Option<Selector>;
 
-  private constructor(selector: Option<Selector>) {
+  protected constructor(selector: Option<Selector>) {
     super("cue-region");
     this._selector = selector;
   }

--- a/packages/alfa-selector/src/selector/simple/pseudo-element/cue.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-element/cue.ts
@@ -24,7 +24,7 @@ export class Cue extends PseudoElementSelector<"cue"> {
 
   private readonly _selector: Option<Selector>;
 
-  private constructor(selector: Option<Selector>) {
+  protected constructor(selector: Option<Selector>) {
     super("cue");
     this._selector = selector;
   }

--- a/packages/alfa-selector/src/selector/simple/pseudo-element/file-selector-button.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-element/file-selector-button.ts
@@ -8,7 +8,7 @@ export class FileSelectorButton extends PseudoElementSelector<"file-selector-but
     return new FileSelectorButton();
   }
 
-  private constructor() {
+  protected constructor() {
     super("file-selector-button");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-element/first-letter.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-element/first-letter.ts
@@ -8,7 +8,7 @@ export class FirstLetter extends PseudoElementSelector<"first-letter"> {
     return new FirstLetter();
   }
 
-  private constructor() {
+  protected constructor() {
     super("first-letter");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-element/first-line.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-element/first-line.ts
@@ -8,7 +8,7 @@ export class FirstLine extends PseudoElementSelector<"first-line"> {
     return new FirstLine();
   }
 
-  private constructor() {
+  protected constructor() {
     super("first-line");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-element/grammar-error.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-element/grammar-error.ts
@@ -8,7 +8,7 @@ export class GrammarError extends PseudoElementSelector<"grammar-error"> {
     return new GrammarError();
   }
 
-  private constructor() {
+  protected constructor() {
     super("grammar-error");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-element/marker.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-element/marker.ts
@@ -8,7 +8,7 @@ export class Marker extends PseudoElementSelector<"marker"> {
     return new Marker();
   }
 
-  private constructor() {
+  protected constructor() {
     super("marker");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-element/part.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-element/part.ts
@@ -16,7 +16,7 @@ export class Part extends PseudoElementSelector<"part"> {
 
   private readonly _idents: ReadonlyArray<Token.Ident>;
 
-  private constructor(idents: Array<Token.Ident>) {
+  protected constructor(idents: Array<Token.Ident>) {
     super("part");
     this._idents = idents;
   }

--- a/packages/alfa-selector/src/selector/simple/pseudo-element/placeholder.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-element/placeholder.ts
@@ -8,7 +8,7 @@ export class Placeholder extends PseudoElementSelector<"placeholder"> {
     return new Placeholder();
   }
 
-  private constructor() {
+  protected constructor() {
     super("placeholder");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-element/selection.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-element/selection.ts
@@ -8,7 +8,7 @@ export class Selection extends PseudoElementSelector<"selection"> {
     return new Selection();
   }
 
-  private constructor() {
+  protected constructor() {
     super("selection");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-element/slotted.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-element/slotted.ts
@@ -29,7 +29,7 @@ export class Slotted extends PseudoElementSelector<"slotted"> {
 
   private readonly _selector: Compound | Simple;
 
-  private constructor(selector: Compound | Simple) {
+  protected constructor(selector: Compound | Simple) {
     super(
       "slotted",
       Specificity.sum(selector.specificity, Specificity.of(0, 0, 1)),

--- a/packages/alfa-selector/src/selector/simple/pseudo-element/spelling-error.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-element/spelling-error.ts
@@ -8,7 +8,7 @@ export class SpellingError extends PseudoElementSelector<"spelling-error"> {
     return new SpellingError();
   }
 
-  private constructor() {
+  protected constructor() {
     super("spelling-error");
   }
 

--- a/packages/alfa-selector/src/selector/simple/pseudo-element/target-text.ts
+++ b/packages/alfa-selector/src/selector/simple/pseudo-element/target-text.ts
@@ -8,7 +8,7 @@ export class TargetText extends PseudoElementSelector<"target-text"> {
     return new TargetText();
   }
 
-  private constructor() {
+  protected constructor() {
     super("target-text");
   }
 

--- a/packages/alfa-selector/src/selector/simple/type.ts
+++ b/packages/alfa-selector/src/selector/simple/type.ts
@@ -23,7 +23,7 @@ export class Type extends WithName<"type"> {
   private readonly _namespace: Option<string>;
   protected readonly _key: Option<Type>;
 
-  private constructor(namespace: Option<string>, name: string) {
+  protected constructor(namespace: Option<string>, name: string) {
     super("type", name, Specificity.of(0, 0, 1));
     this._namespace = namespace;
 

--- a/packages/alfa-selector/src/selector/simple/universal.ts
+++ b/packages/alfa-selector/src/selector/simple/universal.ts
@@ -29,7 +29,7 @@ export class Universal extends Selector<"universal"> {
 
   private readonly _namespace: Option<string>;
 
-  private constructor(namespace: Option<string>) {
+  protected constructor(namespace: Option<string>) {
     super("universal", Specificity.empty());
     this._namespace = namespace;
   }

--- a/packages/alfa-selector/src/specificity.ts
+++ b/packages/alfa-selector/src/specificity.ts
@@ -46,7 +46,7 @@ export class Specificity
   private readonly _c: number;
   private readonly _value: number;
 
-  private constructor(a: number, b: number, c: number) {
+  protected constructor(a: number, b: number, c: number) {
     this._a = a;
     this._b = b;
     this._c = c;

--- a/packages/alfa-sequence/src/cons.ts
+++ b/packages/alfa-sequence/src/cons.ts
@@ -1,7 +1,11 @@
 import { Array } from "@siteimprove/alfa-array";
 import type { Callback } from "@siteimprove/alfa-callback";
 import type { Collection } from "@siteimprove/alfa-collection";
-import { Comparable, type Comparer, type Comparison } from "@siteimprove/alfa-comparable";
+import {
+  Comparable,
+  type Comparer,
+  type Comparison,
+} from "@siteimprove/alfa-comparable";
 import { Equatable } from "@siteimprove/alfa-equatable";
 import type { Hash } from "@siteimprove/alfa-hash";
 import { Iterable } from "@siteimprove/alfa-iterable";
@@ -35,7 +39,7 @@ export class Cons<T> implements Sequence<T> {
   private readonly _head: T;
   private readonly _tail: Lazy<Sequence<T>>;
 
-  private constructor(head: T, tail: Lazy<Sequence<T>>) {
+  protected constructor(head: T, tail: Lazy<Sequence<T>>) {
     this._head = head;
     this._tail = tail;
   }

--- a/packages/alfa-set/src/set.ts
+++ b/packages/alfa-set/src/set.ts
@@ -29,7 +29,7 @@ export class Set<T> implements Collection.Unkeyed<T> {
 
   private readonly _values: Map<T, T>;
 
-  private constructor(values: Map<T, T>) {
+  protected constructor(values: Map<T, T>) {
     this._values = values;
   }
 

--- a/packages/alfa-slice/src/slice.ts
+++ b/packages/alfa-slice/src/slice.ts
@@ -1,7 +1,11 @@
 import { Array } from "@siteimprove/alfa-array";
 import type { Callback } from "@siteimprove/alfa-callback";
 import type { Collection } from "@siteimprove/alfa-collection";
-import { Comparable, type Comparer, type Comparison } from "@siteimprove/alfa-comparable";
+import {
+  Comparable,
+  type Comparer,
+  type Comparison,
+} from "@siteimprove/alfa-comparable";
 import { Equatable } from "@siteimprove/alfa-equatable";
 import type { Hash } from "@siteimprove/alfa-hash";
 import { Iterable } from "@siteimprove/alfa-iterable";
@@ -39,7 +43,11 @@ export class Slice<T> implements Collection.Indexed<T> {
   private readonly _offset: number;
   private readonly _length: number;
 
-  private constructor(array: ReadonlyArray<T>, offset: number, length: number) {
+  protected constructor(
+    array: ReadonlyArray<T>,
+    offset: number,
+    length: number,
+  ) {
     this._array = array;
     this._offset = offset;
     this._length = length;

--- a/packages/alfa-style/src/longhand.ts
+++ b/packages/alfa-style/src/longhand.ts
@@ -67,7 +67,7 @@ export class Longhand<SPECIFIED = unknown, COMPUTED = SPECIFIED> {
     [style: Style]
   >;
 
-  private constructor(
+  protected constructor(
     initial: COMPUTED,
     parseBase: parser.Parser<Slice<Token>, SPECIFIED, string>,
     compute: Mapper<Value<SPECIFIED>, Value<COMPUTED>, [style: Style]>,

--- a/packages/alfa-style/src/shorthand.ts
+++ b/packages/alfa-style/src/shorthand.ts
@@ -30,7 +30,7 @@ export class Shorthand<N extends Name = never> {
   private readonly _properties: Array<N>;
   private readonly _parse: Shorthand.Parser<N>;
 
-  private constructor(properties: Array<N>, parse: Shorthand.Parser<N>) {
+  protected constructor(properties: Array<N>, parse: Shorthand.Parser<N>) {
     this._properties = properties;
     this._parse = parse;
   }

--- a/packages/alfa-style/src/style.ts
+++ b/packages/alfa-style/src/style.ts
@@ -205,7 +205,7 @@ export class Style implements Serializable<Style.JSON> {
   // from computed values.
   private _computed = Map.empty<Name, Value>();
 
-  private constructor(
+  protected constructor(
     owner: Option<Element>,
     device: Device,
     parent: Option<Style>,

--- a/packages/alfa-style/src/value.ts
+++ b/packages/alfa-style/src/value.ts
@@ -6,7 +6,7 @@ import type { Functor } from "@siteimprove/alfa-functor";
 import { Serializable } from "@siteimprove/alfa-json";
 import type { Mapper } from "@siteimprove/alfa-mapper";
 import type { Monad } from "@siteimprove/alfa-monad";
-import type { Option} from "@siteimprove/alfa-option";
+import type { Option } from "@siteimprove/alfa-option";
 import { None } from "@siteimprove/alfa-option";
 import type { Predicate } from "@siteimprove/alfa-predicate";
 
@@ -31,7 +31,7 @@ export class Value<T = unknown>
   private readonly _value: T;
   private readonly _source: Option<Declaration>;
 
-  private constructor(value: T, source: Option<Declaration>) {
+  protected constructor(value: T, source: Option<Declaration>) {
     this._value = value;
     this._source = source;
   }

--- a/packages/alfa-table/src/cell.ts
+++ b/packages/alfa-table/src/cell.ts
@@ -148,7 +148,7 @@ export namespace Cell {
       );
     }
 
-    private constructor(
+    protected constructor(
       element: Element,
       anchor: Slot,
       width: number,
@@ -219,7 +219,7 @@ export namespace Cell {
 
     private readonly _scope: Scope;
 
-    private constructor(
+    protected constructor(
       element: Element,
       anchor: Slot,
       width: number,

--- a/packages/alfa-table/src/column.ts
+++ b/packages/alfa-table/src/column.ts
@@ -20,7 +20,7 @@ export class Column implements Anchored, Equatable, Serializable<Column.JSON> {
 
   private readonly _x: number;
 
-  private constructor(x: number) {
+  protected constructor(x: number) {
     this._x = x;
   }
 
@@ -76,7 +76,7 @@ export namespace Column {
     private readonly _x: number;
     private readonly _width: number;
 
-    private constructor(element: Element, x: number, width: number) {
+    protected constructor(element: Element, x: number, width: number) {
       this._element = element;
       this._x = x;
       this._width = width;

--- a/packages/alfa-table/src/row.ts
+++ b/packages/alfa-table/src/row.ts
@@ -20,7 +20,7 @@ export class Row implements Anchored, Equatable, Serializable<Row.JSON> {
 
   private readonly _y: number;
 
-  private constructor(y: number) {
+  protected constructor(y: number) {
     this._y = y;
   }
 
@@ -76,7 +76,7 @@ export namespace Row {
     private readonly _y: number;
     private readonly _height: number;
 
-    private constructor(element: Element, y: number, height: number) {
+    protected constructor(element: Element, y: number, height: number) {
       this._element = element;
       this._y = y;
       this._height = height;

--- a/packages/alfa-table/src/slot.ts
+++ b/packages/alfa-table/src/slot.ts
@@ -1,4 +1,4 @@
-import type { Comparable} from "@siteimprove/alfa-comparable";
+import type { Comparable } from "@siteimprove/alfa-comparable";
 import { Comparison } from "@siteimprove/alfa-comparable";
 import type { Equatable } from "@siteimprove/alfa-equatable";
 import type { Serializable } from "@siteimprove/alfa-json";
@@ -20,7 +20,7 @@ export class Slot
   private readonly _x: number;
   private readonly _y: number;
 
-  private constructor(x: number, y: number) {
+  protected constructor(x: number, y: number) {
     this._x = x;
     this._y = y;
   }

--- a/packages/alfa-table/src/table.ts
+++ b/packages/alfa-table/src/table.ts
@@ -48,7 +48,7 @@ export class Table implements Equatable, Serializable<Table.JSON> {
   private readonly _cells: Array<Cell>;
   private readonly _groups: Array<Group>;
 
-  private constructor(
+  protected constructor(
     element: Element,
     cells: Array<Cell>,
     groups: Array<Group>,

--- a/packages/alfa-time/src/timeout.ts
+++ b/packages/alfa-time/src/timeout.ts
@@ -11,7 +11,7 @@ export class Timeout {
   private readonly _timeout: number;
   private readonly _time: Time;
 
-  private constructor(timeout: number, time: Time) {
+  protected constructor(timeout: number, time: Time) {
     this._timeout = timeout;
     this._time = time;
   }

--- a/packages/alfa-toolchain/src/dependency-graph/dependency-graph.ts
+++ b/packages/alfa-toolchain/src/dependency-graph/dependency-graph.ts
@@ -69,7 +69,7 @@ export class DependencyGraph {
   private readonly _edges: Array<[string, string]> = [];
   private readonly _clusters: Map<string, gv.Color>;
 
-  private constructor(
+  protected constructor(
     pkg: Package,
     fullDepTree: madge.MadgeInstance,
     noTypeDepTree: madge.MadgeInstance,

--- a/packages/alfa-trampoline/src/trampoline.ts
+++ b/packages/alfa-trampoline/src/trampoline.ts
@@ -127,7 +127,7 @@ class Done<T> extends Trampoline<T> {
 
   private readonly _value: T;
 
-  private constructor(value: T) {
+  protected constructor(value: T) {
     super();
     this._value = value;
   }
@@ -164,7 +164,7 @@ class Suspend<T> extends Trampoline<T> {
 
   private readonly _thunk: Thunk<Trampoline<T>>;
 
-  private constructor(thunk: Thunk<Trampoline<T>>) {
+  protected constructor(thunk: Thunk<Trampoline<T>>) {
     super();
     this._thunk = thunk;
   }
@@ -197,7 +197,7 @@ class Bind<S, T> extends Trampoline<T> {
   private readonly _thunk: Thunk<Trampoline<S>>;
   private readonly _mapper: Mapper<S, Trampoline<T>>;
 
-  private constructor(
+  protected constructor(
     thunk: Thunk<Trampoline<S>>,
     mapper: Mapper<S, Trampoline<T>>,
   ) {

--- a/packages/alfa-url/src/url.ts
+++ b/packages/alfa-url/src/url.ts
@@ -68,7 +68,7 @@ export class URL implements Equatable, Hashable, Serializable<URL.JSON> {
   private readonly _fragment: Option<string>;
   private readonly _cannotBeABase: boolean;
 
-  private constructor(
+  protected constructor(
     scheme: string,
     username: Option<string>,
     password: Option<string>,

--- a/packages/alfa-wcag/src/criterion.ts
+++ b/packages/alfa-wcag/src/criterion.ts
@@ -26,7 +26,7 @@ export class Criterion<
 
   private readonly _chapter: C;
 
-  private constructor(chapter: C, uri: U) {
+  protected constructor(chapter: C, uri: U) {
     super("criterion", uri);
     this._chapter = chapter;
   }

--- a/packages/alfa-wcag/src/technique.ts
+++ b/packages/alfa-wcag/src/technique.ts
@@ -15,7 +15,7 @@ export class Technique<
   private readonly _name: N;
   private readonly _title: Technique.Title<N>;
 
-  private constructor(name: N, uri: Technique.URI<N>) {
+  protected constructor(name: N, uri: Technique.URI<N>) {
     super("technique", uri);
     this._name = name;
     this._title = Techniques[name].title;

--- a/packages/alfa-web/src/page.ts
+++ b/packages/alfa-web/src/page.ts
@@ -38,7 +38,7 @@ export class Page
   private readonly _document: Document;
   private readonly _device: Device;
 
-  private constructor(
+  protected constructor(
     request: Request,
     response: Response,
     document: Document,

--- a/packages/alfa-web/src/site.ts
+++ b/packages/alfa-web/src/site.ts
@@ -18,7 +18,7 @@ export class Site<R extends Resource = Resource>
 
   private readonly _resources: Graph<R>;
 
-  private constructor(resources: Graph<R>) {
+  protected constructor(resources: Graph<R>) {
     this._resources = resources;
   }
 

--- a/packages/alfa-xpath/src/expression.ts
+++ b/packages/alfa-xpath/src/expression.ts
@@ -1,6 +1,6 @@
 import type { Equatable } from "@siteimprove/alfa-equatable";
 import type { Serializable } from "@siteimprove/alfa-json";
-import type { Option} from "@siteimprove/alfa-option";
+import type { Option } from "@siteimprove/alfa-option";
 import { None } from "@siteimprove/alfa-option";
 
 import type * as json from "@siteimprove/alfa-json";
@@ -51,7 +51,7 @@ export namespace Expression {
 
     private readonly _value: number;
 
-    private constructor(value: number) {
+    protected constructor(value: number) {
       this._value = value;
     }
 
@@ -94,7 +94,7 @@ export namespace Expression {
 
     private readonly _value: number;
 
-    private constructor(value: number) {
+    protected constructor(value: number) {
       this._value = value;
     }
 
@@ -137,7 +137,7 @@ export namespace Expression {
 
     private readonly _value: number;
 
-    private constructor(value: number) {
+    protected constructor(value: number) {
       this._value = value;
     }
 
@@ -180,7 +180,7 @@ export namespace Expression {
 
     private readonly _value: string;
 
-    private constructor(value: string) {
+    protected constructor(value: string) {
       this._value = value;
     }
 
@@ -224,7 +224,7 @@ export namespace Expression {
     private readonly _left: Expression;
     private readonly _right: Expression;
 
-    private constructor(left: Expression, right: Expression) {
+    protected constructor(left: Expression, right: Expression) {
       this._left = left;
       this._right = right;
     }
@@ -284,7 +284,7 @@ export namespace Expression {
     private readonly _test: Option<Test>;
     private readonly _predicates: Array<Expression>;
 
-    private constructor(
+    protected constructor(
       axis: Axis.Type,
       test: Option<Test>,
       predicates: Array<Expression>,
@@ -462,7 +462,7 @@ export namespace Expression {
 
       private readonly _name: Option<string>;
 
-      private constructor(name: Option<string>) {
+      protected constructor(name: Option<string>) {
         this._name = name;
       }
 
@@ -511,7 +511,7 @@ export namespace Expression {
 
       private readonly _name: Option<string>;
 
-      private constructor(name: Option<string>) {
+      protected constructor(name: Option<string>) {
         this._name = name;
       }
 
@@ -643,7 +643,7 @@ export namespace Expression {
       private readonly _prefix: Option<string>;
       private readonly _name: string;
 
-      private constructor(prefix: Option<string>, name: string) {
+      protected constructor(prefix: Option<string>, name: string) {
         this._prefix = prefix;
         this._name = name;
       }
@@ -701,7 +701,7 @@ export namespace Expression {
     private readonly _base: Expression;
     private readonly _predicates: Array<Expression>;
 
-    private constructor(base: Expression, predicates: Array<Expression>) {
+    protected constructor(base: Expression, predicates: Array<Expression>) {
       this._base = base;
       this._predicates = predicates;
     }
@@ -803,7 +803,7 @@ export namespace Expression {
     private readonly _arity: number;
     private readonly _parameters: Array<Expression>;
 
-    private constructor(
+    protected constructor(
       prefix: Option<string>,
       name: string,
       arity: number,

--- a/packages/alfa-xpath/src/syntax/token.ts
+++ b/packages/alfa-xpath/src/syntax/token.ts
@@ -59,7 +59,7 @@ export namespace Token {
 
     private readonly _value: number;
 
-    private constructor(value: number) {
+    protected constructor(value: number) {
       this._value = value;
     }
 
@@ -108,7 +108,7 @@ export namespace Token {
 
     private readonly _value: number;
 
-    private constructor(value: number) {
+    protected constructor(value: number) {
       this._value = value;
     }
 
@@ -157,7 +157,7 @@ export namespace Token {
 
     private readonly _value: number;
 
-    private constructor(value: number) {
+    protected constructor(value: number) {
       this._value = value;
     }
 
@@ -206,7 +206,7 @@ export namespace Token {
 
     private readonly _value: string;
 
-    private constructor(value: string) {
+    protected constructor(value: string) {
       this._value = value;
     }
 
@@ -255,7 +255,7 @@ export namespace Token {
 
     private readonly _value: string;
 
-    private constructor(value: string) {
+    protected constructor(value: string) {
       this._value = value;
     }
 
@@ -305,7 +305,7 @@ export namespace Token {
     private readonly _prefix: Option<string>;
     private readonly _value: string;
 
-    private constructor(prefix: Option<string>, value: string) {
+    protected constructor(prefix: Option<string>, value: string) {
       this._prefix = prefix;
       this._value = value;
     }
@@ -379,7 +379,7 @@ export namespace Token {
 
     private readonly _value: number;
 
-    private constructor(value: number) {
+    protected constructor(value: number) {
       this._value = value;
     }
 


### PR DESCRIPTION
Part of #1733

* Make constructors that are not part of a Singleton pattern `protected` instead of `private`. This let consumers extend the class if they want.
* Fix a missing singleton pattern.