### PR TITLE
Add defaults for `Text.of` optional parameters

### DIFF
--- a/.changeset/sour-balloons-sing.md
+++ b/.changeset/sour-balloons-sing.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-dom": patch
+---
+
+**Fixed:** Optional parameters `box` and `device` of `Text.of` now defaults to `None`.

--- a/docs/review/api/alfa-dom.api.md
+++ b/docs/review/api/alfa-dom.api.md
@@ -1416,7 +1416,7 @@ export class Text extends Node<"text"> implements Slotable {
     // @internal (undocumented)
     protected _internalPath(options?: Node.Traversal): string;
     // (undocumented)
-    static of(data: string, box: Option<Rectangle>, device: Option<Device>, externalId?: string, internalId?: string, extraData?: any): Text;
+    static of(data: string, box?: Option<Rectangle>, device?: Option<Device>, externalId?: string, internalId?: string, extraData?: any): Text;
     // (undocumented)
     toJSON(options: Node.SerializationOptions & {
         verbosity: json.Serializable.Verbosity.Minimal | json.Serializable.Verbosity.Low;

--- a/packages/alfa-dom/src/node/text.ts
+++ b/packages/alfa-dom/src/node/text.ts
@@ -16,8 +16,8 @@ import { Slotable } from "./slotable.js";
 export class Text extends Node<"text"> implements Slotable {
   public static of(
     data: string,
-    box: Option<Rectangle>,
-    device: Option<Device>,
+    box: Option<Rectangle> = None,
+    device: Option<Device> = None,
     externalId?: string,
     internalId?: string,
     extraData?: any,

--- a/packages/alfa-dom/test/node/text.spec.ts
+++ b/packages/alfa-dom/test/node/text.spec.ts
@@ -1,0 +1,32 @@
+import { test } from "@siteimprove/alfa-test";
+
+import { Device } from "@siteimprove/alfa-device";
+import { Option } from "@siteimprove/alfa-option";
+import { Rectangle } from "@siteimprove/alfa-rectangle";
+
+import { Text } from "../../dist/index.js";
+
+const device = Device.standard();
+
+test("#of() accepts optional box and device", (t) => {
+  t.deepEqual(
+    Text.of(
+      "foo",
+      Option.of(Rectangle.of(8, 8, 50, 50)),
+      Option.of(device),
+    ).toJSON({ device }),
+    {
+      type: "text",
+      data: "foo",
+      box: { type: "rectangle", x: 8, y: 8, width: 50, height: 50 },
+    },
+  );
+});
+
+test("#of() handles missing optional parameters", (t) => {
+  t.deepEqual(Text.of("foo").toJSON({ device }), {
+    type: "text",
+    data: "foo",
+    box: null,
+  });
+});

--- a/packages/alfa-dom/test/tsconfig.json
+++ b/packages/alfa-dom/test/tsconfig.json
@@ -13,6 +13,7 @@
     "./node.spec.tsx",
     "./node/attribute.spec.ts",
     "./node/element.spec.tsx",
+    "./node/text.spec.ts",
     "./node/predicate/has-tab-index.spec.tsx",
     "./node/traversal/get-nodes-between.spec.tsx",
     "./node/traversal/lowest-common-ancestor.spec.tsx",


### PR DESCRIPTION
The optional parameters `box` and `device` should have defaults.