### PR TITLE
Accept callbacks in `Result#*orElse` methods

### DIFF
--- a/.changeset/tiny-pianos-travel.md
+++ b/.changeset/tiny-pianos-travel.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-result": minor
+---
+
+**Added:** `Result#getOrElse` now accepts a `Callback(E, U)` (building the new value from the error); `Result#getErrOrElse` now accepts a `Callback(T, F)`.

--- a/docs/review/api/alfa-result.api.md
+++ b/docs/review/api/alfa-result.api.md
@@ -56,7 +56,7 @@ export class Err<E> implements Result<never, E> {
     // (undocumented)
     getOr<U>(value: U): U;
     // (undocumented)
-    getOrElse<U>(value: Thunk<U>): U;
+    getOrElse<U>(value: Callback<E, U>): U;
     // @internal (undocumented)
     getUnsafe(message?: string): never;
     // (undocumented)
@@ -154,7 +154,7 @@ export class Ok<T> implements Result<T, never> {
     // (undocumented)
     getErrOr<F>(error: F): F;
     // (undocumented)
-    getErrOrElse<F>(error: Thunk<F>): F;
+    getErrOrElse<F>(error: Callback<T, F>): F;
     // @internal (undocumented)
     getErrUnsafe(message?: string): never;
     // (undocumented)
@@ -253,13 +253,13 @@ export interface Result<T, E = T> extends Monad<T>, Foldable<T>, Iterable<T>, Eq
     // (undocumented)
     getErrOr<F>(error: F): E | F;
     // (undocumented)
-    getErrOrElse<F>(error: Thunk<F>): E | F;
+    getErrOrElse<F>(error: Callback<T, F>): E | F;
     // @internal
     getErrUnsafe(message?: string): E;
     // (undocumented)
     getOr<U>(value: U): T | U;
     // (undocumented)
-    getOrElse<U>(value: Thunk<U>): T | U;
+    getOrElse<U>(value: Callback<E, U>): T | U;
     // @internal
     getUnsafe(message?: string): T;
     // (undocumented)

--- a/packages/alfa-result/src/err.ts
+++ b/packages/alfa-result/src/err.ts
@@ -150,8 +150,8 @@ export class Err<E> implements Result<never, E> {
     return value;
   }
 
-  public getOrElse<U>(value: Thunk<U>): U {
-    return value();
+  public getOrElse<U>(value: Callback<E, U>): U {
+    return value(this._error);
   }
 
   public getErrOr(): E {

--- a/packages/alfa-result/src/ok.ts
+++ b/packages/alfa-result/src/ok.ts
@@ -159,8 +159,8 @@ export class Ok<T> implements Result<T, never> {
     return error;
   }
 
-  public getErrOrElse<F>(error: Thunk<F>): F {
-    return error();
+  public getErrOrElse<F>(error: Callback<T, F>): F {
+    return error(this._value);
   }
 
   public ok(): Option<T> {

--- a/packages/alfa-result/src/result.ts
+++ b/packages/alfa-result/src/result.ts
@@ -72,9 +72,9 @@ export interface Result<T, E = T>
    */
   getErrUnsafe(message?: string): E;
   getOr<U>(value: U): T | U;
-  getOrElse<U>(value: Thunk<U>): T | U;
+  getOrElse<U>(value: Callback<E, U>): T | U;
   getErrOr<F>(error: F): E | F;
-  getErrOrElse<F>(error: Thunk<F>): E | F;
+  getErrOrElse<F>(error: Callback<T, F>): E | F;
   ok(): Option<T>;
   err(): Option<E>;
   tee(callback: Callback<T>): Result<T, E>;

--- a/packages/alfa-result/test/result.spec.ts
+++ b/packages/alfa-result/test/result.spec.ts
@@ -51,3 +51,45 @@ test(".from() constructs a result from an async thunk that throws", async (t) =>
     error: "fail",
   });
 });
+
+test("#getOrElse() returns the ok value", (t) => {
+  t.deepEqual(
+    n.getOrElse(() => 2),
+    1,
+  );
+});
+
+test("#getOrElse() returns the thunk value on errors", (t) => {
+  t.deepEqual(
+    err.getOrElse(() => 2),
+    2,
+  );
+});
+
+test("#getOrElse() returns the callback value on errors", (t) => {
+  t.deepEqual(
+    err.getOrElse((msg) => msg.length),
+    5,
+  );
+});
+
+test("#getErrOrElse() returns the error value", (t) => {
+  t.deepEqual(
+    err.getErrOrElse(() => 2),
+    "error",
+  );
+});
+
+test("#getErrOrElse() returns the thunk value on oks", (t) => {
+  t.deepEqual(
+    n.getErrOrElse(() => 20),
+    20,
+  );
+});
+
+test("#getErrOrElse() returns the callback value on oks", (t) => {
+  t.deepEqual(
+    n.getErrOrElse((value) => value + 3),
+    4,
+  );
+});


### PR DESCRIPTION
Small improvement that would have helped for https://github.com/Siteimprove/alfa-integrations/pull/120/files#diff-4897711f57e3d63495da7d9ad4ad75a9613e906f4a6de9383fba63401d59bc8cR230-R235 
