### PR TITLE
A11Y-11673: Ignore non-clickable composite containers in target size

### DIFF
--- a/.changeset/target-size-composite-containers.md
+++ b/.changeset/target-size-composite-containers.md
@@ -2,4 +2,4 @@
 "@siteimprove/alfa-rules": patch
 ---
 
-**Fixed:** Target size checks no longer report menu containers as pointer targets when their child menu items are the actual targets.
+**Fixed:** Target size checks (SIA-R111, SIA-R113) no longer report non-clickable composite widget containers as pointer targets when their child widgets are the actual targets.

--- a/.changeset/target-size-composite-containers.md
+++ b/.changeset/target-size-composite-containers.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-rules": patch
+---
+
+**Fixed:** Target size checks no longer report composite widget containers, such as menus, as pointer targets when their child widgets are the actual targets.

--- a/.changeset/target-size-composite-containers.md
+++ b/.changeset/target-size-composite-containers.md
@@ -2,4 +2,4 @@
 "@siteimprove/alfa-rules": patch
 ---
 
-**Fixed:** Target size checks no longer report composite widget containers, such as menus, as pointer targets when their child widgets are the actual targets.
+**Fixed:** Target size checks no longer report menu containers as pointer targets when their child menu items are the actual targets.

--- a/packages/alfa-rules/src/common/applicability/targets-of-pointer-events.ts
+++ b/packages/alfa-rules/src/common/applicability/targets-of-pointer-events.ts
@@ -103,12 +103,8 @@ export function isTarget(device: Device): Predicate<Element> {
     isFocusable(device),
     isVisible(device),
     not(isScrolledBehind(device)),
-    hasRole(device, hasTargetRole),
+    hasRole(device, isPointerTargetWidget),
   );
-}
-
-function hasTargetRole(role: Role): boolean {
-  return role.isWidget() && !isNonClickableCompositeContainer(role);
 }
 
 // These composite widgets normally delegate pointer actions to child widgets:
