### PR TITLE
Hardens actions against script injections

### DIFF
--- a/.github/actions/publish/action.yaml
+++ b/.github/actions/publish/action.yaml
@@ -71,7 +71,11 @@ runs:
     - name: Set token for npm publication (npm registry)
       if: inputs.npm-publish == 'true'
       shell: bash
-      run: npm config set //registry.npmjs.org/:_authToken=${{ inputs.npm-token }}
+      run: npm config set //registry.npmjs.org/:_authToken="${NPM_TOKEN}"
+      env:
+        # Passing it as a variable rather than inline hardens against script injection.
+        # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+        NPM_TOKEN: ${{ inputs.npm-token }}
     - name: Make npm release (npm Packages Registry)
       # Overwrite the registry with a CLI option, thus leaving the package.json files untouched.
       if: inputs.npm-publish == 'true'
@@ -84,10 +88,10 @@ runs:
     - name: Make Github release
       shell: bash
       run: >
-        gh release create ${VERSION}
+        gh release create "${VERSION}"
         --prerelease
         --verify-tag
-        --title ${VERSION}
+        --title "${VERSION}"
         --notes "[Changelog for this release](CHANGELOG.md)"
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -84,5 +84,10 @@ runs:
       # We need a user able to bypass branch protection (i.e. admin on the repo).
       run: |
         git config --local core.filemode false
-        git config --local user.name "${{ inputs.user-name }}"
-        git config --local user.email "${{ inputs.user-email }}"
+        git config --local user.name "${GIT_USER_NAME}"
+        git config --local user.email "${GIT_USER_EMAIL}"
+      env:
+      # Passing them as a variables rather than inline hardens against script injection.
+      # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+        GIT_USER_NAME: ${{ inputs.user-name }}
+        GIT_USER_EMAIL: ${{ inputs.user-email }}


### PR DESCRIPTION
Use intermediate shell variables to avoid inputs being expanded at workflow generation time and harden them against some script injection.