### PR TITLE
Fix serialization of imported stylesheets

### DIFF
--- a/.changeset/few-taxis-thank.md
+++ b/.changeset/few-taxis-thank.md
@@ -2,4 +2,4 @@
 "@siteimprove/alfa-dom": patch
 ---
 
-**Fixed**: Imported style sheets are now serialized.
+**Fixed:** Imported style sheets are now serialized.

--- a/.changeset/few-taxis-thank.md
+++ b/.changeset/few-taxis-thank.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-dom": patch
+---
+
+**Fixed**: Imported style sheets are now serialized.

--- a/docs/review/api/alfa-dom.api.md
+++ b/docs/review/api/alfa-dom.api.md
@@ -549,7 +549,7 @@ export class ImportRule extends ConditionRule<"import"> {
     // (undocumented)
     static of(href: string, sheet: Sheet, mediaCondition?: Option<string>, supportCondition?: Option<string>, layer?: Option<string>): ImportRule;
     // (undocumented)
-    get rules(): Iterable<Rule>;
+    get rules(): Iterable_2<Rule>;
     // (undocumented)
     get sheet(): Sheet;
     // (undocumented)

--- a/packages/alfa-dom/src/style/rule/import.ts
+++ b/packages/alfa-dom/src/style/rule/import.ts
@@ -1,7 +1,8 @@
 import { Lexer } from "@siteimprove/alfa-css";
 import { Feature } from "@siteimprove/alfa-css-feature";
 import type { Device } from "@siteimprove/alfa-device";
-import { Option, None } from "@siteimprove/alfa-option";
+import { Iterable } from "@siteimprove/alfa-iterable";
+import { None, Option } from "@siteimprove/alfa-option";
 import { Predicate } from "@siteimprove/alfa-predicate";
 import { Trampoline } from "@siteimprove/alfa-trampoline";
 
@@ -108,6 +109,7 @@ export class ImportRule extends ConditionRule<"import"> {
       // We match the CSSImportRule interface returning null when no layer
       // is declared, and "" for an anonymous layer.
       layer: this._layer.getOr(null),
+      rules: Iterable.toJSON(this.rules),
     };
   }
 

--- a/packages/alfa-dom/test/style.spec.ts
+++ b/packages/alfa-dom/test/style.spec.ts
@@ -10,3 +10,37 @@ test("Sheet.of assigns owner to descendants of condition rules", (t) => {
 
   t.equal(rule.owner.getUnsafe(), sheet);
 });
+
+test("#toJSON serializes imported sheets", (t) => {
+  const importedSheet = h.sheet([
+    h.rule.style("p", { background: "aliceblue" }),
+  ]);
+  const sheet = h.sheet([h.rule.importRule("foo.css", importedSheet)]);
+
+  t.deepEqual(sheet.toJSON(), {
+    rules: [
+      {
+        type: "import",
+        condition: "all",
+        href: "foo.css",
+        layer: null,
+        rules: [
+          {
+            type: "style",
+            selector: "p",
+            style: [
+              {
+                important: false,
+                name: "background",
+                value: "aliceblue",
+              },
+            ],
+          },
+        ],
+        supportText: null,
+      },
+    ],
+    disabled: false,
+    condition: null,
+  });
+});


### PR DESCRIPTION
The `rules` property of `ImportRule` does not use the private field `_rules` which is left unset. Instead it calls to `_sheet.rules`. The parent class however serializes the `_rules` field which is then empty in the serialized output. To fix this, we override the serialization in `ImportRule` to use the public `rules` property to serialize `_sheet.rules`.