### PR TITLE
Add support for "expected to fail" testing

### DIFF
--- a/.changeset/fair-masks-brake.md
+++ b/.changeset/fair-masks-brake.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-test": patch
+---
+
+**Added:** Support for "expected to fail" testing was added in the form of an `xfail` function.

--- a/packages/alfa-style/test/property/background-origin.spec.tsx
+++ b/packages/alfa-style/test/property/background-origin.spec.tsx
@@ -1,0 +1,72 @@
+import { h } from "@siteimprove/alfa-dom/h";
+import { xfail } from "@siteimprove/alfa-test";
+
+import { computed } from "../common.js";
+
+// https://github.com/Siteimprove/alfa/issues/1730
+xfail(
+  "#computed() repeats values to match number of layers determined by `background-image`",
+  (t) => {
+    t.deepEqual(
+      computed(
+        <div
+          style={{
+            backgroundImage: "url(flower.png), url(ball.png), url(grass.png)",
+            backgroundOrigin: "border-box, content-box",
+          }}
+        ></div>,
+        "background-origin",
+      ),
+      {
+        value: {
+          type: "list",
+          separator: ", ",
+          values: [
+            { type: "keyword", value: "border-box" },
+            { type: "keyword", value: "content-box" },
+            { type: "keyword", value: "border-box" },
+          ],
+        },
+        source: h
+          .declaration("background-origin", "border-box, content-box")
+          .toJSON(),
+      },
+    );
+  },
+);
+
+// https://github.com/Siteimprove/alfa/issues/1730
+xfail(
+  "#computed() discards excess values to match number of layers determined by `background-image`",
+  (t) => {
+    t.deepEqual(
+      computed(
+        <div
+          style={{
+            backgroundImage: "url(flower.png), url(ball.png), url(grass.png)",
+            backgroundOrigin:
+              "border-box, content-box, border-box, content-box",
+          }}
+        ></div>,
+        "background-origin",
+      ),
+      {
+        value: {
+          type: "list",
+          separator: ", ",
+          values: [
+            { type: "keyword", value: "border-box" },
+            { type: "keyword", value: "content-box" },
+            { type: "keyword", value: "border-box" },
+          ],
+        },
+        source: h
+          .declaration(
+            "background-origin",
+            "border-box, content-box, border-box, content-box",
+          )
+          .toJSON(),
+      },
+    );
+  },
+);

--- a/packages/alfa-style/test/tsconfig.json
+++ b/packages/alfa-style/test/tsconfig.json
@@ -19,6 +19,7 @@
     "./property/background.spec.tsx",
     "./property/background-color.spec.tsx",
     "./property/background-image.spec.tsx",
+    "./property/background-origin.spec.tsx",
     "./property/background-position.spec.tsx",
     "./property/background-size.spec.tsx",
     "./property/border.spec.tsx",

--- a/packages/alfa-test/src/test.ts
+++ b/packages/alfa-test/src/test.ts
@@ -6,6 +6,25 @@ import type { Assertions } from "./types.js";
 /**
  * @public
  */
+export interface Controller<T = number> {
+  rng: RNG<T>;
+  iterations: number;
+  // This interface should instead extend Vitest's TestOptions.
+  // However, doing so causes Vitest to be transitively included everywhere,
+  // thus triggering https://github.com/vitejs/vite/issues/9813
+  // Having one vitest.d.ts file in this package is OK, requiring one in every
+  // dependent is not.
+  // So, we just hardcode the property we need, until Vitest bug is fixed.
+  timeout?: number;
+}
+
+function defaultController(): Controller<number> {
+  return { rng: RNG.standard().create(), iterations: 1 };
+}
+
+/**
+ * @public
+ */
 export async function test<T = number>(
   name: string,
   assertion: (assert: Assertions, rng: RNG<T>) => void | Promise<void>,
@@ -29,20 +48,32 @@ export async function test<T = number>(
 }
 
 /**
- * @public
+ * @pulic
+ *
+ * A test that captures expected, but currently unimplemented or broken behavior.
+ * The idea is that, when a bug or missing feature is reported, an `xfail` can be
+ * written to reproduce the incorrect behavior, without failing the test suite.
+ * When the behavior is eventually implemented, the `xfail` will fail and it can
+ * then simply be converted to a real test. Preferably we would review `xfail`
+ * tests periodically and ensure that they converted to real tests.
+ *
+ * Inspired by pytest:
+ * {@link https://docs.pytest.org/en/stable/how-to/skipping.html#xfail-mark-test-functions-as-expected-to-fail}
  */
-export interface Controller<T = number> {
-  rng: RNG<T>;
-  iterations: number;
-  // This interface should instead extend Vitest's TestOptions.
-  // However, doing so causes Vitest to be transitively included everywhere,
-  // thus triggering https://github.com/vitejs/vite/issues/9813
-  // Having one vitest.d.ts file in this package is OK, requiring one in every
-  // dependent is not.
-  // So, we just hardcode the property we need, until Vitest bug is fixed.
-  timeout?: number;
-}
+export async function xfail(
+  name: string,
+  assertion: (assert: Assertions) => void | Promise<void>,
+): Promise<void> {
+  it(name, async () => {
+    try {
+      await assertion(assert);
+    } catch (e) {
+      // Test failed as expected.
+      return;
+    }
 
-function defaultController(): Controller<number> {
-  return { rng: RNG.standard().create(), iterations: 1 };
+    throw new Error(
+      "Test passed, but was expected to fail. Please convert it from an `xfail` to a proper `test`.",
+    );
+  });
 }


### PR DESCRIPTION
Proposal for adding a `xfail` testing function that succeeds on incorrect behavior and fails on correct behavior. The idea is to be able to document expected, but unimplemented behavior through tests without failing the test suite. Since the `xfail` and `test` functions have the same signatures an `xfail` can just be changed to a `test` when we are ready to implement the wanted behavior.