### PR TITLE
Revert src-less images to a role of img

### DIFF
--- a/.changeset/shiny-turkeys-dance.md
+++ b/.changeset/shiny-turkeys-dance.md
@@ -2,8 +2,8 @@
 "@siteimprove/alfa-aria": minor
 ---
 
-**Changed:** `<img>` elements with no `src` attribute now maps to `img` role again.
+**Changed:** `<img>` elements with no `src` attribute now map to `img` role again.
 
-This effectively reverts #1273 which was based on a discussion that didn't make it to the spec, and thus Alfa follows current major browsers implementation. Moreover, the HTML specification mandates the presence of a `src` (or `srcset`) attribute on `<img>` elements, making the case rather hypothetical.
+This effectively reverts #1273 which was based on a discussion that didn't make it to the specs yet, and thus Alfa follows current major browsers implementation. Moreover, the HTML specification mandates the presence of a `src` (or `srcset`) attribute on `<img>` elements, making the case rather hypothetical.
 
 Thanks to [Jeff Witt](https://github.com/wittjeff) for reporting the issue.

--- a/.changeset/shiny-turkeys-dance.md
+++ b/.changeset/shiny-turkeys-dance.md
@@ -1,0 +1,9 @@
+---
+"@siteimprove/alfa-aria": minor
+---
+
+**Changed:** `<img>` elements with no `src` attribute now maps to `img` role again.
+
+This effectively reverts #1273 which was based on a discussion that didn't make it to the spec, and thus Alfa follows current major browsers implementation. Moreover, the HTML specification mandates the presence of a `src` (or `srcset`) attribute on `<img>` elements, making the case rather hypothetical.
+
+Thanks to [Jeff Witt](https://github.com/wittjeff) for reporting the issue.

--- a/packages/alfa-aria/src/feature.ts
+++ b/packages/alfa-aria/src/feature.ts
@@ -369,10 +369,15 @@ const Features: Features = {
           yield Role.of("presentation");
         }
 
-        // if there is no src attribute, or it is empty
-        if (element.attribute("src").every((src) => src.value.trim() === "")) {
-          yield Role.of("presentation");
-        }
+        // The role of src-less images is still "img" in the specs (and major browsers),
+        // however, there seems to be consensus ARIA side that it should be "none", but
+        // the exact phrasing is complicated due to empty `<img>` inside `<picture>`.
+        // See https://github.com/w3c/aria/pull/2221
+        // Keeping this here for memory purpose.
+        // // if there is no src attribute, or it is empty
+        // if (element.attribute("src").every((src) => src.value.trim() === "")) {
+        //   yield Role.of("presentation");
+        // }
 
         yield Role.of("img");
       },

--- a/packages/alfa-aria/test/role.spec.tsx
+++ b/packages/alfa-aria/test/role.spec.tsx
@@ -156,21 +156,26 @@ test(`.from() maps \`<select>\` to listboxes`, (t) => {
   });
 });
 
-test(`.from() maps \`<img>\` with no source to presentational role`, (t) => {
-  const empty = {
-    type: "container",
-    node: "/img[1]",
-    role: null,
-    children: [],
-  };
-
-  const images = [<img />, <img src="" />, <img alt="Hello" src="" />];
-
-  for (const img of images) {
-    t.deepEqual(Node.from(img, device).toJSON(), empty);
-  }
-});
-
+// The role of src-less images is still "img" in the specs (and major browsers),
+// however, there seems to be consensus ARIA side that it should be "none", but
+// the exact phrasing is complicated due to empty `<img>` inside `<picture>`.
+// See https://github.com/w3c/aria/pull/2221
+// Keeping this here for memory purpose.
+// test(`.from() maps \`<img>\` with no source to image role`, (t) => {
+//   const empty = {
+//     type: "container",
+//     node: "/img[1]",
+//     role: null,
+//     children: [],
+//   };
+//
+//   const images = [<img />, <img src="" />, <img alt="Hello" src="" />];
+//
+//   for (const img of images) {
+//     t.deepEqual(Node.from(img, device).toJSON(), empty);
+//   }
+// });
+//
 test(`.from() correctly handles slotted list items`, (t) => {
   const target = (
     <div>


### PR DESCRIPTION
Resolves #2141 
Reverts #1273.

The [proposed change in ARIA](https://github.com/w3c/aria/pull/2221) hasn't made it to the specs yet, and major browser still expose `src`-less images as `img` role. This gets complicated due to responsive images (`<picture>`) where the nested `<img>` doesn't need a direct source.

For the meantime, we revert to following browsers behaviour.

Thanks to @wittjeff for reporting the issue.
