### PR TITLE
Make packages type-only

### DIFF
--- a/.changeset/long-humans-jump.md
+++ b/.changeset/long-humans-jump.md
@@ -1,0 +1,10 @@
+---
+"@siteimprove/alfa-applicative": patch
+"@siteimprove/alfa-collection": patch
+"@siteimprove/alfa-foldable": patch
+"@siteimprove/alfa-functor": patch
+"@siteimprove/alfa-mapper": patch
+"@siteimprove/alfa-monad": patch
+---
+
+**Changed:** Packages that only export type now only pack their `.d.ts` files.

--- a/packages/alfa-applicative/package.json
+++ b/packages/alfa-applicative/package.json
@@ -15,10 +15,8 @@
     "node": ">=20.0.0"
   },
   "type": "module",
-  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/**/*.js",
     "dist/**/*.d.ts"
   ],
   "dependencies": {

--- a/packages/alfa-applicative/src/index.ts
+++ b/packages/alfa-applicative/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * This package provides types for modelling
+ * {@link https://en.wikipedia.org/wiki/Applicative_functor | applicative functors}.
+ *
+ * @packageDocumentation
+ */
+export type * from "./applicative.js";

--- a/packages/alfa-applicative/src/index.ts
+++ b/packages/alfa-applicative/src/index.ts
@@ -1,7 +1,0 @@
-/**
- * This package provides types for modelling
- * {@link https://en.wikipedia.org/wiki/Applicative_functor | applicative functors}.
- *
- * @packageDocumentation
- */
-export * from "./applicative.js";

--- a/packages/alfa-applicative/src/tsconfig.json
+++ b/packages/alfa-applicative/src/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "../tsconfig.json",
-  "compilerOptions": { "outDir": "../dist" },
+  "compilerOptions": { "outDir": "../dist", "emitDeclarationOnly": true },
   "files": ["./applicative.ts", "./index.ts"],
   "references": [
     { "path": "../../alfa-functor" },

--- a/packages/alfa-collection/package.json
+++ b/packages/alfa-collection/package.json
@@ -15,10 +15,8 @@
     "node": ">=20.0.0"
   },
   "type": "module",
-  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/**/*.js",
     "dist/**/*.d.ts"
   ],
   "dependencies": {

--- a/packages/alfa-collection/src/index.ts
+++ b/packages/alfa-collection/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./collection.js";
+export type * from "./collection.js";

--- a/packages/alfa-collection/src/tsconfig.json
+++ b/packages/alfa-collection/src/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "../tsconfig.json",
-  "compilerOptions": { "outDir": "../dist" },
+  "compilerOptions": { "outDir": "../dist", "emitDeclarationOnly": true },
   "files": ["./collection.ts", "./index.ts"],
   "references": [
     { "path": "../../alfa-applicative" },

--- a/packages/alfa-foldable/package.json
+++ b/packages/alfa-foldable/package.json
@@ -15,10 +15,8 @@
     "node": ">=20.0.0"
   },
   "type": "module",
-  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/**/*.js",
     "dist/**/*.d.ts"
   ],
   "dependencies": {

--- a/packages/alfa-foldable/src/index.ts
+++ b/packages/alfa-foldable/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./foldable.js";
+export type * from "./foldable.js";

--- a/packages/alfa-foldable/src/tsconfig.json
+++ b/packages/alfa-foldable/src/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "../tsconfig.json",
-  "compilerOptions": { "outDir": "../dist" },
+  "compilerOptions": { "outDir": "../dist", "emitDeclarationOnly": true },
   "files": ["./foldable.ts", "./index.ts"],
   "references": [{ "path": "../../alfa-reducer" }]
 }

--- a/packages/alfa-functor/package.json
+++ b/packages/alfa-functor/package.json
@@ -15,10 +15,8 @@
     "node": ">=20.0.0"
   },
   "type": "module",
-  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/**/*.js",
     "dist/**/*.d.ts"
   ],
   "dependencies": {

--- a/packages/alfa-functor/src/index.ts
+++ b/packages/alfa-functor/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./functor.js";
+export type * from "./functor.js";

--- a/packages/alfa-functor/src/tsconfig.json
+++ b/packages/alfa-functor/src/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "../tsconfig.json",
-  "compilerOptions": { "outDir": "../dist" },
+  "compilerOptions": { "outDir": "../dist", "emitDeclarationOnly": true },
   "files": ["./functor.ts", "./index.ts"],
   "references": [{ "path": "../../alfa-mapper" }]
 }

--- a/packages/alfa-mapper/package.json
+++ b/packages/alfa-mapper/package.json
@@ -15,10 +15,8 @@
     "node": ">=20.0.0"
   },
   "type": "module",
-  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/**/*.js",
     "dist/**/*.d.ts"
   ],
   "publishConfig": {

--- a/packages/alfa-mapper/src/index.ts
+++ b/packages/alfa-mapper/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./mapper.js";
+export type * from "./mapper.js";

--- a/packages/alfa-mapper/src/tsconfig.json
+++ b/packages/alfa-mapper/src/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "../tsconfig.json",
-  "compilerOptions": { "outDir": "../dist" },
+  "compilerOptions": { "outDir": "../dist", "emitDeclarationOnly": true },
   "files": ["./index.ts", "./mapper.ts"]
 }

--- a/packages/alfa-monad/package.json
+++ b/packages/alfa-monad/package.json
@@ -15,10 +15,8 @@
     "node": ">=20.0.0"
   },
   "type": "module",
-  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/**/*.js",
     "dist/**/*.d.ts"
   ],
   "dependencies": {

--- a/packages/alfa-monad/src/index.ts
+++ b/packages/alfa-monad/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./monad.js";
+export type * from "./monad.js";

--- a/packages/alfa-monad/src/tsconfig.json
+++ b/packages/alfa-monad/src/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "../tsconfig.json",
-  "compilerOptions": { "outDir": "../dist" },
+  "compilerOptions": { "outDir": "../dist", "emitDeclarationOnly": true },
   "files": ["./index.ts", "./monad.ts"],
   "references": [
     { "path": "../../alfa-applicative" },


### PR DESCRIPTION
Resolves #1732

The "missing" `main` in `package.json` is what DefiniteylTyped does ([example](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/package.json)), so it should be good enough.