### PR TITLE
Fix duplicate Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directories:
-      - "/"
-      - "/packages/alfa-*"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -40,9 +38,7 @@ updates:
       # Other dependencies will be in separate PRs (one for each) as we may need to look into them in more detail.
 
   - package-ecosystem: "npm" # Security updates (patch/minor), apply asap.
-    directories:
-      - "/"
-      - "/packages/alfa-*"
+    directory: "/"
     target-branch: "main" #See https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219
     schedule:
       interval: "daily"


### PR DESCRIPTION
This is a follow up to https://github.com/Siteimprove/alfa/pull/1787.

Only the root directory should be specified for monorepos, otherwise Dependabot will create duplicate PRs and not update the yarn.lock in one of them, which is invalid. See https://github.com/dependabot/dependabot-core/issues/4993#issuecomment-1289133027
