### PR TITLE
Remove distinction between block and inline elements in painting order

### DIFF
--- a/.changeset/vast-owls-post.md
+++ b/.changeset/vast-owls-post.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-painting-order": patch
+---
+
+**Changed:** The painting order algorithm now doesn't distinguish between inline and block elements. This trades incorrect results for mixed inline and block parent-child elements with incorrect result for inline and block siblings.

--- a/packages/alfa-painting-order/test/painting-order.spec.tsx
+++ b/packages/alfa-painting-order/test/painting-order.spec.tsx
@@ -135,19 +135,6 @@ test("floating descendants are not painted atomically with respect to positioned
   testOrder(t, body, [body, div2, div1, div3]);
 });
 
-test("floating descendants are painted before inline-level descendants", (t) => {
-  const div1 = <div style={{ display: "inline" }}>Hello</div>;
-  const div2 = <div style={{ float: "left" }}>World</div>;
-  const body = (
-    <body>
-      {div1}
-      {div2}
-    </body>
-  );
-
-  testOrder(t, body, [body, div2, div1]);
-});
-
 test("inline-level descendants are painted in tree-order", (t) => {
   const span3 = <span>Hello</span>;
   const span2 = <span>World</span>;
@@ -250,20 +237,6 @@ test("positioned elements with positive z-index are painted in z-order then tree
   );
 
   testOrder(t, body, [body, div2, div3, div1]);
-});
-
-test("inline-level stacking context element is painted after floating descendants and before inline-level descendants", (t) => {
-  const div2 = <div style={{ float: "left" }}>Hello</div>;
-  const div3 = <div style={{ display: "inline" }}>World</div>;
-  const div1 = (
-    <div style={{ display: "inline", isolation: "isolate" }}>
-      {div2}
-      {div3}
-    </div>
-  );
-  const body = <body>{div1}</body>;
-
-  testOrder(t, body, [body, div2, div1, div3]);
 });
 
 test("stacking context creating elements are painted atomically", (t) => {

--- a/packages/alfa-painting-order/test/painting-order.spec.tsx
+++ b/packages/alfa-painting-order/test/painting-order.spec.tsx
@@ -336,3 +336,10 @@ test("invisible elements are not painted", (t) => {
 
   testOrder(t, body, [body]);
 });
+
+test("block-level element is painted after inline-level parent", (t) => {
+  const div = <div>Hello</div>;
+  const span = <span>{div}</span>;
+
+  testOrder(t, span, [span, div]);
+});


### PR DESCRIPTION
This replaces one incorrect implementation with another incorrect implementation. This will incorrectly order sibling inline and block elements, but correctly order inline parents and block children which is more likely to stack on top of each other, making it more important to get the order right in those cases.

Resolves https://siteimprove-wgs.atlassian.net/browse/II-9309