@@ -124,6 +120,11 @@ const isNonClickableCompositeContainer = Role.hasName(
   "tree",
   "grid",
   "treegrid",
+);
+
+const isPointerTargetWidget = and(
+  (role: Role) => role.isWidget(),
+  not(isNonClickableCompositeContainer),
 );
 
 function hasNonEmptyBoundingBox(device: Device): Predicate<Element> {

--- a/packages/alfa-rules/src/common/applicability/targets-of-pointer-events.ts
+++ b/packages/alfa-rules/src/common/applicability/targets-of-pointer-events.ts
@@ -108,13 +108,13 @@ export function isTarget(device: Device): Predicate<Element> {
 }
 
 function hasTargetRole(role: Role): boolean {
-  return role.isWidget() && !isCompositeContainer(role);
+  return role.isWidget() && !isMenuContainer(role);
 }
 
-function isCompositeContainer(role: Role): boolean {
-  // These roles organize child widgets; the children provide the pointer
+function isMenuContainer(role: Role): boolean {
+  // Menus organize child menu items; the child items provide the pointer
   // targets, not the container itself.
-  return role.is("select") || role.is("grid") || role.is("tablist");
+  return role.hasName("menu") || role.hasName("menubar");
 }
 
 function hasNonEmptyBoundingBox(device: Device): Predicate<Element> {

--- a/packages/alfa-rules/src/common/applicability/targets-of-pointer-events.ts
+++ b/packages/alfa-rules/src/common/applicability/targets-of-pointer-events.ts
@@ -1,4 +1,4 @@
-import { DOM } from "@siteimprove/alfa-aria";
+import { DOM, type Role } from "@siteimprove/alfa-aria";
 import { Cache } from "@siteimprove/alfa-cache";
 import type { Device } from "@siteimprove/alfa-device";
 import type { Document } from "@siteimprove/alfa-dom";
@@ -103,8 +103,18 @@ export function isTarget(device: Device): Predicate<Element> {
     isFocusable(device),
     isVisible(device),
     not(isScrolledBehind(device)),
-    hasRole(device, (role) => role.isWidget()),
+    hasRole(device, hasTargetRole),
   );
+}
+
+function hasTargetRole(role: Role): boolean {
+  return role.isWidget() && !isCompositeContainer(role);
+}
+
+function isCompositeContainer(role: Role): boolean {
+  // These roles organize child widgets; the children provide the pointer
+  // targets, not the container itself.
+  return role.is("select") || role.is("grid") || role.is("tablist");
 }
 
 function hasNonEmptyBoundingBox(device: Device): Predicate<Element> {

--- a/packages/alfa-rules/src/common/applicability/targets-of-pointer-events.ts
+++ b/packages/alfa-rules/src/common/applicability/targets-of-pointer-events.ts
@@ -1,4 +1,4 @@
-import { DOM, type Role } from "@siteimprove/alfa-aria";
+import { DOM, Role } from "@siteimprove/alfa-aria";
 import { Cache } from "@siteimprove/alfa-cache";
 import type { Device } from "@siteimprove/alfa-device";
 import type { Document } from "@siteimprove/alfa-dom";
@@ -108,14 +108,23 @@ export function isTarget(device: Device): Predicate<Element> {
 }
 
 function hasTargetRole(role: Role): boolean {
-  return role.isWidget() && !isMenuContainer(role);
+  return role.isWidget() && !isNonClickableCompositeContainer(role);
 }
 
-function isMenuContainer(role: Role): boolean {
-  // Menus organize child menu items; the child items provide the pointer
-  // targets, not the container itself.
-  return role.hasName("menu") || role.hasName("menubar");
-}
+// These composite widgets normally delegate pointer actions to child widgets:
+// menuitem*, tab, radio, option, treeitem, or cell/row descendants. Combobox
+// and spinbutton stay targetable because their containers are commonly the
+// pointer-actionable controls.
+const isNonClickableCompositeContainer = Role.hasName(
+  "menu",
+  "menubar",
+  "tablist",
+  "radiogroup",
+  "listbox",
+  "tree",
+  "grid",
+  "treegrid",
+);
 
 function hasNonEmptyBoundingBox(device: Device): Predicate<Element> {
   return function (element) {

--- a/packages/alfa-rules/test/sia-r113/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r113/rule.spec.tsx
@@ -4,6 +4,7 @@ import { test } from "@siteimprove/alfa-test";
 import { Device } from "@siteimprove/alfa-device";
 import { Rectangle } from "@siteimprove/alfa-rectangle";
 
+import { getApplicableTargets } from "../../src/common/applicability/targets-of-pointer-events.ts";
 import { TargetSize } from "../../src/common/outcome/target-size.ts";
 import R113 from "../../src/sia-r113/rule.ts";
 import { evaluate } from "../common/evaluate.ts";
@@ -653,6 +654,71 @@ test("evaluate() does not target exposed regions of menu containers", async (t) 
         item3.getBoundingBox(device).getUnsafe(),
       ),
     }),
+  ]);
+});
+
+test("getApplicableTargets() excludes non-clickable composite containers", (t) => {
+  const device = Device.standard();
+  const roles = [
+    "menu",
+    "menubar",
+    "tablist",
+    "radiogroup",
+    "listbox",
+    "tree",
+    "grid",
+    "treegrid",
+  ];
+
+  for (const [index, role] of roles.entries()) {
+    const target = (
+      <div
+        role={role}
+        tabindex="0"
+        box={{ device, x: 8, y: 8 + index * 40, width: 240, height: 32 }}
+      >
+        {role}
+      </div>
+    );
+
+    const document = h.document([target]);
+
+    t.deepEqual(getApplicableTargets(document, device).toArray(), []);
+  }
+});
+
+test("getApplicableTargets() keeps commonly clickable composite controls", (t) => {
+  const device = Device.standard();
+
+  const combobox = (
+    <div
+      role="combobox"
+      aria-expanded="false"
+      tabindex="0"
+      box={{ device, x: 8, y: 8, width: 240, height: 32 }}
+    >
+      Choose
+    </div>
+  );
+
+  const spinbutton = (
+    <div
+      role="spinbutton"
+      aria-valuemin="0"
+      aria-valuemax="10"
+      aria-valuenow="1"
+      tabindex="0"
+      box={{ device, x: 8, y: 48, width: 240, height: 32 }}
+    >
+      1
+    </div>
+  );
+
+  const document = h.document([combobox, spinbutton]);
+
+  t.deepEqual(getApplicableTargets(document, device).toArray(), [
+    combobox,
+    spinbutton,
   ]);
 });
 

