### PR TITLE
Limit rectangle subtraction

### DIFF
--- a/.changeset/floppy-peaches-attack.md
+++ b/.changeset/floppy-peaches-attack.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-rectangle": patch
+---
+
+**Fixed:** `Rectangle#subtract` now limits the size of the result of subtracting.

--- a/packages/alfa-rectangle/package.json
+++ b/packages/alfa-rectangle/package.json
@@ -22,6 +22,7 @@
     "dist/**/*.d.ts"
   ],
   "dependencies": {
+    "@siteimprove/alfa-comparable": "workspace:^",
     "@siteimprove/alfa-equatable": "workspace:^",
     "@siteimprove/alfa-hash": "workspace:^",
     "@siteimprove/alfa-json": "workspace:^",

--- a/packages/alfa-rectangle/src/tsconfig.json
+++ b/packages/alfa-rectangle/src/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": { "outDir": "../dist" },
   "files": ["./index.ts", "./rectangle.ts"],
   "references": [
+    { "path": "../../alfa-comparable" },
     { "path": "../../alfa-equatable" },
     { "path": "../../alfa-hash" },
     { "path": "../../alfa-json" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1810,6 +1810,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@siteimprove/alfa-rectangle@workspace:packages/alfa-rectangle"
   dependencies:
+    "@siteimprove/alfa-comparable": "workspace:^"
     "@siteimprove/alfa-equatable": "workspace:^"
     "@siteimprove/alfa-fnv": "workspace:^"
     "@siteimprove/alfa-hash": "workspace:^"


### PR DESCRIPTION
Limits the size of the result of subtracting rectangles because the current way of representing the result can become too big to fit into an array.

Ideally, we should find a better way to represent the difference of rectangles that doesn't need to break the rectangles into many smaller rectangles. We could look into rectilinear polygons: https://en.wikipedia.org/wiki/Rectilinear_polygon.