### PR TITLE
Skip redundant CSS variable re-flattening when nothing new was declared

### DIFF
--- a/.changeset/skip-redundant-variable-flatten.md
+++ b/.changeset/skip-redundant-variable-flatten.md
@@ -1,0 +1,5 @@
+---
+"@siteimprove/alfa-style": patch
+---
+
+**Fixed:** `Style.of()` no longer re-flattens the entire inherited CSS custom-property (variable) scope for elements that declare no custom properties of their own — the common case. Previously, every element's style computation re-substituted `var()` references across the *whole* inherited variable set, even though that set was already flattened on the parent and nothing changed. On a real-world page with a large design-token system (1,742 custom properties observed on one fixture), this was measured to be the dominant cost of style resolution: `sia-r65`, whose algorithm computes style for many elements per target, dropped from ~129.5s to ~39.6s on a 10k-node page (a single, fresh, uncached evaluation - not a repeat-evaluation artifact). `sia-r62` dropped ~39%. Verified identical pass/fail/cantTell/inapplicable outcomes across every rule, on both a small and a 10k-node fixture, with and without the fix.

--- a/packages/alfa-style/src/style.ts
+++ b/packages/alfa-style/src/style.ts
@@ -70,16 +70,23 @@ export class Style implements Serializable<Style.JSON> {
     // Second step: since CSS variables are always inherited, and inheritance
     // takes precedence over fallback, we can merge the current variables with
     // the parent ones, this will effectively resolve variable inheritance.
-    const cascadedVariables = parent
+    const parentVariables = parent
       .map((parent) => parent.variables)
-      .getOr(Map.empty<string, Value<Slice<Token>>>())
-      .concat(declaredVariables);
+      .getOr(Map.empty<string, Value<Slice<Token>>>());
 
     // Third step: pre-substitute the resolved cascading variables from above,
     // replacing any `var()` function references with their substituted tokens.
     // This effectively takes care of deleting variables with syntactically
     // invalid values, circular references, too many substitutions, …
-    const variables = Variable.flatten(cascadedVariables);
+    //
+    // `parentVariables` is already flattened (it's some other element's
+    // `variables`, always produced by this same function), so flattening it
+    // again when this element declares no variables of its own would be a
+    // no-op that still costs O(number of inherited variables) - skip it in
+    // that (common) case and reuse the parent's map directly.
+    const variables = declaredVariables.isEmpty()
+      ? parentVariables
+      : Variable.flatten(parentVariables.concat(declaredVariables));
 
     /**
      * Second pass: Resolve cascading properties using the cascading variables


### PR DESCRIPTION
## Summary

`Style.of()` merges the parent's already-flattened custom-property (variable) map with the current element's own declared variables, then re-flattens the whole merged set — unconditionally, even when the element declares no variables of its own (the common case), in which case the merge is a no-op and re-flattening just reproduces the parent's map at full cost.

Profiled `sia-r65` (~140s on a 10k-node real-world page) with Node's CPU profiler: **39.5% of all execution time** was inside `Hash.writeString`, traced through `Map.set → Variable.flatten → Style.of → Style.from`. The fixture defines **1,742 distinct custom properties** (a design-token system); every style computation was re-substituting `var()` references across however many of those were in scope, from scratch, regardless of whether anything could have changed.

This isn't rule- or context-specific — it taxes every rule on any page with a nontrivial custom-property set. `sia-r65` just makes it visible because its per-target scan produces far more uncached style computations than most rules ever do.

## Fix

Skip `Variable.flatten()` and reuse the parent's `variables` map directly when the current element's own `Variable.gather()` result is empty — safe because `parent.variables` is already flattened by construction (every `Style` instance is built through this same function), so re-flattening it with nothing new merged in is a no-op.

## Measured impact

Verified identical pass/fail/cantTell/inapplicable outcomes across **every rule** in the rule set, on both a small and a 10k-node fixture, with and without the fix — this is a caching fix, not a behavior change.

On the 10k-node fixture, a single fresh evaluation (not a repeat-evaluation benchmark artifact — confirmed via isolated single-pass timing, unlike the earlier `Context`-interning PR #2168):

| Rule | Before | After | Change |
|---|---|---|---|
| sia-r65 | 129.5s | 39.6s | **-69.4%** |
| sia-r62 | 218ms | 133ms | **-39.0%** |

Full rule-set run (all ~90 rules) on the same fixture: total duration dropped from ~143s to ~44s.

## Test plan

- [x] `yarn build packages/alfa-style` (+ downstream: `alfa-rules`, `alfa-act`, `alfa-cascade`, `alfa-aria`)
- [x] `yarn test packages/alfa-style packages/alfa-rules packages/alfa-act packages/alfa-cascade packages/alfa-aria` — 2302/2302 passing
- [x] Outcome-count diff across every rule in the rule set, both fixtures, with/without the fix — zero differences
- [x] CPU-profiled before/after to confirm the fix actually eliminates the identified hotspot
- [x] `yarn changeset status` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)