### PR TITLE
Allow Dependabot to update CodeQL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,3 +63,6 @@ updates:
     labels:
       - "actions"
       - "dependencies"
+    allow:
+      # Allow updates for CodeQL Action
+      - dependency-name: "github/codeql-action/*"


### PR DESCRIPTION
Since CodeQL in in `github/*` and not `actions/*` it wasn't taken up by the dependabot config. This should fix it.
