### PR TITLE
Setup dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,59 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "/"
+      - "/packages/alfa-*"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: monday
+      time: 01:00
+      timezone: Europe/Copenhagen
     labels:
       - "npm"
       - "dependencies"
-    # https://github.com/dependabot/dependabot-core/issues/1297
-    open-pull-requests-limit: 0
+    reviewers:
+      - "Siteimprove/alfa-owners"
+    groups:
+      production-patch:
+        # Patch updates to production packages. Low risk.
+        # This group could be auto-merge, this need a separate action. Maybe acting on a label that would be set here?
+        # We might want to run that for some time before actually enabling auto merging.
+        # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#automatically-approving-a-pull-request
+        dependency-type: production
+        applies-to: version-updates
+        update-types:
+          - "patch"
+        # TODO: consider adding custom commit-message.
+      development-minor-patch:
+        # Mino and Patch updates to development packages. Low risk.
+        # This group could be auto-merge, this need a separate action. Maybe acting on a label that would be set here?
+        # We might want to run that for some time before actually enabling auto merging.
+        # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#automatically-approving-a-pull-request
+        dependency-type: development
+        applies-to: version-updates-updates
+        update-types:
+          - "minor"
+          - "patch"
+        # TODO: consider adding custom commit-message.
+      security-update:
+        # Security updates (patch/minor), apply asap.
+        applies-to: security-updates
+        update-types:
+          - "minor"
+          - "patch"
+        schedule:
+          interval: daily
+      # Other dependencies will be in separate PRs (one for each) as we may need to look into them in more detail.
+
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: monday
+      time: 01:00
+      timezone: Europe/Copenhagen
     labels:
       - "actions"
       - "dependencies"


### PR DESCRIPTION
Switch to a working 🤞 dependabot config for all updates.
We should monitor this for some times, then if it works fine:
- [ ] Delete renovate.json, de-activate Renovate (and forking-renovate).
- [ ] Make similar changes to other Alfa repos.
- [ ] Delete `config/alfa-renovate.json` that is shared with the rest.

Note that other repos may have to use a `registries` key to find packages in the Github registry.