--- a/packages/alfa-rules/test/sia-r113/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r113/rule.spec.tsx
@@ -575,7 +575,7 @@ test("evaluate() is inapplicable to <area> elements", async (t) => {
   t.deepEqual(await evaluate(R113, { document, device }), [inapplicable(R113)]);
 });
 
-test("evaluate() does not target exposed regions of composite menu containers", async (t) => {
+test("evaluate() does not target exposed regions of menu containers", async (t) => {
   const device = Device.standard();
 
   const item1 = (

--- a/packages/alfa-rules/test/sia-r113/rule.spec.tsx
+++ b/packages/alfa-rules/test/sia-r113/rule.spec.tsx
@@ -575,6 +575,87 @@ test("evaluate() is inapplicable to <area> elements", async (t) => {
   t.deepEqual(await evaluate(R113, { document, device }), [inapplicable(R113)]);
 });
 
+test("evaluate() does not target exposed regions of composite menu containers", async (t) => {
+  const device = Device.standard();
+
+  const item1 = (
+    <li
+      role="menuitem"
+      tabindex="0"
+      box={{ device, x: 8, y: 8, width: 240, height: 32 }}
+    >
+      Action Button
+    </li>
+  );
+
+  const item2 = (
+    <li
+      role="menuitem"
+      tabindex="-1"
+      box={{ device, x: 8, y: 40, width: 240, height: 32 }}
+    >
+      Action Link
+    </li>
+  );
+
+  const divider = (
+    <li
+      role="none"
+      aria-hidden="true"
+      tabindex="-1"
+      box={{ device, x: 8, y: 72, width: 240, height: 9 }}
+    >
+      <div box={{ device, x: 8, y: 76, width: 240, height: 1 }}></div>
+    </li>
+  );
+
+  const item3 = (
+    <li
+      role="menuitem"
+      tabindex="-1"
+      box={{ device, x: 8, y: 81, width: 240, height: 32 }}
+    >
+      Disabled Action Button
+    </li>
+  );
+
+  const menu = (
+    <ul
+      role="menu"
+      tabindex="-1"
+      box={{ device, x: 8, y: 8, width: 240, height: 105 }}
+    >
+      {item1}
+      {item2}
+      {divider}
+      {item3}
+    </ul>
+  );
+
+  const document = h.document([menu]);
+
+  t.deepEqual(await evaluate(R113, { document, device }), [
+    passed(R113, item1, {
+      1: TargetSize.HasSufficientSize(
+        "Action Button",
+        item1.getBoundingBox(device).getUnsafe(),
+      ),
+    }),
+    passed(R113, item2, {
+      1: TargetSize.HasSufficientSize(
+        "Action Link",
+        item2.getBoundingBox(device).getUnsafe(),
+      ),
+    }),
+    passed(R113, item3, {
+      1: TargetSize.HasSufficientSize(
+        "Disabled Action Button",
+        item3.getBoundingBox(device).getUnsafe(),
+      ),
+    }),
+  ]);
+});
+
 test("evaluate() is inapplicable to button with display: none", async (t) => {
   const device = Device.standard();
 


### PR DESCRIPTION
## Problem

Target size checks could report focusable composite widget containers, such as menus, when their child items were the actual pointer targets. This made exposed non-target regions like menu dividers appear as undersized targets.

## Solution

Exclude container-style composite widget roles from pointer target applicability while keeping their child widgets, such as menu items, covered by the rule.

## Related Jira

https://siteimprove-wgs.atlassian.net/browse/A11Y-11673

<img width="1717" height="999" alt="" src="https://github.com/user-attachments/assets/13bcfd08-b9d8-47c0-8657-03dfd226027e" />